### PR TITLE
Simplify installation on the UI side

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,10 @@ stages:
 
 jobs:
   include:
-    # In app tests
+    # In app unit tests
     ##############
     - stage: test
-      env:
-        - IN_APP_TEST
+      name: In app unit tests
       node_js:
         - "8.9.4"
       cache:
@@ -32,11 +31,10 @@ jobs:
       after_success: # Upload coverage reports
         - COVERALLS_REPO_TOKEN=$coveralls_repo_token npm run coveralls
 
-    # integration tests
+    # Integration tests
     ###################
     - stage: test
-      env:
-        - INTEGRATION_TEST
+      name: Integration tests
       node_js:
         - "8.9.4"
       services:

--- a/build/src/src/calls/installPackage.js
+++ b/build/src/src/calls/installPackage.js
@@ -1,12 +1,12 @@
 const {eventBus, eventBusTag} = require('eventBus');
 const logs = require('logs.js')(module);
+const db = require('../db');
 // Modules
 const packages = require('modules/packages');
 const dappGet = require('modules/dappGet');
 const dappGetBasic = require('modules/dappGet/basic');
 const getManifest = require('modules/getManifest');
 const lockPorts = require('modules/lockPorts');
-const shouldOpenPorts = require('modules/shouldOpenPorts');
 // Utils
 const logUI = require('utils/logUI');
 const parse = require('utils/parse');
@@ -161,7 +161,8 @@ const installPackage = async ({id, userSetEnvs = {}, userSetVols = {}, userSetPo
 
     // Skip if there are no ports to open or if UPnP is not available
     const portsToOpen = [...mappedPortsToOpen, ...lockedPortsToOpen];
-    if (portsToOpen.length && (await shouldOpenPorts())) {
+    const upnpAvailable = await db.get('upnpAvailable');
+    if (portsToOpen.length && upnpAvailable) {
       eventBus.emit(eventBusTag.call, {
         callId: 'managePorts',
         kwargs: {

--- a/build/src/src/calls/resolveRequest.js
+++ b/build/src/src/calls/resolveRequest.js
@@ -13,27 +13,20 @@ const dappGetBasic = require('modules/dappGet/basic');
  * @return {Object} A formated success message.
  * result: empty
  */
-const removePackage = async ({
-  req,
-  options = {},
-}) => {
-    // result = {
-    //     success: {'bind.dnp.dappnode.eth': '0.1.4'}
-    //     alreadyUpdated: {'bind.dnp.dappnode.eth': '0.1.2'}
-    // }
-    const result = options.BYPASS_RESOLVER
-    ? await dappGetBasic(req)
-    : await dappGet(req);
+const removePackage = async ({req, options = {}}) => {
+  // result = {
+  //     success: {'bind.dnp.dappnode.eth': '0.1.4'}
+  //     alreadyUpdated: {'bind.dnp.dappnode.eth': '0.1.2'}
+  // }
+  const result = options.BYPASS_RESOLVER ? await dappGetBasic(req) : await dappGet(req);
 
-    // Prevent old UIs from crashing
-    result.state = {};
+  // Prevent old UIs from crashing
+  result.state = {};
 
-    return {
-        message: 'Resolve request for ' + req.name + '@' + req.ver+
-            ', resolved: '+Boolean(result.success),
-        result,
-    };
+  return {
+    message: 'Resolve request for ' + req.name + '@' + req.ver + ', resolved: ' + Boolean(result.success),
+    result,
+  };
 };
-
 
 module.exports = removePackage;

--- a/build/src/src/modules/docker/Docker.js
+++ b/build/src/src/modules/docker/Docker.js
@@ -1,6 +1,9 @@
 // node modules
 let shell = require('./shell');
 
+/* eslint-disable max-len */
+/* eslint-disable no-useless-escape */
+
 const docker = {
   compose: {
     // Usage: up [options] [--scale SERVICE=NUM...] [SERVICE...]
@@ -16,9 +19,9 @@ const docker = {
     // --build                    Build images before starting containers.
     // --exit-code-from SERVICE   Return the exit code of the selected service
     //                            container. Implies --abort-on-container-exit.
-    up: (DOCKERCOMPOSE_PATH, options={}) => {
+    up: (DOCKERCOMPOSE_PATH, options = {}) => {
       let optionsString = parseOptions(options);
-      return shell('docker-compose -f ' + DOCKERCOMPOSE_PATH + ' up -d'+optionsString);
+      return shell('docker-compose -f ' + DOCKERCOMPOSE_PATH + ' up -d' + optionsString);
     },
 
     // Usage: down [options]
@@ -29,46 +32,45 @@ const docker = {
     //     -v, --volumes           Remove named volumes declared in the `volumes`
     //     --remove-orphans        Remove containers for services not defined in the Compose file
     //     -t, --timeout TIMEOUT   Specify a shutdown timeout in seconds. (default: 10)
-    down: (DOCKERCOMPOSE_PATH, options={}) => {
+    down: (DOCKERCOMPOSE_PATH, options = {}) => {
       let optionsString = parseOptions(options);
-      return shell('docker-compose -f ' + DOCKERCOMPOSE_PATH + ' down'+optionsString);
+      return shell('docker-compose -f ' + DOCKERCOMPOSE_PATH + ' down' + optionsString);
     },
 
     // Usage: start [SERVICE...]
-    start: (DOCKERCOMPOSE_PATH, options={}) => {
+    start: (DOCKERCOMPOSE_PATH, options = {}) => {
       let optionsString = parseOptions(options);
-      return shell('docker-compose -f ' + DOCKERCOMPOSE_PATH + ' start'+optionsString);
+      return shell('docker-compose -f ' + DOCKERCOMPOSE_PATH + ' start' + optionsString);
     },
 
     // Usage: stop [options] [SERVICE...]
     // Options:
     // -t, --timeout TIMEOUT      Specify a shutdown timeout in seconds (default: 10).
-    stop: (DOCKERCOMPOSE_PATH, options={}) => {
+    stop: (DOCKERCOMPOSE_PATH, options = {}) => {
       let optionsString = parseOptions(options);
-      return shell('docker-compose -f ' + DOCKERCOMPOSE_PATH + ' stop'+optionsString);
+      return shell('docker-compose -f ' + DOCKERCOMPOSE_PATH + ' stop' + optionsString);
     },
 
     // Usage: restart [options] [SERVICE...]
     // Options:
     // -t, --timeout TIMEOUT      Specify a shutdown timeout in seconds. (default: 10)
-    rm: (DOCKERCOMPOSE_PATH, options={}) => {
+    rm: (DOCKERCOMPOSE_PATH, options = {}) => {
       let optionsString = parseOptions(options);
-      return shell('docker-compose -f ' + DOCKERCOMPOSE_PATH + ' rm -sf'+optionsString);
+      return shell('docker-compose -f ' + DOCKERCOMPOSE_PATH + ' rm -sf' + optionsString);
     },
 
     // Safe down & up
-    rm_up: (DOCKERCOMPOSE_PATH, options={}) => {
+    rm_up: (DOCKERCOMPOSE_PATH, options = {}) => {
       let optionsString = parseOptions(options);
-      return shell('docker-compose -f ' + DOCKERCOMPOSE_PATH + ' rm -sf'+optionsString
-      +' && docker-compose -f ' + DOCKERCOMPOSE_PATH + ' up -d'+optionsString);
+      return shell('docker-compose -f ' + DOCKERCOMPOSE_PATH + ' rm -sf' + optionsString + ' && docker-compose -f ' + DOCKERCOMPOSE_PATH + ' up -d' + optionsString);
     },
 
     // Usage: restart [options] [SERVICE...]
     // Options:
     // -t, --timeout TIMEOUT      Specify a shutdown timeout in seconds. (default: 10)
-    restart: (DOCKERCOMPOSE_PATH, options={}) => {
+    restart: (DOCKERCOMPOSE_PATH, options = {}) => {
       let optionsString = parseOptions(options);
-      return shell('docker-compose -f ' + DOCKERCOMPOSE_PATH + ' restart'+optionsString);
+      return shell('docker-compose -f ' + DOCKERCOMPOSE_PATH + ' restart' + optionsString);
     },
 
     // Usage: logs [options] [SERVICE...]
@@ -78,10 +80,9 @@ const docker = {
     // -t, --timestamps    Show timestamps
     // --tail="all"        Number of lines to show from the end of the logs
     //                     for each container.
-    logs: (DOCKERCOMPOSE_PATH, options={}) => {
+    logs: (DOCKERCOMPOSE_PATH, options = {}) => {
       let optionsString = parseOptions(options);
-      return shell('docker-compose -f ' + DOCKERCOMPOSE_PATH
-        + ' logs'+optionsString + ' 2>&1', true);
+      return shell('docker-compose -f ' + DOCKERCOMPOSE_PATH + ' logs' + optionsString + ' 2>&1');
     },
 
     // Usage: ps [options] [SERVICE...]
@@ -90,7 +91,6 @@ const docker = {
     ps: (DOCKERCOMPOSE_PATH) => {
       return shell('docker-compose -f ' + DOCKERCOMPOSE_PATH + ' ps');
     },
-
   },
 
   volume: {
@@ -103,24 +103,24 @@ const docker = {
 
   // SPECIAL OPERATION
   // Searches for semver
-  /* eslint-disable no-useless-escape *//* eslint-disable max-len */
   images: () => {
-    return shell(`docker images --format "{{.Repository}}:{{.Tag}}"`, true);
+    return shell(`docker images --format "{{.Repository}}:{{.Tag}}"`);
   },
+
   rmi: (imgsToDelete) => {
     return shell(`docker rmi ${imgsToDelete.join(' ')}`);
   },
+
   rmOldSemverImages: (packageName) => {
     return shell(`docker rmi $(docker images --format "{{.Repository}}:{{.Tag}}" | grep "${packageName}:[0-9]\+.[0-9]\+.[0-9]\+")`);
   },
-  /* eslint-enable no-useless-escape *//* eslint-enable max-len */
 
   // NOT A DOCKER-COMPOSE
   // Usage: docker load [OPTIONS]
   // --input , -i		Read from tar archive file, instead of STDIN
   // --quiet , -q		Suppress the load output
   load: (imagePath) => {
-    return shell('docker load -i ' + imagePath);
+    return shell('docker load -i ' + imagePath, {timeout: 15 * 60 * 1000});
   },
 
   // NOT A DOCKER-COMPOSE
@@ -136,17 +136,9 @@ const docker = {
     // Parse options
     let optionsString = '';
     // --timeout TIMEOUT      Specify a shutdown timeout in seconds (default: 10).
-    if (
-      options.hasOwnProperty('timestamps')
-      && options.timestamps
-    ) optionsString += ' --timestamps';
-
-    if (
-      options.hasOwnProperty('tail')
-      && !isNaN(options.tail)
-    ) optionsString += ' --tail '+options.tail;
-
-    return shell('docker logs ' + containerNameOrId+' '+optionsString+' 2>&1', true);
+    if (options.hasOwnProperty('timestamps') && options.timestamps) optionsString += ' --timestamps';
+    if (options.hasOwnProperty('tail') && !isNaN(options.tail)) optionsString += ' --tail ' + options.tail;
+    return shell('docker logs ' + containerNameOrId + ' ' + optionsString + ' 2>&1');
   },
 
   // NOT A DOCKER-COMPOSE
@@ -157,7 +149,7 @@ const docker = {
   },
 
   status: (containerNameOrId) => {
-    return shell('docker inspect --format=\'{{.State.Status}}\' ' + containerNameOrId, true);
+    return shell('docker inspect --format=\'{{.State.Status}}\' ' + containerNameOrId);
   },
 
   // NOT A DOCKER, DOCKER-COMPOSE
@@ -172,9 +164,7 @@ const docker = {
   },
   isUpnpAvailable: async () => {
     const IMAGE = await shell(getVpnImageCmd());
-    return await shell('docker run --rm --net=host '
-      +IMAGE+' upnpc -l | awk -F\'= \'  \'/ExternalIPAddress/{print $2}\'')
-    .then((res) => (res && res.includes('.')), (err) => false);
+    return await shell('docker run --rm --net=host ' + IMAGE + ' upnpc -l | awk -F\'= \'  \'/ExternalIPAddress/{print $2}\'').then((res) => res && res.includes('.'), (err) => false);
   },
 };
 
@@ -200,24 +190,22 @@ function getUpnpCmd(port = {}, type, IMAGE) {
   let flag;
   if (type === 'open') flag = '-r';
   if (type === 'close') flag = '-d';
-  /* eslint-disable max-len */
+
   return `docker run --rm --net=host ${IMAGE.trim()} upnpc -e DAppNode ${flag} ${port.number} ${port.type || 'TCP'}`;
-  /* eslint-enable max-len */
 }
 
 function parseOptions(options) {
   let optionsString = '';
 
   // --timeout TIMEOUT      Specify a shutdown timeout in seconds (default: 10).
-  if (!isNaN(options.timeout)) optionsString += ' --timeout '+options.timeout;
+  if (!isNaN(options.timeout)) optionsString += ' --timeout ' + options.timeout;
   // -t, --timestamps    Show timestamps
   if (options.timestamps) optionsString += ' --timestamps';
   if (options.volumes) optionsString += ' --volumes';
   if (options.v) optionsString += ' -v';
-  if (options.core) optionsString += (' ' + options.core);
+  if (options.core) optionsString += ' ' + options.core;
 
   return optionsString;
 }
-
 
 module.exports = docker;

--- a/build/src/src/modules/docker/shell.js
+++ b/build/src/src/modules/docker/shell.js
@@ -8,13 +8,13 @@ const logs = require('logs')(module);
  * This solution allows the user to be able to reset or reinstall a broken package.
 */
 
-async function shellWrap(cmd) {
+async function shellWrap(cmd, options) {
   try {
-    return await shell(cmd);
+    return await shell(cmd, options);
   } catch (e) {
     if (e.message && e.message.includes('Couldn\'t find env file:')) {
       const envPath = e.message.split('Couldn\'t find env file:')[1].trim();
-      logs.warn('RETRY SHELL JS command, creating envFile '+envPath);
+      logs.warn('RETRY SHELL JS command, creating envFile ' + envPath);
       await shell(`touch ${envPath}`);
       return await shell(cmd);
     } else {

--- a/build/src/src/modules/upnpc/README.md
+++ b/build/src/src/modules/upnpc/README.md
@@ -1,0 +1,14 @@
+NAME
+
+upnpc - interact with an external UPnP Internet Gateway Device
+SYNOPSIS
+setuc [ifn | cname] # Host interface to use
+
+upnpc -a ip port external_port tcp | udp # Add port mapping
+upnpc -d external_port tcp | udp # Delete port mapping
+upnpc -e # External IP address
+upnpc -i # Initialize device list
+upnpc -s # Status
+upnpc -l # List port mappings
+upnpc -n ip # Get friendly name
+upnpc -r port1 tcp | udp [...] # Map these ports to the host interface

--- a/build/src/src/modules/upnpc/index.js
+++ b/build/src/src/modules/upnpc/index.js
@@ -1,0 +1,80 @@
+const shell = require('utils/shell');
+const validateKwargs = require('./validateKwargs');
+const parseOpenOutput = require('./parseOpenOutput');
+const parseCloseOutput = require('./parseCloseOutput');
+const parseListOutput = require('./parseListOutput');
+
+// upnpc - interact with an external UPnP Internet Gateway Device
+//
+// setuc [ifn | cname]                      # Host interface to use
+//
+// upnpc -a ip port external_port tcp | udp # Add port mapping
+// upnpc -d external_port tcp | udp         # Delete port mapping
+// upnpc -e                                 # External IP address
+// upnpc -i                                 # Initialize device list
+// upnpc -s                                 # Status
+// upnpc -l                                 # List port mappings
+// upnpc -n ip                              # Get friendly name
+// upnpc -r port1 tcp | udp [...]           # Map these ports to the host interface
+
+// Available commands
+// - open
+// - close
+// - list
+// - status
+
+/* eslint-disable max-len */
+
+function upnpcCommand(cmd) {
+  return shell(`docker inspect DAppNodeCore-vpn.dnp.dappnode.eth -f '{{.Config.Image}}'`, {trim: true}).then((image) => shell(`docker run --rm --net=host ${image} upnpc ${cmd} `));
+}
+
+const upnpc = {
+  /**
+   * Closes port = deletes port mapping
+   * Actual command example:
+   *   docker run --rm --net=host ${IMAGE} upnpc -e DAppNode -r 500 UDP
+   *
+   * @param {Object} kwargs: {
+   *   protocol: 'TCP',
+   *   portNumber: '3000'
+   * }
+   * @return {*}
+   */
+  open: ({protocol, portNumber}) => {
+    validateKwargs({protocol, portNumber});
+    return upnpcCommand(`-e DAppNode -r ${portNumber} ${protocol}`).then(parseOpenOutput);
+  },
+
+  /**
+   * Opens port = maps requested port to host
+   * Actual command example:
+   *   docker run --rm --net=host ${IMAGE} upnpc -e DAppNode -d 500 UDP
+   *
+   * @param {Object} kwargs: {
+   *   protocol: 'TCP',
+   *   portNumber: '3000'
+   * }
+   * @return {*}
+   */
+  close: ({protocol, portNumber}) => {
+    validateKwargs({protocol, portNumber});
+    return upnpcCommand(`-e DAppNode -d ${portNumber} ${protocol}`).then(parseCloseOutput);
+  },
+
+  /**
+   * Lists current port mapping for DAppNode
+   * Actual command:
+   *   docker run --rm --net=host ${IMAGE} upnpc -l
+   *
+   * @return {Array} port mappings = [
+   *   {protocol: 'UDP', exPort: '500', inPort: '500'},
+   *   {protocol: 'UDP', exPort: '4500', inPort: '4500'},
+   *   {protocol: 'UDP', exPort: '30303', inPort: '30303'},
+   *   {protocol: 'TCP', exPort: '30303', inPort: '30303'},
+   * ]
+   */
+  list: () => upnpcCommand(`-l`).then(parseListOutput),
+};
+
+module.exports = upnpc;

--- a/build/src/src/modules/upnpc/parseCloseOutput.js
+++ b/build/src/src/modules/upnpc/parseCloseOutput.js
@@ -1,0 +1,71 @@
+const parseGeneralErrors = require('./parseGeneralErrors');
+const validateKwargs = require('./validateKwargs');
+
+/* eslint-disable max-len */
+
+// SUCCESSFUL: Close an existing port
+
+// dappnode@machine:/usr/src/dappnode/DNCORE$ docker run --rm --net=host ${IMAGE} upnpc -e DAppNode -d 4002 UDP
+// upnpc : miniupnpc library test client, version 2.0.
+//  (c) 2005-2017 Thomas Bernard.
+// Go to http://miniupnp.free.fr/ or https://miniupnp.tuxfamily.org/
+// for more information.
+// List of UPNP devices found on the network :
+//  desc: http://192.168.1.1:5001/dyn/uuid:0011-0011-0011-0011
+//  st: urn:schemas-upnp-org:device:InternetGatewayDevice:1
+
+// Found valid IGD : http://192.168.1.1:5001/uuid:0011-0011-0011-0011/WANPPPConnection:1
+// Local LAN ip address : 192.168.1.01
+// UPNP_DeletePortMapping() returned : 0
+
+// ERROR: Close a NON existing port
+
+// dappnode@machine:/usr/src/dappnode/DNCORE$ docker run --rm --net=host ${IMAGE} upnpc -e DAppNode -d 40025 UDP
+// upnpc : miniupnpc library test client, version 2.0.
+//  (c) 2005-2017 Thomas Bernard.
+// Go to http://miniupnp.free.fr/ or https://miniupnp.tuxfamily.org/
+// for more information.
+// List of UPNP devices found on the network :
+//  desc: http://192.168.1.1:5001/dyn/uuid:0011-0011-0011-0011
+//  st: urn:schemas-upnp-org:device:InternetGatewayDevice:1
+
+// Found valid IGD : http://192.168.1.1:5001/uuid:0011-0011-0011-0011/WANPPPConnection:1
+// Local LAN ip address : 192.168.1.01
+// UPNP_DeletePortMapping() failed with code : 714
+
+// ERROR: no UPnP device found
+
+// root@lionDAppnode:/usr/src/dappnode/DNCORE# docker run --rm --net=host ${IMAGE} upnpc -s
+// upnpc : miniupnpc library test client, version 2.0.
+//  (c) 2005-2017 Thomas Bernard.
+// Go to http://miniupnp.free.fr/ or https://miniupnp.tuxfamily.org/
+// for more information.
+// No IGD UPnP Device found on the network !
+
+/**
+ *
+ * @param {String} terminalOutput A sample can be found above
+ * @return {*}
+ */
+function parseCloseOutput(terminalOutput) {
+  validateKwargs({terminalOutput});
+  parseGeneralErrors(terminalOutput);
+
+  // Get the last line of the output
+  const lines = terminalOutput.trim().split(/\r?\n/);
+  const lastLine = lines[lines.length - 1];
+
+  // Check if it contains "failed"
+  if (lastLine.includes('failed')) {
+    const errorMessage = 'failed ' + (lastLine.split('failed')[1] || '').trim();
+    throw Error(`Error closing port: ${errorMessage}`);
+  }
+
+  // Check if is contains "returned.0"
+  const okRegex = RegExp(/returned.+0/);
+  if (okRegex.test(lastLine)) {
+    return true;
+  }
+}
+
+module.exports = parseCloseOutput;

--- a/build/src/src/modules/upnpc/parseGeneralErrors.js
+++ b/build/src/src/modules/upnpc/parseGeneralErrors.js
@@ -1,0 +1,17 @@
+// ERROR - no UPNP DEVICE:
+
+// upnpc : miniupnpc library test client, version 2.0.
+//  (c) 2005-2017 Thomas Bernard.
+// Go to http://miniupnp.free.fr/ or https://miniupnp.tuxfamily.org/
+// for more information.
+// No IGD UPnP Device found on the network !
+
+function parseGeneralErrors(terminalOutput) {
+  const noDeviceFoundRegex = RegExp(/no.+device found/);
+  if (noDeviceFoundRegex.test((terminalOutput || '').toLowerCase())) {
+    throw Error('NOUPNP: No UPnP device available');
+  }
+  return terminalOutput;
+}
+
+module.exports = parseGeneralErrors;

--- a/build/src/src/modules/upnpc/parseListOutput.js
+++ b/build/src/src/modules/upnpc/parseListOutput.js
@@ -1,0 +1,79 @@
+const parseGeneralErrors = require('./parseGeneralErrors');
+const validateKwargs = require('./validateKwargs');
+
+/* eslint-disable max-len */
+
+// SUCCESSFUL
+
+// dappnode@machine:/usr/src/dappnode/DNCORE$ docker run --rm --net=host ${IMAGE} upnpc -e DAppNode -l
+// upnpc : miniupnpc library test client, version 2.0.
+//  (c) 2005-2017 Thomas Bernard.
+// Go to http://miniupnp.free.fr/ or https://miniupnp.tuxfamily.org/
+// for more information.
+// List of UPNP devices found on the network :
+//  desc: http://192.168.1.1:5001/dyn/uuid:0011-0011-0011-0011
+//  st: urn:schemas-upnp-org:device:InternetGatewayDevice:1
+//
+// Found valid IGD : http://192.168.1.1:5001/uuid:0011-0011-0011-0011/WANPPPConnection:1
+// Local LAN ip address : 192.168.1.01
+// Connection Type : IP_Routed
+// Status : Connected, uptime=1360425s, LastConnectionError :
+//   Time started : Tue Feb 31 00:00:01 2018
+// MaxBitRateDown : 0 bps   MaxBitRateUp 0 bps
+// ExternalIPAddress = 85.84.83.82
+//  i protocol exPort->inAddr:inPort description remoteHost leaseTime
+//  0 UDP   500->192.168.1.42:500   'DAppNode' '' 0
+//  1 UDP  4500->192.168.1.42:4500  'DAppNode' '' 0
+//  2 TCP    22->192.168.1.42:22    'DAppNode' '' 0
+//  3 UDP 30303->192.168.1.42:30303 'DAppNode' '' 0
+//  4 TCP 30303->192.168.1.42:30303 'DAppNode' '' 0
+//  5 TCP  4001->192.168.1.42:4001  'DAppNode' '' 0
+//  6 UDP  4002->192.168.1.42:4002  'DAppNode' '' 0
+//  7 TCP 32000->192.168.1.52:32000 'otherApp (TCP)' '' 0
+//  8 UDP 32000->192.168.1.52:32000 'otherApp (UDP)' '' 0
+// GetGenericPortMappingEntry() returned 713 (SpecifiedArrayIndexInvalid)
+
+// ERROR: no UPnP device found
+
+// root@lionDAppnode:/usr/src/dappnode/DNCORE# docker run --rm --net=host ${IMAGE} upnpc -s
+// upnpc : miniupnpc library test client, version 2.0.
+//  (c) 2005-2017 Thomas Bernard.
+// Go to http://miniupnp.free.fr/ or https://miniupnp.tuxfamily.org/
+// for more information.
+// No IGD UPnP Device found on the network !
+
+/**
+ *
+ * @param {String} terminalOutput A sample can be found above
+ * @return {Array} port mappings = [
+ *   {protocol: 'UDP', exPort: '500', inPort: '500'},
+ *   {protocol: 'UDP', exPort: '4500', inPort: '4500'},
+ *   {protocol: 'UDP', exPort: '30303', inPort: '30303'},
+ *   {protocol: 'TCP', exPort: '30303', inPort: '30303'},
+ * ]
+ */
+function parseListOutput(terminalOutput) {
+  validateKwargs({terminalOutput});
+  parseGeneralErrors(terminalOutput);
+
+  // 1. Cut to the start of the table
+  const validLineRegex = RegExp(/\d+\s+(UDP|TCP)\s+\d+->(\d+\.){3}\d+:\d+\s+.DAppNode/);
+  return (
+    terminalOutput
+      .trim()
+      .split(/\r?\n/)
+      // Filter by lines that have the table format above
+      .filter((line) => line && typeof line === 'string' && validLineRegex.test(line))
+      // Parse the line to extract the protocol and port mapping
+      .map((line) => {
+        const [, protocol, mapping] = line.trim().split(/\s+/);
+        const exPort = mapping.split('->')[0];
+        const [, inPort] = (mapping.split('->')[1] || '').split(':');
+        return {protocol, exPort, inPort};
+      })
+      // Make sure that the result is correct, otherwise remove it
+      .filter(({protocol, exPort, inPort}) => (protocol === 'UDP' || protocol === 'TCP') && !isNaN(exPort) && !isNaN(inPort))
+  );
+}
+
+module.exports = parseListOutput;

--- a/build/src/src/modules/upnpc/parseOpenOutput.js
+++ b/build/src/src/modules/upnpc/parseOpenOutput.js
@@ -1,0 +1,52 @@
+const parseGeneralErrors = require('./parseGeneralErrors');
+const validateKwargs = require('./validateKwargs');
+
+/* eslint-disable max-len */
+
+// SUCCESSFUL: Open a NON existing port
+// (ERROR): Open an already openned port (same output)
+
+// dappnode@machine:/usr/src/dappnode/DNCORE$ docker run --rm --net=host ${IMAGE} upnpc -e DAppNode -r 4002 UDP
+// upnpc : miniupnpc library test client, version 2.0.
+//  (c) 2005-2017 Thomas Bernard.
+// Go to http://miniupnp.free.fr/ or https://miniupnp.tuxfamily.org/
+// for more information.
+// List of UPNP devices found on the network :
+//  desc: http://192.168.1.1:5001/dyn/uuid:0011-0011-0011-0011
+//  st: urn:schemas-upnp-org:device:InternetGatewayDevice:1
+
+// Found valid IGD : http://192.168.1.1:5001/uuid:0011-0011-0011-0011/WANPPPConnection:1
+// Local LAN ip address : 192.168.1.01
+// ExternalIPAddress = 85.84.83.82
+// InternalIP:Port = 192.168.1.01:4002
+// external 85.84.83.82:4002 UDP is redirected to internal 192.168.1.01:4002 (duration=0)
+
+// ERROR - no UPNP DEVICE:
+
+// upnpc : miniupnpc library test client, version 2.0.
+//  (c) 2005-2017 Thomas Bernard.
+// Go to http://miniupnp.free.fr/ or https://miniupnp.tuxfamily.org/
+// for more information.
+// No IGD UPnP Device found on the network !
+
+/**
+ *
+ * @param {String} terminalOutput A sample can be found above
+ * @return {*}
+ */
+function parseOpenOutput(terminalOutput) {
+  validateKwargs({terminalOutput});
+  parseGeneralErrors(terminalOutput);
+
+  // Get the last line of the output
+  const lines = terminalOutput.trim().split(/\r?\n/);
+  const lastLine = lines[lines.length - 1];
+
+  // Check if is contains "is redirected"
+  const okRegex = RegExp(/is.redirected/);
+  if (okRegex.test(lastLine)) {
+    return true;
+  }
+}
+
+module.exports = parseOpenOutput;

--- a/build/src/src/modules/upnpc/validateKwargs.js
+++ b/build/src/src/modules/upnpc/validateKwargs.js
@@ -1,0 +1,7 @@
+function validateKwargs(kwargs) {
+  for (const key of Object.keys(kwargs)) {
+    if (!kwargs[key]) throw Error(`${key} must be defined`);
+  }
+}
+
+module.exports = validateKwargs;

--- a/build/src/src/utils/envsHelper.js
+++ b/build/src/src/utils/envsHelper.js
@@ -44,7 +44,7 @@ function writeEnvs(name, isCore, envs) {
 function getManifestEnvs(manifest) {
   const envsArray = (manifest.image || {}).environment || [];
   return envsArray.reduce((obj, row) => {
-    const [key, value] = (row || '').trim().split('=');
+    const [key, value] = (row || '').trim().split(/=(.*)/);
     obj[key] = value || '';
     return obj;
   }, {});

--- a/build/src/src/utils/envsHelper.js
+++ b/build/src/src/utils/envsHelper.js
@@ -1,0 +1,57 @@
+const fs = require('fs');
+const parse = require('utils/parse');
+const params = require('params');
+const getPath = require('utils/getPath');
+const validate = require('utils/validate');
+
+/**
+ * Loads a `.env` file from disk and parses its envs
+ * @param {String} name
+ * @param {Bool} isCore
+ * @return {Object} envs = {
+ *   ENV_NAME: 'value'
+ * }
+ */
+function loadEnvs(name, isCore) {
+  const envFilePath = getPath.envFile(name, params, isCore);
+  if (!fs.existsSync(envFilePath)) {
+    return {};
+  }
+  const envFileData = fs.readFileSync(envFilePath, 'utf8');
+  return parse.envFile(envFileData);
+}
+
+/**
+ * Stringifies an env object and write to an `.env` file to disk
+ * @param {String} name
+ * @param {Bool} isCore
+ * @param {Object} envs = {
+ *   ENV_NAME: 'value'
+ * }
+ */
+function writeEnvs(name, isCore, envs) {
+  const envFilePath = getPath.envFileSmart(name, params, isCore);
+  fs.writeFileSync(validate.path(envFilePath), parse.stringifyEnvs(envs));
+}
+
+/**
+ * Parses a manifest object to return an envs object
+ * @param {Object} manifest
+ * @return {Object} envs = {
+ *   ENV_NAME: 'value'
+ * }
+ */
+function getManifestEnvs(manifest) {
+  const envsArray = (manifest.image || {}).environment || [];
+  return envsArray.reduce((obj, row) => {
+    const [key, value] = (row || '').trim().split('=');
+    obj[key] = value || '';
+    return obj;
+  }, {});
+}
+
+module.exports = {
+  load: loadEnvs,
+  write: writeEnvs,
+  getManifestEnvs,
+};

--- a/build/src/src/utils/parse.js
+++ b/build/src/src/utils/parse.js
@@ -73,19 +73,17 @@ function dockerComposePorts(dockerComposePath) {
 }
 
 function envFile(envFileData) {
-  let res = {};
   // Parses key1=value1 files, splited by new line
   //        key2=value2
-  envFileData
+  return envFileData
     .trim()
     .split('\n')
     .filter((row) => row.length > 0)
-    .map((row) => {
-      const [key, value] = row.split(/=(.+)/);
-      res[key] = value;
-    });
-
-  return res;
+    .reduce((obj, row) => {
+      const [key, value] = row.split(/=(.*)/);
+      obj[key] = value;
+      return obj;
+    }, {});
 }
 
 function stringifyEnvs(envs) {

--- a/build/src/src/utils/parse.js
+++ b/build/src/src/utils/parse.js
@@ -20,7 +20,7 @@ function stringifyDockerCompose(dcObject) {
 // Helper function, read and parse docker-compose
 function readDockerCompose(dockerComposePath) {
   if (!fs.existsSync(dockerComposePath)) {
-    throw Error('docker-compose does not exist: '+dockerComposePath);
+    throw Error('docker-compose does not exist: ' + dockerComposePath);
   }
   const dcString = fs.readFileSync(dockerComposePath, 'utf-8');
   return parseDockerCompose(dcString);
@@ -31,7 +31,6 @@ function writeDockerCompose(dockerComposePath, dcObject) {
   const dcString = stringifyDockerCompose(dcObject);
   fs.writeFileSync(dockerComposePath, dcString, 'utf-8');
 }
-
 
 // Select the first service in a docker-compose
 function getUniqueDockerComposeService(dockerComposePath) {
@@ -80,7 +79,7 @@ function envFile(envFileData) {
   envFileData
     .trim()
     .split('\n')
-    .filter((row) => row.length > 0 )
+    .filter((row) => row.length > 0)
     .map((row) => {
       const [key, value] = row.split(/=(.+)/);
       res[key] = value;
@@ -93,30 +92,29 @@ function stringifyEnvs(envs) {
   if (typeof envs === typeof {}) {
     // great
   } else if (typeof envs === typeof 'string') {
-    throw Error('Attempting to stringify envs of type STRING. Must be an OBJECT: '+envs);
+    throw Error('Attempting to stringify envs of type STRING. Must be an OBJECT: ' + envs);
   } else {
-    throw Error('Attempting to stringify envs of UNKOWN type. Must be an OBJECT: '+envs);
+    throw Error('Attempting to stringify envs of UNKOWN type. Must be an OBJECT: ' + envs);
   }
-  return Object.getOwnPropertyNames(envs)
-    .map((envName) => {
-      let envValue = envs[envName];
-      return envName + '=' + envValue;
-    })
-    .join('\n').trim();
+  return (
+    Object.getOwnPropertyNames(envs)
+      // Use join() to prevent "ENV_NAME=undefined"
+      .map((envName) => [envName, envs[envName] || ''].join('='))
+      .join('\n')
+      .trim()
+  );
 }
-
 
 function packageReq(req) {
   if (!req) throw Error('PARSE ERROR: packageReq is undefined');
 
-  if (typeof(req) != 'string') {
+  if (typeof req != 'string') {
     throw Error('PARSE ERROR: packageReq must be a string, packageReq: ' + req);
   }
 
   // Added for debugging on development
   if (req.length == 1) {
-    throw Error('WARNING: packageReq has only one character, this should not happen, '
-      + 'packageReq: ' + req);
+    throw Error('WARNING: packageReq has only one character, this should not happen, ' + 'packageReq: ' + req);
   }
 
   const [name, ver] = req.split('@');
@@ -137,12 +135,10 @@ function packageReq(req) {
 // }
 
 const manifest = {
-
   depObject: function(manifest) {
     let depObject = manifest.dependencies || {};
-    if ( !depObject || typeof(depObject) != typeof({}) ) {
-      throw Error('BROKEN DEPENDENCY OBJECT, of package: '
-        + JSON.stringify(packageReq)+' depObject: '+depObject);
+    if (!depObject || typeof depObject != typeof {}) {
+      throw Error('BROKEN DEPENDENCY OBJECT, of package: ' + JSON.stringify(packageReq) + ' depObject: ' + depObject);
     }
     return depObject;
   },
@@ -153,7 +149,6 @@ const manifest = {
   type: (manifest) => manifest.type,
   version: (manifest) => manifest.version,
 };
-
 
 module.exports = {
   parseDockerCompose,

--- a/build/src/src/utils/parseManifestPorts.js
+++ b/build/src/src/utils/parseManifestPorts.js
@@ -1,0 +1,32 @@
+/**
+ * Parses ports
+ * @param {Object} manifest or portsArray = ['32323:30303/udp']
+ * @return {Array} [ {number: '32323', type: 'UDP'}, ... ]
+ */
+function parseManifestPorts(manifest = {}) {
+  if (!manifest) return [];
+  const portsArray = (manifest.image || {}).ports || [];
+
+  //                host : container / type
+  // portsArray = ['32323:30303/udp']
+  //               container / type
+  // portsArray = ['30303/udp']
+  return (
+    portsArray
+      // Ensure each port mapping is unique
+      .filter((item, i, ar) => ar.indexOf(item) === i)
+      // Ignore ports that are not mapped
+      .filter((e) => e.includes(':'))
+      // Transform ['30303:30303/udp'] => [ {number: '30303', type: 'UDP'} ]
+      .map((p) => {
+        const hostPortNumber = p.split(':')[0];
+        const portType = p.split('/')[1] || 'TCP';
+        return {
+          number: hostPortNumber,
+          type: (portType || '').toUpperCase(),
+        };
+      })
+  );
+}
+
+module.exports = parseManifestPorts;

--- a/build/src/src/utils/registerHandler.js
+++ b/build/src/src/utils/registerHandler.js
@@ -1,0 +1,79 @@
+const logUserAction = require('../logUserAction');
+const logs = require('../logs')(module);
+
+/*
+ * RPC register wrapper
+ * ********************
+ * This function absctracts and standarizes the response formating, error handling
+ * and logging of errors and actions.
+ */
+
+const wrapErrors = (handler, event) =>
+  async function(args, kwargs, details) {
+    logs.debug('In-call to ' + event);
+    // 0. args: an array with call arguments
+    // 1. kwargs: an object with call arguments
+    // 2. details: an object which provides call metadata
+    try {
+      const res = await handler(kwargs);
+
+      // Log internally
+      logUserAction.log({level: 'info', event, ...res, kwargs});
+      const eventShort = event.replace('.dappmanager.dnp.dappnode.eth', '');
+      if (res.logMessage) {
+        logs.info('Call ' + eventShort + ' success: ' + res.message);
+      }
+
+      // Return to crossbar
+      return JSON.stringify({
+        success: true,
+        message: res.message,
+        result: res.result || {},
+      });
+    } catch (err) {
+      // Rename known shit-errors
+      // When attempting to call a contract while the chain is syncing:
+      if (err.message && (err.message.includes('decode 0x from ABI') || err.message.includes('decode address from ABI'))) {
+        err.code = 'SYNCING';
+        err.message = `Chain is still syncing: ${err.message}`;
+      }
+      // When attempting an JSON RPC but the connection with the node is closed:
+      if (err.message && err.message.includes('connection not open')) {
+        err.message = `Could not connect to ethchain: ${err.message}`;
+      }
+
+      // ##### Don't reflect logId in the userActions logs (delete w/ immutable method)
+      const _kwargs = Object.assign({}, kwargs);
+      if (_kwargs && _kwargs.logId) delete _kwargs.logId;
+
+      // Don't log to userActions is "SYNCING" errors
+      if (err.code !== 'SYNCING') {
+        logUserAction.log({level: 'error', event, ...error2obj(err), kwargs: _kwargs});
+      }
+      logs.error('Call ' + event + ' error: ' + err.message + '\nStack: ' + err.stack);
+      return JSON.stringify({
+        success: false,
+        message: err.message,
+      });
+    }
+  };
+
+const registerHandler = (session, event, handler) => {
+  return session.register(event, wrapErrors(handler, event)).then(
+    function(reg) {
+      logs.info('CROSSBAR: registered ' + event);
+    },
+    function(err) {
+      logs.error('CROSSBAR: error registering ' + event + '. Error message: ' + err.error);
+    }
+  );
+};
+
+function error2obj(e) {
+  return {name: e.name, message: e.message, stack: e.stack, userAction: true};
+}
+
+module.exports = {
+  registerHandler,
+  wrapErrors,
+};

--- a/build/src/src/utils/shell.js
+++ b/build/src/src/utils/shell.js
@@ -14,19 +14,20 @@ const exec = util.promisify(require('child_process').exec);
  * identified by the killSignal property (the default is 'SIGTERM')
  * if the child runs longer than timeout milliseconds.
  */
-const timeout = 3*60*1000; // ms
+const defaultTimeout = 3 * 60 * 1000; // ms
 
-function shell(cmd) {
-    return exec(cmd, {timeout})
-    .then((res) => res.stdout)
+function shell(cmd, _options) {
+  const options = typeof _options === 'object' ? _options : {};
+  const timeout = options.timeout || defaultTimeout;
+  return exec(cmd, {timeout})
+    .then((res) => (res.stdout || '').trim())
     .catch((err) => {
-        if (err.signal === 'SIGTERM') {
-            throw Error(`cmd "${err.cmd}" timed out (${timeout} ms)`);
-        }
-        throw err;
+      if (err.signal === 'SIGTERM') {
+        throw Error(`cmd "${err.cmd}" timed out (${timeout} ms)`);
+      }
+      throw err;
     });
 }
-
 
 /**
  * About the error object
@@ -64,6 +65,5 @@ cat: aa.txt: No such file or directory
  *
  * Using child_process it's best to just rethrow the recieved error.
  */
-
 
 module.exports = shell;

--- a/build/src/test/calls/installPackage.test.js
+++ b/build/src/test/calls/installPackage.test.js
@@ -4,158 +4,193 @@ const sinon = require('sinon');
 const {eventBusTag} = require('eventBus');
 
 describe('Call function: installPackage', function() {
-    const params = {
-        REPO_DIR: 'test_files/',
-        DOCKERCOMPOSE_NAME: 'docker-compose.yml',
-    };
+  const params = {
+    REPO_DIR: 'test_files/',
+    DOCKERCOMPOSE_NAME: 'docker-compose.yml',
+  };
 
-    const pkgName = 'dapp.dnp.dappnode.eth';
-    const pkgVer = '0.1.1';
-    const pkgManifest = {
-        type: 'service',
-    };
+  const pkgName = 'dapp.dnp.dappnode.eth';
+  const pkgVer = '0.1.1';
+  const pkgManifest = {
+    name: pkgName,
+    type: 'service',
+  };
 
-    const depName = 'kovan.dnp.dappnode.eth';
-    const depVer = '0.1.1';
-    const depManifest = {
-        type: 'library',
-    };
-    const depPortsToOpen = [
-        {number: 32769, type: 'UDP'},
-        {number: 32769, type: 'TCP'},
-    ];
+  const depName = 'kovan.dnp.dappnode.eth';
+  const depVer = '0.1.1';
+  const depManifest = {
+    name: depName,
+    type: 'library',
+  };
+  const depPortsToOpen = [{number: 32769, type: 'UDP'}, {number: 32769, type: 'TCP'}];
 
-    const logId = '1234abcd';
+  const logId = '1234abcd';
 
-    // Stub packages module. Resolve always returning nothing
-    const packages = {
-        download: sinon.fake.resolves(),
-        run: sinon.fake.resolves(),
-    };
+  // Stub packages module. Resolve always returning nothing
+  const packages = {
+    download: sinon.fake.resolves(),
+    run: sinon.fake.resolves(),
+  };
 
-    const dappGet = sinon.fake.resolves({
-        success: {[pkgName]: pkgVer, [depName]: depVer},
-        state: {[pkgName]: '0.1.0'},
-    });
+  const dappGet = sinon.fake.resolves({
+    success: {[pkgName]: pkgVer, [depName]: depVer},
+    state: {[pkgName]: '0.1.0'},
+  });
 
-    const getManifest = sinon.stub().callsFake(async function(pkg) {
-        if (pkg.name === pkgName) return pkgManifest;
-        else if (pkg.name === depName) return depManifest;
-        else throw Error(`[SINON STUB] Manifest of ${pkg.name} not available`);
-    });
+  const getManifest = sinon.stub().callsFake(async function(pkg) {
+    if (pkg.name === pkgName) return pkgManifest;
+    else if (pkg.name === depName) return depManifest;
+    else throw Error(`[SINON STUB] Manifest of ${pkg.name} not available`);
+  });
 
-    const eventBusPackage = {
-        eventBus: {
-            emit: sinon.stub(),
+  const eventBusPackage = {
+    eventBus: {
+      emit: sinon.stub(),
+    },
+    eventBusTag,
+  };
+
+  const dockerList = {
+    listContainers: async () => {},
+  };
+
+  // Simulate that only the dependency has p2p ports
+  const lockPorts = sinon.stub().callsFake(async ({pkg}) => {
+    if (pkg.name === depName) return depPortsToOpen;
+    else return [];
+  });
+
+  // Simulate you are in a physical DAppNode behind an UPnP capable router
+  const shouldOpenPorts = async () => true;
+
+  // Simulated the chain is already synced
+  const isSyncing = async () => false;
+
+  const installPackage = proxyquire('calls/installPackage', {
+    'modules/packages': packages,
+    'modules/dappGet': dappGet,
+    'modules/getManifest': getManifest,
+    'modules/dockerList': dockerList,
+    'modules/lockPorts': lockPorts,
+    'modules/shouldOpenPorts': shouldOpenPorts,
+    'eventBus': eventBusPackage,
+    'utils/isSyncing': isSyncing,
+    'params': params,
+  });
+
+  // before(() => {
+  //     const DOCKERCOMPOSE_PATH = getPath.dockerCompose(PACKAGE_NAME, params);
+  //     validate.path(DOCKERCOMPOSE_PATH);
+  //     fs.writeFileSync(DOCKERCOMPOSE_PATH, dockerComposeTemplate);
+  // });
+
+  it('should install the package with correct arguments', async () => {
+    const res = await installPackage({id: pkgName, logId});
+    expect(res).to.be.an('object');
+    expect(res).to.have.property('message');
+  });
+
+  // Step 1: Parse request
+  // Step 2: Resolve the request
+  it('should have called dappGet with correct arguments', async () => {
+    sinon.assert.calledWith(dappGet, {name: pkgName, req: pkgName, ver: '*'});
+  });
+
+  // Step 3: Format the request and filter out already updated packages
+  // Step 4: Download requested packages
+  it('should have called download', async () => {
+    sinon.assert.callCount(packages.download, 2);
+    expect(packages.download.getCall(0).args).to.deep.equal(
+      [
+        {
+          logId,
+          pkg: {
+            manifest: {...pkgManifest},
+            name: pkgName,
+            ver: pkgVer,
+          },
         },
-        eventBusTag,
-    };
-
-    const dockerList = {
-        listContainers: async () => {},
-    };
-
-    // Simulate that only the dependency has p2p ports
-    const lockPorts = sinon.stub().callsFake(async ({pkg}) => {
-        if (pkg.name === depName) return depPortsToOpen;
-        else return [];
-    });
-
-    // Simulate you are in a physical DAppNode behind an UPnP capable router
-    const shouldOpenPorts = async () => true;
-
-    // Simulated the chain is already synced
-    const isSyncing = async () => false;
-
-    const installPackage = proxyquire('calls/installPackage', {
-        'modules/packages': packages,
-        'modules/dappGet': dappGet,
-        'modules/getManifest': getManifest,
-        'modules/dockerList': dockerList,
-        'modules/lockPorts': lockPorts,
-        'modules/shouldOpenPorts': shouldOpenPorts,
-        'eventBus': eventBusPackage,
-        'utils/isSyncing': isSyncing,
-        'params': params,
-    });
-
-    // before(() => {
-    //     const DOCKERCOMPOSE_PATH = getPath.dockerCompose(PACKAGE_NAME, params);
-    //     validate.path(DOCKERCOMPOSE_PATH);
-    //     fs.writeFileSync(DOCKERCOMPOSE_PATH, dockerComposeTemplate);
-    // });
-
-    it('should install the package with correct arguments', async () => {
-        const res = await installPackage({id: pkgName, logId});
-        expect(res).to.be.an('object');
-        expect(res).to.have.property('message');
-    });
-
-    // Step 1: Parse request
-    // Step 2: Resolve the request
-    it('should have called dappGet with correct arguments', async () => {
-        sinon.assert.calledWith(dappGet, {name: pkgName, req: pkgName, ver: '*'});
-    });
-
-    // Step 3: Format the request and filter out already updated packages
-    // Step 4: Download requested packages
-    it('should have called download', async () => {
-        sinon.assert.callCount(packages.download, 2);
-        expect(packages.download.getCall(0).args).to.deep.equal([{logId, pkg: {
-            manifest: {...pkgManifest, isCore: false},
-            name: pkgName,
-            ver: pkgVer,
-        }}], `should call packages.download first for package ${pkgName}`);
-        expect(packages.download.getCall(1).args).to.deep.equal([{logId, pkg: {
-            manifest: {...depManifest, isCore: false},
+      ],
+      `should call packages.download first for package ${pkgName}`
+    );
+    expect(packages.download.getCall(1).args).to.deep.equal(
+      [
+        {
+          logId,
+          pkg: {
+            manifest: {...depManifest},
             name: depName,
             ver: depVer,
-        }}], `should call packages.download second for dependency ${depName}`);
-    });
+          },
+        },
+      ],
+      `should call packages.download second for dependency ${depName}`
+    );
+  });
 
-    // Step 5: Run requested packages
-    it('should have called run', async () => {
-        sinon.assert.callCount(packages.run, 2);
-        expect(packages.run.getCall(0).args).to.deep.equal([{logId, pkg: {
-            manifest: {...pkgManifest, isCore: false},
+  // Step 5: Run requested packages
+  it('should have called run', async () => {
+    sinon.assert.callCount(packages.run, 2);
+    expect(packages.run.getCall(0).args).to.deep.equal(
+      [
+        {
+          logId,
+          pkg: {
+            manifest: {...pkgManifest},
             name: pkgName,
             ver: pkgVer,
-        }}], `should call packages.run second for dependency ${depName}`);
-        expect(packages.run.getCall(1).args).to.deep.equal([{logId, pkg: {
-            manifest: {...depManifest, isCore: false},
+          },
+        },
+      ],
+      `should call packages.run second for dependency ${depName}`
+    );
+    expect(packages.run.getCall(1).args).to.deep.equal(
+      [
+        {
+          logId,
+          pkg: {
+            manifest: {...depManifest},
             name: depName,
             ver: depVer,
-        }}], `should call packages.run second for dependency ${depName}`);
-    });
+          },
+        },
+      ],
+      `should call packages.run second for dependency ${depName}`
+    );
+  });
 
-    // Step 6: P2P ports: modify docker-compose + open ports
-    it('should emit an internal call to the eventBus', async () => {
-        sinon.assert.callCount(lockPorts, 2);
-        // eventBus should be called once to open ports, and then to emitPackages
-        sinon.assert.callCount(eventBusPackage.eventBus.emit, 3);
-        expect(eventBusPackage.eventBus.emit.getCall(0).args).to.deep.equal([
-            eventBusTag.call,
-            {callId: 'managePorts', kwargs: {
-                action: 'open', ports: depPortsToOpen,
-            }},
-        ], `eventBus.emit first call must be to open the dependencies' ports`);
-    });
+  // Step 6: P2P ports: modify docker-compose + open ports
+  it('should emit an internal call to the eventBus', async () => {
+    sinon.assert.callCount(lockPorts, 2);
+    // eventBus should be called once to open ports, and then to emitPackages
+    sinon.assert.callCount(eventBusPackage.eventBus.emit, 3);
+    expect(eventBusPackage.eventBus.emit.getCall(0).args).to.deep.equal(
+      [
+        eventBusTag.call,
+        {
+          callId: 'managePorts',
+          kwargs: {
+            action: 'open',
+            ports: depPortsToOpen,
+          },
+        },
+      ],
+      `eventBus.emit first call must be to open the dependencies' ports`
+    );
+  });
 
-    // Step FINAL:
-    it('should request to emit packages to refresh the UI', async () => {
-        expect(eventBusPackage.eventBus.emit.getCall(1).args).to.deep.equal([
-            eventBusTag.emitPackages,
-        ], `eventBus.emit second call must be to request emit packages`);
-    });
+  // Step FINAL:
+  it('should request to emit packages to refresh the UI', async () => {
+    expect(eventBusPackage.eventBus.emit.getCall(1).args).to.deep.equal([eventBusTag.emitPackages], `eventBus.emit second call must be to request emit packages`);
+  });
 
-    // it('should throw an error with wrong package name', async () => {
-    //     let error = '--- removePackage did not throw ---';
-    //     try {
-    //         await removePackage({id: PACKAGE_NAME});
-    //     } catch (e) {
-    //         error = e.message;
-    //     }
-    //     expect(error).to.include('No docker-compose found');
-    // });
+  // it('should throw an error with wrong package name', async () => {
+  //     let error = '--- removePackage did not throw ---';
+  //     try {
+  //         await removePackage({id: PACKAGE_NAME});
+  //     } catch (e) {
+  //         error = e.message;
+  //     }
+  //     expect(error).to.include('No docker-compose found');
+  // });
 });
-

--- a/build/src/test/calls/installPackage.test.js
+++ b/build/src/test/calls/installPackage.test.js
@@ -66,6 +66,13 @@ describe('Call function: installPackage', function() {
   // Simulated the chain is already synced
   const isSyncing = async () => false;
 
+  // db to know UPnP state
+  const db = {
+    get: async (key) => {
+      if (key === 'upnpAvailable') return true;
+    },
+  };
+
   const installPackage = proxyquire('calls/installPackage', {
     'modules/packages': packages,
     'modules/dappGet': dappGet,
@@ -76,6 +83,7 @@ describe('Call function: installPackage', function() {
     'eventBus': eventBusPackage,
     'utils/isSyncing': isSyncing,
     'params': params,
+    '../db': db,
   });
 
   // before(() => {

--- a/build/src/test/index.test.int.js
+++ b/build/src/test/index.test.int.js
@@ -54,6 +54,14 @@ describe('Full integration test with REAL docker: ', function() {
     // - > installPackage
     testInstallPackage(installPackage, {id});
 
+    // EXTRA, verify that the envs were set correctly
+    it('should had to update DNP ENVs during the installation', async () => {
+      const getPath = require('utils/getPath');
+      const ENV_FILE_PATH = getPath.envFile(id, params);
+      let envRes = fs.readFileSync(ENV_FILE_PATH, 'utf8');
+      expect(envRes).to.include('VIRTUAL_HOST=\nLETSENCRYPT_HOST=');
+    }).timeout(10 * 1000);
+
     // - > logPackage
     testLogPackage(logPackage, {
       id,
@@ -215,12 +223,6 @@ function testUpdatePackageEnv(updatePackageEnv, id, restart, params) {
     });
     expect(res).to.have.property('message');
     let envRes = fs.readFileSync(ENV_FILE_PATH, 'utf8');
-    expect(envRes).to.equal(
-      `
-VIRTUAL_HOST=
-LETSENCRYPT_HOST=
-time=${envValue}
-`.trim()
-    );
+    expect(envRes).to.include(`time=${envValue}`);
   }).timeout(120 * 1000);
 }

--- a/build/src/test/index.test.int.js
+++ b/build/src/test/index.test.int.js
@@ -215,6 +215,12 @@ function testUpdatePackageEnv(updatePackageEnv, id, restart, params) {
     });
     expect(res).to.have.property('message');
     let envRes = fs.readFileSync(ENV_FILE_PATH, 'utf8');
-    expect(envRes).to.equal('time=' + envValue);
+    expect(envRes).to.equal(
+      `
+VIRTUAL_HOST=
+LETSENCRYPT_HOST=
+time=${envValue}
+`.trim()
+    );
   }).timeout(120 * 1000);
 }

--- a/build/src/test/index.test.int.js
+++ b/build/src/test/index.test.int.js
@@ -16,8 +16,8 @@ describe('Full integration test with REAL docker: ', function() {
   const logPackage = require('calls/logPackage');
   const updatePackageEnv = require('calls/updatePackageEnv');
   const listPackages = require('calls/listPackages');
-  const fetchDirectory = require('calls/fetchDirectory');
-  const fetchPackageVersions = require('calls/fetchPackageVersions');
+  // const fetchDirectory = require('calls/fetchDirectory');
+  // const fetchPackageVersions = require('calls/fetchPackageVersions');
   // const fetchPackageData = require('calls/fetchPackageData');
   // const managePorts = require('calls/managePorts');
   // const getUserActionLogs = require('calls/getUserActionLogs');

--- a/build/src/test/index.test.int.js
+++ b/build/src/test/index.test.int.js
@@ -34,21 +34,13 @@ describe('Full integration test with REAL docker: ', function() {
       this.timeout(10000);
       // runs before all tests in this block
       await Promise.all([
-        await shell('docker volume create --name=nginxproxydnpdappnodeeth_vhost.d')
-        .catch(() => {}),
-        await shell('docker volume create --name=nginxproxydnpdappnodeeth_html')
-        .catch(() => {}),
-        await shell('docker network create dncore_network')
-        .catch(() => {}),
+        await shell('docker volume create --name=nginxproxydnpdappnodeeth_vhost.d').catch(() => {}),
+        await shell('docker volume create --name=nginxproxydnpdappnodeeth_html').catch(() => {}),
+        await shell('docker network create dncore_network').catch(() => {}),
         // Clean previous stuff
-        await shell('rm -rf dnp_repo/nginx-proxy.dnp.dappnode.eth/')
-        .catch(() => {}),
-        await shell('rm -rf dnp_repo/letsencrypt-nginx.dnp.dappnode.eth/')
-        .catch(() => {}),
-        await shell('docker rm -f '
-          +'DAppNodePackage-letsencrypt-nginx.dnp.dappnode.eth '
-          +'DAppNodePackage-nginx-proxy.dnp.dappnode.eth')
-        .catch(() => {}),
+        await shell('rm -rf dnp_repo/nginx-proxy.dnp.dappnode.eth/').catch(() => {}),
+        await shell('rm -rf dnp_repo/letsencrypt-nginx.dnp.dappnode.eth/').catch(() => {}),
+        await shell('docker rm -f ' + 'DAppNodePackage-letsencrypt-nginx.dnp.dappnode.eth ' + 'DAppNodePackage-nginx-proxy.dnp.dappnode.eth').catch(() => {}),
       ]);
     });
 
@@ -75,7 +67,6 @@ describe('Full integration test with REAL docker: ', function() {
       id: 'nginx-proxy.dnp.dappnode.eth',
       options: {},
     });
-
 
     // - > updatePackageEnv (with reset, after install)
     testUpdatePackageEnv(updatePackageEnv, id, true, params);
@@ -104,22 +95,17 @@ describe('Full integration test with REAL docker: ', function() {
     testListPackages(listPackages, id, 'down');
   });
 
-
   describe('TEST 2, updatePackageEnv', () => {
     // - > updatePackageEnv (of a non-existent package)
     testUpdatePackageEnv(updatePackageEnv, 'fake.eth', false, params);
   });
 
-
   after(() => {
     logs.info('\x1b[36m%s\x1b[0m', '>> CLOSING TEST');
     const web3 = require('modules/web3Setup');
     web3.clearWatch();
-    if (web3.currentProvider
-      && web3.currentProvider.connection
-      && web3.currentProvider.connection.close
-    ) {
-      logs.info('\x1b[36m%s\x1b[0m', '>> CLOSING WS: '+web3.currentProvider.host);
+    if (web3.currentProvider && web3.currentProvider.connection && web3.currentProvider.connection.close) {
+      logs.info('\x1b[36m%s\x1b[0m', '>> CLOSING WS: ' + web3.currentProvider.host);
       web3.currentProvider.connection.close();
     }
   });
@@ -148,7 +134,6 @@ describe('Full integration test with REAL docker: ', function() {
 // - > fetchDirectory
 // - > fetchPackageVersions
 
-
 // The test will perfom intense tasks and could take up to some minutes
 // TEST - 1
 // - > updatePackageEnv
@@ -157,19 +142,19 @@ function testInstallPackage(installPackage, kwargs) {
   it('call installPackage', (done) => {
     logs.info('\x1b[36m%s\x1b[0m', '>> INSTALLING');
     installPackage(kwargs)
-    .then(
-      (res) => {
-        // logs.info('\x1b[33m%s\x1b[0m', res)
-        expect(res).to.have.property('message');
-      },
-      (e) => {
-        if (e) logs.error(e.stack);
-        expect(e).to.be.undefined;
-      }
-    ).then(done);
-  }).timeout(120*1000);
+      .then(
+        (res) => {
+          // logs.info('\x1b[33m%s\x1b[0m', res)
+          expect(res).to.have.property('message');
+        },
+        (e) => {
+          if (e) logs.error(e.stack);
+          expect(e).to.be.undefined;
+        }
+      )
+      .then(done);
+  }).timeout(5 * 60 * 1000);
 }
-
 
 function testLogPackage(logPackage, kwargs) {
   it('call logPackage', async () => {
@@ -182,12 +167,11 @@ function testLogPackage(logPackage, kwargs) {
     expect(res.result.logs).to.be.a('string');
     // let packageNames = parsedRes.result.map(e => name)
     // expect(packageNames).to.include(packageReq)
-  }).timeout(10*1000);
+  }).timeout(10 * 1000);
 }
 
-
 function testListPackages(listPackages, packageName, state) {
-  it('call listPackages, to check '+packageName+' is '+state, async () => {
+  it('call listPackages, to check ' + packageName + ' is ' + state, async () => {
     logs.info('\x1b[36m%s\x1b[0m', '>> LISTING');
     const res = await listPackages();
     expect(res).to.have.property('message');
@@ -198,27 +182,24 @@ function testListPackages(listPackages, packageName, state) {
     // logs.info('\x1b[33m%s\x1b[0m', pkg)
     if (state == 'down') expect(pkg).to.be.undefined;
     else expect(pkg.state).to.equal(state);
-  }).timeout(10*1000);
+  }).timeout(10 * 1000);
 }
-
 
 function testTogglePackage(togglePackage, kwargs) {
   it('call togglePackage', async () => {
     logs.info('\x1b[36m%s\x1b[0m', '>> TOGGLING START / STOP');
     const res = await togglePackage(kwargs);
     expect(res).to.have.property('message');
-  }).timeout(20*1000);
+  }).timeout(20 * 1000);
 }
-
 
 function testRemovePackage(removePackage, kwargs) {
   it('call removePackage', async () => {
     logs.info('\x1b[36m%s\x1b[0m', '>> REMOVING');
     const res = await removePackage(kwargs);
     expect(res).to.have.property('message');
-  }).timeout(20*1000);
+  }).timeout(20 * 1000);
 }
-
 
 function testUpdatePackageEnv(updatePackageEnv, id, restart, params) {
   const getPath = require('utils/getPath');
@@ -234,7 +215,6 @@ function testUpdatePackageEnv(updatePackageEnv, id, restart, params) {
     });
     expect(res).to.have.property('message');
     let envRes = fs.readFileSync(ENV_FILE_PATH, 'utf8');
-    expect(envRes).to.equal('time='+envValue);
-  }).timeout(120*1000);
+    expect(envRes).to.equal('time=' + envValue);
+  }).timeout(120 * 1000);
 }
-

--- a/build/src/test/modules/docker/shell.test.js
+++ b/build/src/test/modules/docker/shell.test.js
@@ -1,18 +1,17 @@
 const expect = require('chai').expect;
 
-const shellExecSync = require('modules/docker/shell');
+const shell = require('modules/docker/shell');
 
-describe('Util: shell', function() {
+describe('Util: shell', () => {
   it('should return an error when cating a non-existing file', async () => {
-    let res = await shellExecSync('cat package.json', true);
-    expect(res)
-      .to.include('"dependencies": {');
+    let res = await shell('cat package.json');
+    expect(res).to.include('"dependencies": {');
   });
 
   it('should return the content of a file when cating', async () => {
-    let error = '--- shellExecSync did not throw ---';
+    let error = '--- shell did not throw ---';
     try {
-      await shellExecSync('cat jfnakjsdfnodfu9sadf', true);
+      await shell('cat jfnakjsdfnodfu9sadf');
     } catch (e) {
       error = e.message;
     }

--- a/build/src/test/modules/upnpc/parseCloseOutput.test.js
+++ b/build/src/test/modules/upnpc/parseCloseOutput.test.js
@@ -1,0 +1,46 @@
+const expect = require('chai').expect;
+const parseCloseOutput = require('modules/upnpc/parseCloseOutput');
+
+/* eslint-disable max-len */
+
+describe('upnpn: parseCloseOutput', () => {
+  const terminalOutputSuccess = `upnpc : miniupnpc library test client, version 2.0.
+  (c) 2005-2017 Thomas Bernard.
+Go to http://miniupnp.free.fr/ or https://miniupnp.tuxfamily.org/
+for more information.
+List of UPNP devices found on the network :
+  desc: http://192.168.1.1:5001/dyn/uuid:0011-0011-0011-0011
+  st: urn:schemas-upnp-org:device:InternetGatewayDevice:1
+
+Found valid IGD : http://192.168.1.1:5001/uuid:0011-0011-0011-0011/WANPPPConnection:1
+Local LAN ip address : 192.168.1.01
+UPNP_DeletePortMapping() returned : 0
+`;
+
+  const terminalOutputErrorNoPort = `upnpc : miniupnpc library test client, version 2.0.
+ (c) 2005-2017 Thomas Bernard.
+Go to http://miniupnp.free.fr/ or https://miniupnp.tuxfamily.org/
+for more information.
+List of UPNP devices found on the network :
+ desc: http://192.168.1.1:5001/dyn/uuid:0011-0011-0011-0011
+ st: urn:schemas-upnp-org:device:InternetGatewayDevice:1
+
+Found valid IGD : http://192.168.1.1:5001/uuid:0011-0011-0011-0011/WANPPPConnection:1
+Local LAN ip address : 192.168.1.01
+UPNP_DeletePortMapping() failed with code : 714`;
+
+  it('On success, it should return ok', async () => {
+    const ok = parseCloseOutput(terminalOutputSuccess);
+    expect(ok).to.be.ok;
+  });
+
+  it('On error, it should return error', () => {
+    let error;
+    try {
+      parseCloseOutput(terminalOutputErrorNoPort);
+    } catch (e) {
+      error = e.message;
+    }
+    expect(error).to.equal('Error closing port: failed with code : 714');
+  });
+});

--- a/build/src/test/modules/upnpc/parseListOutput.test.js
+++ b/build/src/test/modules/upnpc/parseListOutput.test.js
@@ -1,0 +1,56 @@
+const expect = require('chai').expect;
+const parseListOutput = require('modules/upnpc/parseListOutput');
+
+/* eslint-disable max-len */
+
+describe('upnpn: parseListOutput', () => {
+  const terminalOutputSuccess = `upnpc : miniupnpc library test client, version 2.0.
+ (c) 2005-2017 Thomas Bernard.
+Go to http://miniupnp.free.fr/ or https://miniupnp.tuxfamily.org/
+for more information.
+List of UPNP devices found on the network :
+ desc: http://192.168.1.1:5001/dyn/uuid:0011-0011-0011-0011
+ st: urn:schemas-upnp-org:device:InternetGatewayDevice:1
+
+Found valid IGD : http://192.168.1.1:5001/uuid:0011-0011-0011-0011/WANPPPConnection:1
+Local LAN ip address : 192.168.1.01
+Connection Type : IP_Routed
+Status : Connected, uptime=1360425s, LastConnectionError :
+  Time started : Tue Feb 31 00:00:01 2018
+MaxBitRateDown : 0 bps   MaxBitRateUp 0 bps
+ExternalIPAddress = 85.84.83.82
+ i protocol exPort->inAddr:inPort description remoteHost leaseTime
+ 0 UDP   500->192.168.1.42:500   'DAppNode' '' 0
+ 1 UDP  4500->192.168.1.42:4500  'DAppNode' '' 0
+2 TCP    22->192.168.1.42:22    'DAppNode' '' 0
+ 3 UDP 30303->192.168.1.42:30303 'DAppNode' '' 0
+ 4 TCP 30303->192.168.1.42:30303 'DAppNode' '' 0
+ 5 TCP  4001->192.168.1.42:4001  'DAppNode' '' 0
+ 6 UDP  4002->192.168.1.42:4002  'DAppNode' '' 0
+ 7 TCP 32000->192.168.1.52:32000 'otherApp (TCP)' '' 0
+ 8 UDP 32000->192.168.1.52:32000 'otherApp (UDP)' '' 0
+GetGenericPortMappingEntry() returned 713 (SpecifiedArrayIndexInvalid)
+`;
+
+  const terminalOutputErrorNoDevice = `upnpc : miniupnpc library test client, version 2.0.
+(c) 2005-2017 Thomas Bernard.
+Go to http://miniupnp.free.fr/ or https://miniupnp.tuxfamily.org/
+for more information.
+No IGD UPnP Device found on the network !
+`;
+
+  it('On success, it should return the current port mappings', async () => {
+    const ports = parseListOutput(terminalOutputSuccess);
+    expect(ports).to.deep.equal([{protocol: 'UDP', exPort: '500', inPort: '500'}, {protocol: 'UDP', exPort: '4500', inPort: '4500'}, {protocol: 'TCP', exPort: '22', inPort: '22'}, {protocol: 'UDP', exPort: '30303', inPort: '30303'}, {protocol: 'TCP', exPort: '30303', inPort: '30303'}, {protocol: 'TCP', exPort: '4001', inPort: '4001'}, {protocol: 'UDP', exPort: '4002', inPort: '4002'}]);
+  });
+
+  it('On error, it should return error', () => {
+    let error;
+    try {
+      parseListOutput(terminalOutputErrorNoDevice);
+    } catch (e) {
+      error = e.message;
+    }
+    expect(error).to.equal('NOUPNP: No UPnP device available');
+  });
+});

--- a/build/src/test/modules/upnpc/parseOpenOutput.js
+++ b/build/src/test/modules/upnpc/parseOpenOutput.js
@@ -1,0 +1,26 @@
+const expect = require('chai').expect;
+const parseOpenOutput = require('modules/upnpc/parseOpenOutput');
+
+/* eslint-disable max-len */
+
+describe('upnpn: parseOpenOutput', () => {
+  const terminalOutputSuccess = `upnpc : miniupnpc library test client, version 2.0.
+ (c) 2005-2017 Thomas Bernard.
+Go to http://miniupnp.free.fr/ or https://miniupnp.tuxfamily.org/
+for more information.
+List of UPNP devices found on the network :
+ desc: http://192.168.1.1:5001/dyn/uuid:0011-0011-0011-0011
+ st: urn:schemas-upnp-org:device:InternetGatewayDevice:1
+
+Found valid IGD : http://192.168.1.1:5001/uuid:0011-0011-0011-0011/WANPPPConnection:1
+Local LAN ip address : 192.168.1.01
+ExternalIPAddress = 85.84.83.82
+InternalIP:Port = 192.168.1.01:4002
+external 85.84.83.82:4002 UDP is redirected to internal 192.168.1.01:4002 (duration=0)
+`;
+
+  it('On success, it should return ok', async () => {
+    const ok = parseOpenOutput(terminalOutputSuccess);
+    expect(ok).to.be.ok;
+  });
+});

--- a/build/src/test/utils/envsHelper.test.js
+++ b/build/src/test/utils/envsHelper.test.js
@@ -1,0 +1,62 @@
+const proxyquire = require('proxyquire');
+const expect = require('chai').expect;
+const shell = require('utils/shell');
+const fs = require('fs');
+
+const testDirectory = './test_files/';
+
+const envsHelper = proxyquire('utils/envsHelper', {
+  params: {...require('params'), REPO_DIR: testDirectory, DNCORE_DIR: testDirectory},
+});
+
+// module.exports = {
+//     load: loadEnvs,
+//     write: writeEnvs,
+//     getManifestEnvs,
+//   };
+
+describe('Util: envsHelper', () => {
+  const name = 'dnp-a.dnp.dappnode.eth';
+  const isCore = false;
+  const envPath = `${testDirectory}/${name}/${name}.env`;
+
+  before(async () => {
+    await shell(`mkdir -p ${testDirectory}/${name}`);
+    fs.writeFileSync(envPath, 'ENV_NAME1=on-disk-value');
+  });
+
+  it('should merge envs and write them', () => {
+    const pkg = {
+      manifest: {
+        name,
+        isCore,
+        image: {
+          environment: ['ENV_NAME1=manifest_value', 'ENV_NAME2=manifest_value', 'ENV_NAME3=manifest_value'],
+        },
+      },
+    };
+    const userSetEnvs = {
+      [name]: {
+        ENV_NAME3: 'user-set',
+      },
+    };
+
+    const defaultEnvs = envsHelper.getManifestEnvs(pkg.manifest);
+    const previousEnvs = envsHelper.load(name, isCore);
+    const envs = {...defaultEnvs, ...previousEnvs, ...userSetEnvs[pkg.manifest.name]};
+    envsHelper.write(name, isCore, envs);
+
+    const _envs = fs.readFileSync(envPath, 'utf8');
+
+    expect(_envs).to.equal(
+      `
+ENV_NAME1=on-disk-value
+ENV_NAME2=manifest_value
+ENV_NAME3=user-set`.trim()
+    );
+  });
+
+  after(async () => {
+    await shell(`rm -rf ${testDirectory}`);
+  });
+});

--- a/build/src/test/utils/merge.test.js
+++ b/build/src/test/utils/merge.test.js
@@ -2,63 +2,45 @@ const expect = require('chai').expect;
 
 const merge = require('utils/merge');
 
-describe('Util: merge', function() {
+describe('Util: merge', () => {
   const manifest = {
-    'name': 'kovan.dnp.dappnode.eth',
-    'image': {
-      'ports': [
-        '30303',
-        '30303/udp',
-        '30304:30304',
-      ],
-      'volumes': [
-        'kovan:/root/.local/share/io.parity.ethereum/',
-      ],
+    name: 'kovan.dnp.dappnode.eth',
+    image: {
+      ports: ['30303', '30303/udp', '30304:30304'],
+      volumes: ['kovan:/root/.local/share/io.parity.ethereum/'],
     },
   };
 
-  it('should merge the vols object', () => {
-      const vols = {
-        [manifest.name]: {
-            'kovan:/root/.local/share/io.parity.ethereum/': 'different_path:/root/.local/share/io.parity.ethereum/',
-        },
-      };
-      const editedManifest = merge.manifest.vols(manifest, vols);
-      expect(editedManifest).to.deep.equal({
-        'name': 'kovan.dnp.dappnode.eth',
-        'image': {
-          'ports': [
-            '30303',
-            '30303/udp',
-            '30304:30304',
-          ],
-          'volumes': [
-            'different_path:/root/.local/share/io.parity.ethereum/',
-          ],
-        },
-      });
-  });
-
-  it('should merge the ports object', () => {
-    const ports = {
+  it('should merge the userSetVols object', () => {
+    const userSetVols = {
       [manifest.name]: {
-          '30303': '31313:30303',
-          '30303/udp': '31313:30303/udp',
-          '30304:30304': '30304',
+        'kovan:/root/.local/share/io.parity.ethereum/': 'different_path:/root/.local/share/io.parity.ethereum/',
       },
     };
-    const editedManifest = merge.manifest.ports(manifest, ports);
+    const editedManifest = merge.manifest.vols(manifest, userSetVols);
     expect(editedManifest).to.deep.equal({
-      'name': 'kovan.dnp.dappnode.eth',
-      'image': {
-        'ports': [
-          '31313:30303',
-          '31313:30303/udp',
-          '30304',
-        ],
-        'volumes': [
-          'kovan:/root/.local/share/io.parity.ethereum/',
-        ],
+      name: 'kovan.dnp.dappnode.eth',
+      image: {
+        ports: ['30303', '30303/udp', '30304:30304'],
+        volumes: ['different_path:/root/.local/share/io.parity.ethereum/'],
+      },
+    });
+  });
+
+  it('should merge the userSetPorts object', () => {
+    const userSetPorts = {
+      [manifest.name]: {
+        '30303': '31313:30303',
+        '30303/udp': '31313:30303/udp',
+        '30304:30304': '30304',
+      },
+    };
+    const editedManifest = merge.manifest.ports(manifest, userSetPorts);
+    expect(editedManifest).to.deep.equal({
+      name: 'kovan.dnp.dappnode.eth',
+      image: {
+        ports: ['31313:30303', '31313:30303/udp', '30304'],
+        volumes: ['kovan:/root/.local/share/io.parity.ethereum/'],
       },
     });
   });

--- a/build/src/test/utils/parse.test.js
+++ b/build/src/test/utils/parse.test.js
@@ -7,9 +7,9 @@ chai.should();
 
 const testDirectory = './test_files/';
 
-const DOCKERCOMPOSE_PATH = testDirectory+'docker-compose-test.yml';
-const DOCKERCOMPOSE_PATH2 = testDirectory+'docker-compose-test2.yml';
-const dockerComposeData = (`
+const DOCKERCOMPOSE_PATH = testDirectory + 'docker-compose-test.yml';
+const DOCKERCOMPOSE_PATH2 = testDirectory + 'docker-compose-test2.yml';
+const dockerComposeData = `
 version: '3.4'
 services:
     ipfs.dnp.dappnode.eth:
@@ -36,10 +36,10 @@ networks:
             config:
                 -
                     subnet: 172.33.0.0/16
-`).trim();
+`.trim();
 
 // This one has no ports and no volumes
-const dockerComposeData2 = (`
+const dockerComposeData2 = `
 version: '3.4'
 services:
     ipfs.dnp.dappnode.eth:
@@ -58,8 +58,7 @@ networks:
             config:
                 -
                     subnet: 172.33.0.0/16
-`).trim();
-
+`.trim();
 
 describe('Util: parse', function() {
   describe('docker-compose parsing utils', function() {
@@ -72,32 +71,27 @@ describe('Util: parse', function() {
 
     it('should parse ports', () => {
       const ports = parse.dockerComposePorts(DOCKERCOMPOSE_PATH);
-      ports
-        .should.deep.equal(['4001', '4002']);
+      ports.should.deep.equal(['4001', '4002']);
     });
 
     it('should parse ports when there are non', () => {
       const ports = parse.dockerComposePorts(DOCKERCOMPOSE_PATH2);
-      ports
-        .should.deep.equal([]);
+      ports.should.deep.equal([]);
     });
 
     it('should parse container_name', () => {
       const ports = parse.containerName(DOCKERCOMPOSE_PATH);
-      ports
-        .should.deep.equal('DAppNodeCore-ipfs.dnp.dappnode.eth');
+      ports.should.deep.equal('DAppNodeCore-ipfs.dnp.dappnode.eth');
     });
 
     it('should parse the service volumes', () => {
       const ports = parse.serviceVolumes(DOCKERCOMPOSE_PATH);
-      ports
-        .should.deep.equal(['export', 'data']);
+      ports.should.deep.equal(['export', 'data']);
     });
 
     it('should parse the service volumes when there are non', () => {
       const ports = parse.serviceVolumes(DOCKERCOMPOSE_PATH2);
-      ports
-        .should.deep.equal([]);
+      ports.should.deep.equal([]);
     });
   });
 
@@ -106,36 +100,55 @@ describe('Util: parse', function() {
       VAR1: 'VALUE1',
       VAR2: 'VALUE2',
     };
-    const envString = 'VAR1=VALUE1\nVAR2=VALUE2';
+    const envString = `
+VAR1=VALUE1\nVAR2=VALUE2
+`.trim();
 
     it('should stringify an envs object', () => {
-      parse.stringifyEnvs(envs)
-        .should.equal(envString);
+      parse.stringifyEnvs(envs).should.equal(envString);
     });
 
     it('should parse an env string', () => {
-      parse.envFile(envString)
-        .should.deep.equal(envs);
+      parse.envFile(envString).should.deep.equal(envs);
+    });
+  });
+
+  describe('parse and stringify empty envs', function() {
+    const envs = {
+      VIRTUAL_HOST: '',
+      LETSENCRYPT_HOST: '',
+      time: '1549562581242',
+    };
+    const envString = `
+VIRTUAL_HOST=
+LETSENCRYPT_HOST=
+time=1549562581242
+`.trim();
+
+    it('should stringify an envs object', () => {
+      parse.stringifyEnvs(envs).should.equal(envString);
+    });
+
+    it('should parse an env string', () => {
+      parse.envFile(envString).should.deep.equal(envs);
     });
   });
 
   describe('parse Package request', function() {
     it('should parse a package request', () => {
-      parse.packageReq('package_name@version')
-        .should.deep.equal({
-          name: 'package_name',
-          ver: 'version',
-          req: 'package_name@version',
-        });
+      parse.packageReq('package_name@version').should.deep.equal({
+        name: 'package_name',
+        ver: 'version',
+        req: 'package_name@version',
+      });
     });
 
     it('should add latest to verionless requests', () => {
-      parse.packageReq('package_name')
-        .should.deep.equal({
-          name: 'package_name',
-          ver: '*',
-          req: 'package_name',
-        });
+      parse.packageReq('package_name').should.deep.equal({
+        name: 'package_name',
+        ver: '*',
+        req: 'package_name',
+      });
     });
   });
 });

--- a/build/src/test/utils/parseManifestPorts.test.js
+++ b/build/src/test/utils/parseManifestPorts.test.js
@@ -1,0 +1,14 @@
+const expect = require('chai').expect;
+const parseManifestPorts = require('utils/parseManifestPorts');
+
+describe('Util: parseManifestPorts', function() {
+  it('should parse manifest ports', () => {
+    const manifest = {
+      image: {
+        ports: ['30303:30303/udp', '30304:30303', '8080'],
+      },
+    };
+    const ports = parseManifestPorts(manifest);
+    expect(ports).to.deep.equal([{number: '30303', type: 'UDP'}, {number: '30304', type: 'TCP'}]);
+  });
+});

--- a/build/src/test/utils/shell.test.js
+++ b/build/src/test/utils/shell.test.js
@@ -1,18 +1,17 @@
 const expect = require('chai').expect;
 
-const shellExecSync = require('utils/shell');
+const shell = require('utils/shell');
 
-describe('Util: shell', function() {
+describe('Util: shell', () => {
   it('should return an error when cating a non-existing file', async () => {
-    let res = await shellExecSync('cat package.json', true);
-    expect(res)
-      .to.include('"dependencies": {');
+    let res = await shell('cat package.json');
+    expect(res).to.include('"dependencies": {');
   });
 
   it('should return the content of a file when cating', async () => {
-    let error = '--- shellExecSync did not throw ---';
+    let error = '--- shell did not throw ---';
     try {
-      await shellExecSync('cat jfnakjsdfnodfu9sadf', true);
+      await shell('cat jfnakjsdfnodfu9sadf');
     } catch (e) {
       error = e.message;
     }


### PR DESCRIPTION
The UI will no longer instruct the DAPPMANAGER to set ENVs and open ports on installation. Instead, it will forward three objects that contain the user set parameters.

```js
  userSetEnvs = {
    "kovan.dnp.dappnode.eth": {
      "ENV_NAME": "VALUE1"
    }, ... }
  userSetVols: user set volumes {Object} = {
    "kovan.dnp.dappnode.eth": {
      "kovan:/root/.local/share/io.parity.ethereum/": "different_name"
    }, ... }
  userSetPorts: user set ports {Object} = {
    "kovan.dnp.dappnode.eth": {
      "30303": "31313:30303",
      "30303/udp": "31313:30303/udp"
    }, ... }
```

Then, the DAPPMANAGER will set ENVs and open ports when necessary. This is a necessary step as the logic regarding this operations is getting complex and it is safer to be carried on in a NodeJS environment with highly tested code than in a browser.

Linked to https://github.com/dappnode/DNP_ADMIN/pull/198