### PR TITLE
Show specific errors if the manifest is not valid

### DIFF
--- a/build/src/test/modules/getManifest.test.js
+++ b/build/src/test/modules/getManifest.test.js
@@ -14,7 +14,7 @@ describe('Get manifest', function() {
     ver: 'latest',
   };
   const dnpHash = 'dnpHash';
-  const manifest = '{\n  "item": "manifest"\n}';
+  const manifest = '{"image":{"hash":"/ipfs/Qm"}}';
   const apmGetRepoHashSpy = sinon.spy();
   const apm = {
     getRepoHash: async (packageReq) => {
@@ -54,8 +54,8 @@ describe('Get manifest', function() {
   it('should return a parsed manifest', () => {
     expect(res)
       .to.deep.equal({
-        fromIpfs: undefined,
-        item: 'manifest',
+        image: {hash: '/ipfs/Qm'},
+        fromIpfs: undefined
       });
   });
 });


### PR DESCRIPTION
File size over a limit (100KB)
File not containing a valid json (it's an image or binary)
JSON not parsable (syntax error)
Parsable but the manifest is broken (no image hash)