### PR TITLE
Track and emit user interaction logs

### DIFF
--- a/build/src/src/calls/createGetUserActionLogs.js
+++ b/build/src/src/calls/createGetUserActionLogs.js
@@ -1,0 +1,47 @@
+const fs = require('fs');
+const {promisify} = require('util');
+const paramsDefault = require('params');
+
+// CALL DOCUMENTATION:
+// > kwargs: {
+//     id,
+//     isCore,
+//     options
+//   }
+// > result: {
+//     id,
+//     logs: <String with escape codes> (string)
+//   }
+
+function createGetUserActionLogs({
+    params = paramsDefault,
+}) {
+  const getUserActionLogs = async ({
+    options,
+  }) => {
+    const readFileAsync = promisify(fs.readFile);
+    const {userActionLogsFilename} = params;
+
+    if (!fs.existsSync(userActionLogsFilename)) {
+      return {
+          message: 'UserActionLogs are still empty, returning black',
+          result: '',
+      };
+    }
+    const userActionLogs = await readFileAsync(
+        userActionLogsFilename,
+        {encoding: 'utf8'}
+    );
+
+    return {
+      message: 'Got userActionLogs',
+      result: userActionLogs,
+    };
+  };
+
+  // Expose main method
+  return getUserActionLogs;
+}
+
+
+module.exports = createGetUserActionLogs;

--- a/build/src/src/calls/createInstallPackage.js
+++ b/build/src/src/calls/createInstallPackage.js
@@ -33,7 +33,8 @@ function createInstallPackage({
 
     return {
       message: 'Installed ' + packageReq.name + ' version: ' + packageReq.ver,
-      log: true,
+      logMessage: true,
+      userAction: true,
     };
   };
 

--- a/build/src/src/calls/createListPackages.js
+++ b/build/src/src/calls/createListPackages.js
@@ -55,7 +55,6 @@ function createListPackages({
     return {
       message: 'Listing ' + dnpList.length + ' packages',
       result: dnpList,
-      logMessage: true,
     };
   };
 

--- a/build/src/src/calls/createManagePorts.js
+++ b/build/src/src/calls/createManagePorts.js
@@ -36,6 +36,7 @@ function createManagePorts({
     return {
       message: msg+' ports '+ports.join(', '),
       logMessage: true,
+      userAction: true,
     };
   };
 

--- a/build/src/src/calls/createRemovePackage.js
+++ b/build/src/src/calls/createRemovePackage.js
@@ -42,7 +42,8 @@ function createRemovePackage({
 
     return {
       message: 'Removed package: ' + id,
-      log: true,
+      logMessage: true,
+      userAction: true,
     };
   };
 

--- a/build/src/src/calls/createRestartPackage.js
+++ b/build/src/src/calls/createRestartPackage.js
@@ -34,6 +34,7 @@ function createRestartPackage({
     return {
       message: 'Restarted package: ' + id,
       logMessage: true,
+      userAction: true,
     };
   };
 

--- a/build/src/src/calls/createRestartPackageVolumes.js
+++ b/build/src/src/calls/createRestartPackageVolumes.js
@@ -43,7 +43,8 @@ function createRestartPackageVolumes({
 
     return {
       message: 'Restarted '+id+' volumes: ' + packageVolumes.join(', '),
-      log: true,
+      logMessage: true,
+      userAction: true,
     };
   };
 }

--- a/build/src/src/calls/createTogglePackage.js
+++ b/build/src/src/calls/createTogglePackage.js
@@ -35,7 +35,8 @@ function createTogglePackage({
 
     return {
       message: 'successfully toggled package: ' + id,
-      log: true,
+      logMessage: true,
+      userAction: true,
     };
   };
 

--- a/build/src/src/calls/createUpdatePackageEnv.js
+++ b/build/src/src/calls/createUpdatePackageEnv.js
@@ -31,7 +31,8 @@ function createUpdatePackageEnv({
     if (!restart) {
       return {
         message: 'Updated envs of ' + id,
-        log: true,
+        logMessage: true,
+        userAction: true,
       };
     }
 
@@ -49,7 +50,8 @@ function createUpdatePackageEnv({
 
     return {
       message: 'Updated envs and restarted ' + id,
-      log: true,
+      logMessage: true,
+      userAction: true,
     };
   };
 

--- a/build/src/src/eventBus.js
+++ b/build/src/src/eventBus.js
@@ -1,5 +1,17 @@
 const EventEmitter = require('events');
 
+/* HOW TO:
+
+- ON:
+eventBus.on(eventBusTag.logUI, (data) => {
+    doStuff(data);
+});
+
+- EMIT:
+eventBus.emit(eventBusTag.logUI, data);
+
+*/
+
 class MyEmitter extends EventEmitter {}
 
 const eventBus = new MyEmitter();
@@ -7,6 +19,7 @@ const eventBus = new MyEmitter();
 const eventBusTag = {
     logUI: 'EVENT_BUS_LOGUI',
     call: 'EVENT_BUS_CALL',
+    logUserAction: 'EVENT_BUS_LOGUSERACTION',
   };
 
 module.exports = {

--- a/build/src/src/logUserAction.js
+++ b/build/src/src/logUserAction.js
@@ -1,0 +1,54 @@
+'use strict';
+const winston = require('winston');
+const {createLogger, format, transports} = winston;
+const Transport = require('winston-transport');
+const {eventBus, eventBusTag} = require('eventBus');
+const params = require('params');
+
+/*
+* > LEVELS:
+* ---------------------
+* logs.info('Something')
+* logs.warn('Something')
+* logs.error('Something')
+*/
+
+// Format function to filter out unrelevant logs
+const onlyUserAction = format((info, opts) => {
+  if (!info.userAction) {return false;}
+  delete info.userAction;
+  delete info.logMessage;
+  return info;
+});
+
+// Custom transport to broadcast new logs to the admin directly
+class EmitToAdmin extends Transport {
+  constructor(opts) {
+    super(opts);
+  }
+
+  log(info, callback) {
+    setImmediate(() => {
+      eventBus.emit(eventBusTag.logUserAction, info);
+    });
+    callback();
+  }
+}
+
+// Actual logger
+const logger = createLogger({
+    transports: [
+      new transports.File({
+        filename: params.userActionLogsFilename,
+        level: 'info',
+      }),
+      new EmitToAdmin(),
+    ],
+    format: format.combine(
+      onlyUserAction(),
+      format.timestamp(),
+      format.json()
+    ),
+});
+
+module.exports = logger;

--- a/build/src/src/params.js
+++ b/build/src/src/params.js
@@ -6,6 +6,8 @@ module.exports = {
   // autobahnRealm: 'realm1',
   autobahnRealm: 'dappnode_admin',
   autobahnTag: {
+    logUserActionToDappmanager: 'logUserActionToDappmanager',
+    logUserAction: 'logUserAction.dappmanager.dnp.dappnode.eth',
     DAppManagerLog: 'log.dappmanager.dnp.dappnode.eth',
   },
 
@@ -35,5 +37,8 @@ module.exports = {
 
   // Wweb3 parameters
   WEB3HOSTWS: 'ws://my.ethchain.dnp.dappnode.eth:8546',
+
+  // User Action Logs filename
+  userActionLogsFilename: 'DNCORE/userActionLogs.log',
 
 };


### PR DESCRIPTION
This should be useful to help assist user on errors. It implemented a subscription to have to receive the full list of logs only once. Linked to https://github.com/dappnode/DNP_ADMIN/pull/92