### PR TITLE
Make sure key arguments are defined

### DIFF
--- a/build/src/src/calls/changeIpfsTimeout.js
+++ b/build/src/src/calls/changeIpfsTimeout.js
@@ -6,15 +6,15 @@ const params = require('../params');
  * @return {Object}
  */
 const getStats = async ({timeout}) => {
-    params.IPFS_TIMEOUT = timeout;
+  if (!timeout) throw Error('kwarg timeout must be defined');
 
-    return {
-        message: `IPFS timeout set to ${timeout}`,
-        logMessage: true,
-        userAction: true,
-    };
+  params.IPFS_TIMEOUT = timeout;
+
+  return {
+    message: `IPFS timeout set to ${timeout}`,
+    logMessage: true,
+    userAction: true,
+  };
 };
 
-
 module.exports = getStats;
-

--- a/build/src/src/calls/diskSpaceAvailable.js
+++ b/build/src/src/calls/diskSpaceAvailable.js
@@ -14,28 +14,29 @@ const fs = require('fs');
  *   }
  */
 const diskSpaceAvailable = async ({path}) => {
-    if (!fs.existsSync(path)) {
-        return {
-            exists: false,
-            totalSize: 0,
-            availableSize: 0,
-        };
-    }
-    const res = await shellExec(`df -h ${path} | awk 'NR>1 { print $2,$4}'`, true);
-    const [totalSize, availableSize] = res.split(/\s+/);
-    //  df . -h --output='avail'
-    //  Used Avail
-    //  192G  9.9G
+  if (!path) throw Error('kwarg path must be defined');
 
+  if (!fs.existsSync(path)) {
     return {
-        message: `Checked space of ${path}`,
-        result: {
-            exists: true,
-            totalSize,
-            availableSize,
-        },
+      exists: false,
+      totalSize: 0,
+      availableSize: 0,
     };
-};
+  }
+  const res = await shellExec(`df -h ${path} | awk 'NR>1 { print $2,$4}'`, true);
+  const [totalSize, availableSize] = res.split(/\s+/);
+  //  df . -h --output='avail'
+  //  Used Avail
+  //  192G  9.9G
 
+  return {
+    message: `Checked space of ${path}`,
+    result: {
+      exists: true,
+      totalSize,
+      availableSize,
+    },
+  };
+};
 
 module.exports = diskSpaceAvailable;

--- a/build/src/src/calls/fetchPackageData.js
+++ b/build/src/src/calls/fetchPackageData.js
@@ -19,9 +19,9 @@ const getAvatar = require('modules/getAvatar');
  *     manifest, (object)
  *   },
  */
-const fetchPackageData = async ({
-  id,
-}) => {
+const fetchPackageData = async ({id}) => {
+  if (!id) throw Error('kwarg id must be defined');
+
   const packageReq = parse.packageReq(id);
 
   // Make sure the chain is synced
@@ -32,7 +32,6 @@ const fetchPackageData = async ({
   //     logMessage: true,
   //   };
   // }
-
 
   const manifest = await getManifest(packageReq);
 
@@ -47,18 +46,17 @@ const fetchPackageData = async ({
       avatar = await getAvatar(avatarHash);
     } catch (e) {
       // If the avatar can not be fetched don't crash
-      logs.error('Could not fetch avatar of '+packageReq.name+' at '+avatarHash);
+      logs.error('Could not fetch avatar of ' + packageReq.name + ' at ' + avatarHash);
     }
   }
 
   return {
-    message: 'Got data of '+packageReq.name,
+    message: 'Got data of ' + packageReq.name,
     result: {
       manifest,
       avatar,
     },
   };
 };
-
 
 module.exports = fetchPackageData;

--- a/build/src/src/calls/fetchPackageVersions.js
+++ b/build/src/src/calls/fetchPackageVersions.js
@@ -20,12 +20,12 @@ const isIpfsRequest = require('utils/isIpfsRequest');
  *     ...
  *   ]
  */
-const fetchPackageVersions = async ({
-  id,
-}) => {
+const fetchPackageVersions = async ({id}) => {
+  if (!id) throw Error('kwarg id must be defined');
+
   const packageReq = parse.packageReq(id);
 
-  if (!isIpfsRequest(packageReq) && await isSyncing()) {
+  if (!isIpfsRequest(packageReq) && (await isSyncing())) {
     return {
       message: `Mainnet is still syncing`,
       result: [],
@@ -43,7 +43,7 @@ const fetchPackageVersions = async ({
       result: packageVersions,
     };
 
-  // if the name of the package is already an IFPS hash, skip:
+    // if the name of the package is already an IFPS hash, skip:
   } else if (packageReq.name.startsWith('/ipfs/Qm')) {
     const manifest = await getManifest(packageReq);
     return {
@@ -56,14 +56,14 @@ const fetchPackageVersions = async ({
       ],
     };
   } else {
-    throw Error('Unkown package request: '+packageReq.name);
+    throw Error('Unkown package request: ' + packageReq.name);
   }
 };
 
 // Utility methods
 const getManifestOfVersions = async (packageReq, versions) => {
   await Promise.all(
-    versions.map( async (version) => {
+    versions.map(async (version) => {
       try {
         version.manifest = await getManifest({
           name: packageReq.name,
@@ -79,8 +79,7 @@ const getManifestOfVersions = async (packageReq, versions) => {
 // Reverse to have newer versions on top
 const getPackageVersions = async (packageReq) => {
   const versionsObj = await apm.getRepoVersions(packageReq);
-  return Object.keys(versionsObj)
-  .map((version) => ({
+  return Object.keys(versionsObj).map((version) => ({
     version,
     manifestHash: versionsObj[version],
   }));
@@ -95,4 +94,3 @@ if (process.env.TEST) {
 } else {
   module.exports = fetchPackageVersions;
 }
-

--- a/build/src/src/calls/getUserActionLogs.js
+++ b/build/src/src/calls/getUserActionLogs.js
@@ -2,7 +2,6 @@ const fs = require('fs');
 const {promisify} = require('util');
 const params = require('params');
 
-
 /**
  * Returns the user action logs. This logs are stored in a different
  * file and format, and are meant to ease user support
@@ -14,24 +13,17 @@ const params = require('params');
  * result: = logs (string)
  */
 
-const getUserActionLogs = async ({
-  options,
-  fromLog = 0,
-  numLogs = 50,
-}) => {
+const getUserActionLogs = async ({options, fromLog = 0, numLogs = 50}) => {
   const {userActionLogsFilename} = params;
 
   if (!fs.existsSync(userActionLogsFilename)) {
     return {
-        message: 'UserActionLogs are still empty, returning black',
-        result: '',
+      message: 'UserActionLogs are still empty, returning black',
+      result: '',
     };
   }
 
-  const userActionLogs = await promisify(fs.readFile)(
-      userActionLogsFilename,
-      {encoding: 'utf8'}
-  );
+  const userActionLogs = await promisify(fs.readFile)(userActionLogsFilename, {encoding: 'utf8'});
 
   // The userActionLogs file can grow a lot. Only a part of it will be returned
   // The user can specify which part of the file wants
@@ -45,6 +37,5 @@ const getUserActionLogs = async ({
     result: userActionLogsSelected,
   };
 };
-
 
 module.exports = getUserActionLogs;

--- a/build/src/src/calls/installPackage.js
+++ b/build/src/src/calls/installPackage.js
@@ -56,6 +56,8 @@ const parseManifestPorts = require('utils/parseManifestPorts');
  * result: empty
  */
 const installPackage = async ({id, userSetEnvs = {}, userSetVols = {}, userSetPorts = {}, logId, options = {}}) => {
+  if (!id) throw Error('kwarg id must be defined');
+
   // 1. Parse the id into a request
   // id = 'otpweb.dnp.dappnode.eth@0.1.4'
   // req = { name: 'otpweb.dnp.dappnode.eth', ver: '0.1.4' }

--- a/build/src/src/calls/installPackageSafe.js
+++ b/build/src/src/calls/installPackageSafe.js
@@ -1,6 +1,5 @@
 const installPackage = require('./installPackage');
 
-
 /**
  * Installs a package in safe mode, by setting options.BYPASS_RESOLVER = true
  *
@@ -11,15 +10,11 @@ const installPackage = require('./installPackage');
  * @return {Object} A formated success message.
  * result: empty
  */
-const installPackageSafe = async ({
-  id,
-  vols = {},
-  logId,
-  options = {},
-}) => {
+const installPackageSafe = async ({id, vols = {}, logId, options = {}}) => {
+  if (!id) throw Error('kwarg id must be defined');
+
   options.BYPASS_RESOLVER = true;
   return await installPackage({id, vols, logId, options});
 };
-
 
 module.exports = installPackageSafe;

--- a/build/src/src/calls/logPackage.js
+++ b/build/src/src/calls/logPackage.js
@@ -4,7 +4,6 @@ const parse = require('utils/parse');
 const params = require('params');
 const docker = require('modules/docker');
 
-
 /**
  * Returns the logs of the docker container of a package
  *
@@ -19,13 +18,9 @@ const docker = require('modules/docker');
  *     logs: <String with escape codes> (string)
  *   },
  */
-const logPackage = async ({
-  id,
-  options,
-}) => {
-  if (!id) {
-    throw Error('A valid DNP id must be passed as a kwargs to logPackage: ');
-  }
+const logPackage = async ({id, options}) => {
+  if (!id) throw Error('kwarg id must be defined');
+
   const dockerComposePath = getPath.dockerComposeSmart(id, params);
   if (!fs.existsSync(dockerComposePath)) {
     throw Error('No docker-compose found: ' + dockerComposePath);
@@ -42,6 +37,5 @@ const logPackage = async ({
     },
   };
 };
-
 
 module.exports = logPackage;

--- a/build/src/src/calls/managePorts.js
+++ b/build/src/src/calls/managePorts.js
@@ -1,6 +1,5 @@
 const docker = require('modules/docker');
 
-
 /**
  * Open or closes requested ports
  *
@@ -13,36 +12,32 @@ const docker = require('modules/docker');
  * @return {Object} A formated success message.
  * result: empty
  */
-const managePorts = async ({
-    action,
-    ports,
-}) => {
-    if (!Array.isArray(ports)) {
-        throw Error('ports variable must be an array: '+JSON.stringify(ports));
-    }
+const managePorts = async ({action, ports}) => {
+  if (!Array.isArray(ports)) {
+    throw Error('kwarg ports must be an array: ' + JSON.stringify(ports));
+  }
 
-    let msg;
-    for (const port of ports) {
-        switch (action) {
-            case 'open':
-                await docker.openPort(port);
-                msg = 'Opened';
-                break;
-            case 'close':
-                await docker.closePort(port);
-                msg = 'Closed';
-                break;
-            default:
-                throw Error('Unkown manage ports action: '+action);
-        }
+  let msg;
+  for (const port of ports) {
+    switch (action) {
+      case 'open':
+        await docker.openPort(port);
+        msg = 'Opened';
+        break;
+      case 'close':
+        await docker.closePort(port);
+        msg = 'Closed';
+        break;
+      default:
+        throw Error('Unkown manage ports action: ' + action);
     }
+  }
 
-    return {
-        message: `${msg} ports ${ports.map((p) => `${p.number} ${p.type}`).join(', ')}`,
-        logMessage: true,
-        userAction: true,
-    };
+  return {
+    message: `${msg} ports ${ports.map((p) => `${p.number} ${p.type}`).join(', ')}`,
+    logMessage: true,
+    userAction: true,
+  };
 };
-
 
 module.exports = managePorts;

--- a/build/src/src/calls/notificationsRemove.js
+++ b/build/src/src/calls/notificationsRemove.js
@@ -12,17 +12,16 @@ const db = require('../db');
  * @return {Object} A formated success message.
  */
 
-const notificationsGet = async ({
-    ids = [],
-}) => {
-    for (const id of ids) {
-        await db.remove(`notification.${id}`);
-    }
+const notificationsGet = async ({ids = []}) => {
+  if (!ids) throw Error('kwarg ids must be defined');
 
-    return {
-        message: `Removed notifications: ${ids.join(', ')}`,
-    };
+  for (const id of ids) {
+    await db.remove(`notification.${id}`);
+  }
+
+  return {
+    message: `Removed notifications: ${ids.join(', ')}`,
+  };
 };
-
 
 module.exports = notificationsGet;

--- a/build/src/src/calls/removePackage.js
+++ b/build/src/src/calls/removePackage.js
@@ -24,6 +24,8 @@ const logUI = require('utils/logUI');
  * result: empty
  */
 const removePackage = async ({id, deleteVolumes = false, logId}) => {
+  if (!id) throw Error('kwarg id must be defined');
+
   const packageRepoDir = getPath.packageRepoDir(id, params);
 
   const dockerComposePath = getPath.dockerComposeSmart(id, params);

--- a/build/src/src/calls/resolveRequest.js
+++ b/build/src/src/calls/resolveRequest.js
@@ -14,6 +14,8 @@ const dappGetBasic = require('modules/dappGet/basic');
  * result: empty
  */
 const removePackage = async ({req, options = {}}) => {
+  if (!req) throw Error('kwarg req must be defined');
+
   // result = {
   //     success: {'bind.dnp.dappnode.eth': '0.1.4'}
   //     alreadyUpdated: {'bind.dnp.dappnode.eth': '0.1.2'}

--- a/build/src/src/calls/restartPackage.js
+++ b/build/src/src/calls/restartPackage.js
@@ -5,7 +5,6 @@ const params = require('params');
 const docker = require('modules/docker');
 const {eventBus, eventBusTag} = require('eventBus');
 
-
 /**
  * Calls docker rm and docker up on a package
  *
@@ -15,9 +14,9 @@ const {eventBus, eventBusTag} = require('eventBus');
  * @return {Object} A formated success message.
  * result: empty
  */
-const restartPackage = async ({
-  id,
-}) => {
+const restartPackage = async ({id}) => {
+  if (!id) throw Error('kwarg id must be defined');
+
   const dockerComposePath = getPath.dockerComposeSmart(id, params);
   if (!fs.existsSync(dockerComposePath)) {
     throw Error('No docker-compose found: ' + dockerComposePath);
@@ -40,6 +39,5 @@ const restartPackage = async ({
     userAction: true,
   };
 };
-
 
 module.exports = restartPackage;

--- a/build/src/src/calls/restartPackageVolumes.js
+++ b/build/src/src/calls/restartPackageVolumes.js
@@ -5,7 +5,6 @@ const docker = require('modules/docker');
 const dockerList = require('modules/dockerList');
 const {eventBus, eventBusTag} = require('eventBus');
 
-
 /**
  * Removes a package volumes. The re-ups the package
  *
@@ -15,9 +14,9 @@ const {eventBus, eventBusTag} = require('eventBus');
  * @return {Object} A formated success message.
  * result: empty
  */
-async function restartPackageVolumes({
-  id,
-}) {
+async function restartPackageVolumes({id}) {
+  if (!id) throw Error('kwarg id must be defined');
+
   const dnpList = await dockerList.listContainers();
   const dnp = dnpList.find((_dnp) => _dnp.name && _dnp.name.includes(id));
   if (!dnp) {
@@ -34,7 +33,7 @@ async function restartPackageVolumes({
   // If there are no volumes don't do anything
   if (!dnp.volumes || !dnp.volumes.length) {
     return {
-      message: id+' has no volumes ',
+      message: id + ' has no volumes ',
     };
   }
 
@@ -52,11 +51,10 @@ async function restartPackageVolumes({
   eventBus.emit(eventBusTag.emitPackages);
 
   return {
-    message: 'Restarted '+id+' volumes',
+    message: 'Restarted ' + id + ' volumes',
     logMessage: true,
     userAction: true,
   };
 }
-
 
 module.exports = restartPackageVolumes;

--- a/build/src/src/calls/togglePackage.js
+++ b/build/src/src/calls/togglePackage.js
@@ -4,7 +4,6 @@ const params = require('params');
 const docker = require('modules/docker');
 const {eventBus, eventBusTag} = require('eventBus');
 
-
 /**
  * Stops or starts after fetching its status
  *
@@ -15,10 +14,9 @@ const {eventBus, eventBusTag} = require('eventBus');
  * @return {Object} A formated success message.
  * result: empty
  */
-const togglePackage = async ({
-  id,
-  timeout = 10,
-}) => {
+const togglePackage = async ({id, timeout = 10}) => {
+  if (!id) throw Error('kwarg id must be defined');
+
   const dockerComposePath = getPath.dockerComposeSmart(id, params);
   // This parse utility already throws if no docker-compose found
   let containerName = parse.containerName(dockerComposePath);
@@ -46,6 +44,5 @@ const togglePackage = async ({
     userAction: true,
   };
 };
-
 
 module.exports = togglePackage;

--- a/build/src/src/calls/updatePackageEnv.js
+++ b/build/src/src/calls/updatePackageEnv.js
@@ -22,6 +22,9 @@ const envsHelper = require('utils/envsHelper');
  * result: empty
  */
 const updatePackageEnv = async ({id, envs, isCORE, isCore, restart}) => {
+  if (!id) throw Error('kwarg id must be defined');
+  if (!envs) throw Error('kwarg envs must be defined');
+
   id = parse.packageReq(id).name; // parsing anyway for safety
   if (id.startsWith('/ipfs/')) {
     try {

--- a/build/src/src/modules/dockerList.js
+++ b/build/src/src/modules/dockerList.js
@@ -7,8 +7,8 @@ const request = docker();
 // dedicated modules
 const params = require('../params');
 
-const DNP_CONTAINER_NAME_PREFIX = params.DNP_CONTAINER_NAME_PREFIX;
-const CORE_CONTAINER_NAME_PREFIX = params.CORE_CONTAINER_NAME_PREFIX;
+const CONTAINER_NAME_PREFIX = params.CONTAINER_NAME_PREFIX;
+const CONTAINER_CORE_NAME_PREFIX = params.CONTAINER_CORE_NAME_PREFIX;
 
 // ////////////////////////////
 // Main functions
@@ -17,9 +17,7 @@ const CORE_CONTAINER_NAME_PREFIX = params.CORE_CONTAINER_NAME_PREFIX;
 
 async function listContainers() {
   const containers = await dockerRequest('get', '/containers/json?all=true');
-  return containers
-    .map(format)
-    .filter((pkg) => pkg.isDNP || pkg.isCORE);
+  return containers.map(format).filter((pkg) => pkg.isDNP || pkg.isCORE);
 }
 
 async function runningPackagesInfo() {
@@ -31,10 +29,8 @@ async function runningPackagesInfo() {
   return containersObject;
 }
 
-
 // /////////////////
 // Helper functions
-
 
 function dockerRequest(method, url) {
   const options = {json: true};
@@ -44,19 +40,17 @@ function dockerRequest(method, url) {
   return dockerRequestPromise(url, options);
 }
 
-
 // /////////
 // utils
 
-
 function format(c) {
   const packageName = c.Names[0].replace('/', '');
-  const isDNP = packageName.includes(DNP_CONTAINER_NAME_PREFIX);
-  const isCORE = packageName.includes(CORE_CONTAINER_NAME_PREFIX);
+  const isDNP = packageName.includes(CONTAINER_NAME_PREFIX);
+  const isCORE = packageName.includes(CONTAINER_CORE_NAME_PREFIX);
 
   let name;
-  if (isDNP) name = packageName.split(DNP_CONTAINER_NAME_PREFIX)[1];
-  else if (isCORE) name = packageName.split(CORE_CONTAINER_NAME_PREFIX)[1];
+  if (isDNP) name = packageName.split(CONTAINER_NAME_PREFIX)[1];
+  else if (isCORE) name = packageName.split(CONTAINER_CORE_NAME_PREFIX)[1];
   else name = packageName;
 
   const shortName = name && name.includes('.') ? name.split('.')[0] : name;
@@ -100,7 +94,7 @@ function format(c) {
     portsToClose,
     isDNP,
     isCORE,
-    created: new Date(1000*c.Created),
+    created: new Date(1000 * c.Created),
     image: c.Image,
     name: name,
     shortName: shortName,

--- a/build/src/src/params.js
+++ b/build/src/src/params.js
@@ -3,7 +3,6 @@
  */
 
 module.exports = {
-
   // Autobahn parameters
   autobahnUrl: 'ws://my.wamp.dnp.dappnode.eth:8080/ws',
   autobahnRealm: 'dappnode_admin',
@@ -12,27 +11,16 @@ module.exports = {
   CACHE_DIR: './cache/',
   REPO_DIR: './dnp_repo/',
   DNCORE_DIR: 'DNCORE',
-  DAPPNODE_PACKAGE_NAME: 'dappnode_package.json',
-  DOCKERCOMPOSE_NAME: 'docker-compose.yml',
-  ENV_FILE_EXTENSION: '.env',
-  // dappGet file paths
-  REPO_FILE: 'DNCORE/repo.json',
-
-  // Docker parameters
-  TMP_REPO_DIR: './tmp_dnp_repo/',
-  DNP_CONTAINER_NAME_PREFIX: 'DAppNodePackage-',
-  CORE_CONTAINER_NAME_PREFIX: 'DAppNodeCore-',
 
   // Docker compose parameters
-  DNP_VERSION_TAG: 'dnp_version',
   DNS_SERVICE: '172.33.1.2',
   DNP_NETWORK: 'dncore_network',
   CONTAINER_NAME_PREFIX: 'DAppNodePackage-',
   CONTAINER_CORE_NAME_PREFIX: 'DAppNodeCore-',
 
   // IPFS parameters
-  IPFS: (process.env.IPFS_REDIRECT || 'my.ipfs.dnp.dappnode.eth'),
-  IPFS_TIMEOUT: 30*1000,
+  IPFS: process.env.IPFS_REDIRECT || 'my.ipfs.dnp.dappnode.eth',
+  IPFS_TIMEOUT: 30 * 1000,
 
   // Web3 parameters
   WEB3HOSTWS: 'ws://my.ethchain.dnp.dappnode.eth:8546',
@@ -41,7 +29,4 @@ module.exports = {
 
   // User Action Logs filename
   userActionLogsFilename: 'DNCORE/userActionLogs.log',
-
-  // IPFS
-
 };

--- a/build/src/src/utils/getPath.js
+++ b/build/src/src/utils/getPath.js
@@ -13,91 +13,96 @@ const fs = require('fs');
  * - image
  *
  * Core DNPs and regular DNPs are located in different folders.
- * That's why there is an IS_CORE flag. Also the "Smart" functions
+ * That's why there is an isCore flag. Also the "Smart" functions
  * try to guess if the requested package is a core or not.
 */
 
 // Define paths
 module.exports = {
-
-  packageRepoDir: function(PACKAGE_NAME, params, IS_CORE) {
-    if (!PACKAGE_NAME) throw Error('Package name must be defined');
-    if (!params) throw Error('Package name must be defined');
-    return repoDir(PACKAGE_NAME, params, IS_CORE);
+  packageRepoDir: (dnpName, params, isCore) => {
+    if (!dnpName) throw Error('dnpName must be defined');
+    if (!params) throw Error('params must be defined');
+    return getRepoDirPath(dnpName, params, isCore);
   },
 
-  manifest: function(PACKAGE_NAME, params, IS_CORE) {
-    if (!PACKAGE_NAME) throw Error('Package name must be defined');
-    if (!params) throw Error('Package name must be defined');
-    return repoDir(PACKAGE_NAME, params, IS_CORE) + '/'
-    + manifestName(PACKAGE_NAME, params, IS_CORE);
+  manifest: (dnpName, params, isCore) => {
+    if (!dnpName) throw Error('dnpName must be defined');
+    if (!params) throw Error('params must be defined');
+    return getRepoDirPath(dnpName, params, isCore) + '/' + getManifestName(dnpName, isCore);
   },
 
-  dockerCompose: dockerCompose,
+  dockerCompose: (dnpName, params, isCore) => {
+    if (!dnpName) throw Error('dnpName must be defined');
+    if (!params) throw Error('params must be defined');
+    return getDockerComposePath(dnpName, params, isCore);
+  },
 
-  dockerComposeSmart: function(PACKAGE_NAME, params) {
-    if (!PACKAGE_NAME) throw Error('Package name must be defined');
-    if (!params) throw Error('Package name must be defined');
+  dockerComposeSmart: (dnpName, params) => {
+    if (!dnpName) throw Error('dnpName must be defined');
+    if (!params) throw Error('params must be defined');
     // First check for core docker-compose
-    let DOCKERCOMPOSE_PATH = dockerCompose(PACKAGE_NAME, params, true);
+    let DOCKERCOMPOSE_PATH = getDockerComposePath(dnpName, params, true);
     if (fs.existsSync(DOCKERCOMPOSE_PATH)) return DOCKERCOMPOSE_PATH;
     // Then check for dnp docker-compose
-    return dockerCompose(PACKAGE_NAME, params, false);
+    return getDockerComposePath(dnpName, params, false);
   },
 
-  envFile: envFile,
+  envFile: (dnpName, params, isCore) => {
+    if (!dnpName) throw Error('dnpName must be defined');
+    if (!params) throw Error('params must be defined');
+    return getEnvFilePath(dnpName, params, isCore);
+  },
 
-  envFileSmart: function(PACKAGE_NAME, params, isCORE) {
-    if (!PACKAGE_NAME) throw Error('Package name must be defined');
-    if (!params) throw Error('Package name must be defined');
-    if (isCORE) return envFile(PACKAGE_NAME, params, true);
+  envFileSmart: (dnpName, params, isCORE) => {
+    if (!dnpName) throw Error('dnpName must be defined');
+    if (!params) throw Error('params must be defined');
+    if (isCORE) return getEnvFilePath(dnpName, params, true);
     // First check for core docker-compose
-    let ENV_FILE_PATH = envFile(PACKAGE_NAME, params, true);
+    let ENV_FILE_PATH = getEnvFilePath(dnpName, params, true);
     if (fs.existsSync(ENV_FILE_PATH)) return ENV_FILE_PATH;
     // Then check for dnp docker-compose
-    return envFile(PACKAGE_NAME, params, false);
+    return getEnvFilePath(dnpName, params, false);
   },
 
-  image: function(PACKAGE_NAME, IMAGE_NAME, params, IS_CORE) {
-    return repoDir(PACKAGE_NAME, params, IS_CORE) + '/' + IMAGE_NAME;
+  image: (dnpName, imageName, params, isCore) => {
+    if (!dnpName) throw Error('dnpName must be defined');
+    if (!imageName) throw Error('imageName must be defined');
+    if (!params) throw Error('params must be defined');
+    return getRepoDirPath(dnpName, params, isCore) + '/' + imageName;
   },
 };
 
-
 // Helper functions
 
-function dockerCompose(PACKAGE_NAME, params, IS_CORE) {
-  return repoDir(PACKAGE_NAME, params, IS_CORE) + '/'
-  + dockerComposeName(PACKAGE_NAME, params, IS_CORE);
+function getDockerComposePath(dnpName, params, isCore) {
+  return getRepoDirPath(dnpName, params, isCore) + '/' + getDockerComposeName(dnpName, isCore);
 }
 
-function envFile(PACKAGE_NAME, params, IS_CORE) {
-  return repoDir(PACKAGE_NAME, params, IS_CORE) + '/' + PACKAGE_NAME + params.ENV_FILE_EXTENSION;
+function getEnvFilePath(dnpName, params, isCore) {
+  return getRepoDirPath(dnpName, params, isCore) + '/' + dnpName + '.env';
 }
 
-function repoDir(PACKAGE_NAME, params, IS_CORE) {
-  if (IS_CORE) return params.DNCORE_DIR;
-  return params.REPO_DIR + PACKAGE_NAME;
+function getRepoDirPath(dnpName, params, isCore) {
+  if (!params.DNCORE_DIR) throw Error('params.DNCORE_DIR must be defined');
+  if (!params.REPO_DIR) throw Error('params.REPO_DIR must be defined');
+  if (isCore) return params.DNCORE_DIR;
+  return params.REPO_DIR + dnpName;
 }
 
-
-function dockerComposeName(PACKAGE_NAME, params, IS_CORE) {
-  if (!IS_CORE) return params.DOCKERCOMPOSE_NAME;
-
-  const FILE_PREFIX = params.DOCKERCOMPOSE_NAME.split('.')[0];
-  const EXTENSION = params.DOCKERCOMPOSE_NAME.split('.')[1];
-  const PACKAGE_SHORT_NAME = PACKAGE_NAME.split('.')[0];
-
-  return FILE_PREFIX + '-' + PACKAGE_SHORT_NAME + '.' + EXTENSION;
+function getDockerComposeName(dnpName, isCore) {
+  if (isCore) {
+    const dnpShortName = dnpName.split('.')[0];
+    return `docker-compose-${dnpShortName}.yml`;
+  } else {
+    return 'docker-compose.yml';
+  }
 }
 
-
-function manifestName(PACKAGE_NAME, params, IS_CORE) {
-  if (!IS_CORE) return params.DAPPNODE_PACKAGE_NAME;
-
-  const FILE_PREFIX = params.DAPPNODE_PACKAGE_NAME.split('.')[0];
-  const EXTENSION = params.DAPPNODE_PACKAGE_NAME.split('.')[1];
-  const PACKAGE_SHORT_NAME = PACKAGE_NAME.split('.')[0];
-
-  return FILE_PREFIX + '-' + PACKAGE_SHORT_NAME + '.' + EXTENSION;
+function getManifestName(dnpName, isCore) {
+  if (isCore) {
+    const dnpShortName = dnpName.split('.')[0];
+    return `dappnode_package-${dnpShortName}.json`;
+  } else {
+    return 'dappnode_package.json';
+  }
 }

--- a/build/src/test/calls/installPackage.test.js
+++ b/build/src/test/calls/installPackage.test.js
@@ -5,8 +5,8 @@ const {eventBusTag} = require('eventBus');
 
 describe('Call function: installPackage', function() {
   const params = {
+    DNCORE_DIR: 'DNCORE',
     REPO_DIR: 'test_files/',
-    DOCKERCOMPOSE_NAME: 'docker-compose.yml',
   };
 
   const pkgName = 'dapp.dnp.dappnode.eth';

--- a/build/src/test/calls/listPackages.test.js
+++ b/build/src/test/calls/listPackages.test.js
@@ -12,7 +12,6 @@ describe('Call function: listPackages', function() {
   mockTest();
 });
 
-
 function mockTest() {
   let hasListed = false;
   let envs = {VAR1: 'VALUE1'};
@@ -34,9 +33,8 @@ function mockTest() {
 
   // Mock params
   const params = {
+    DNCORE_DIR: 'DNCORE',
     REPO_DIR: 'test_files/',
-    DOCKERCOMPOSE_NAME: 'docker-compose.yml',
-    ENV_FILE_EXTENSION: '.env',
   };
 
   // initialize call
@@ -68,7 +66,6 @@ function mockTest() {
     });
   });
 }
-
 
 function getParentDir(fullPath) {
   return fullPath.replace(/\/[^/]+$/, '');

--- a/build/src/test/calls/logPackage.test.js
+++ b/build/src/test/calls/logPackage.test.js
@@ -11,19 +11,19 @@ describe('Call function: logPackage', function() {
   mockTest();
 });
 
-const dockerComposeTemplate = (`
+const dockerComposeTemplate = `
 version: '3.4'
 services:
     otpweb.dnp.dappnode.eth:
         image: 'chentex/random-logger:latest'
         container_name: DNP_DAPPMANAGER_TEST_CONTAINER
-`).trim();
+`.trim();
 
 function mockTest() {
   describe('mock test', function() {
     const params = {
+      DNCORE_DIR: 'DNCORE',
       REPO_DIR: 'test_files/',
-      DOCKERCOMPOSE_NAME: 'docker-compose.yml',
     };
 
     let hasLogged = false;

--- a/build/src/test/calls/managePorts.test.js
+++ b/build/src/test/calls/managePorts.test.js
@@ -5,40 +5,40 @@ const expect = require('chai').expect;
 chai.should();
 
 describe('Call function: managePorts', function() {
-      const openedPorts = [];
-      const docker = {
-        openPort: async (port) => {
-          openedPorts.push(port);
-        },
-      };
+  const openedPorts = [];
+  const docker = {
+    openPort: async (port) => {
+      openedPorts.push(port);
+    },
+  };
 
-      const managePorts = proxyquire('calls/managePorts', {
-        'modules/docker': docker,
-      });
+  const managePorts = proxyquire('calls/managePorts', {
+    'modules/docker': docker,
+  });
 
-      it('should open the requested ports', async () => {
-        const ports = [5000, 5001];
-        const res = await managePorts({
-          action: 'open',
-          ports,
-        });
-        // Check opened ports
-        expect(ports).to.deep.equal(openedPorts);
-        // Check response message
-        expect(res).to.be.ok;
-        expect(res).to.have.property('message');
-      });
+  it('should open the requested ports', async () => {
+    const ports = [5000, 5001];
+    const res = await managePorts({
+      action: 'open',
+      ports,
+    });
+    // Check opened ports
+    expect(ports).to.deep.equal(openedPorts);
+    // Check response message
+    expect(res).to.be.ok;
+    expect(res).to.have.property('message');
+  });
 
-      it('should throw an error with wrong ports variable', async () => {
-        let error = '--- managePorts did not throw ---';
-        try {
-          await managePorts({
-            action: 'open',
-            ports: 'not an array',
-          });
-        } catch (e) {
-          error = e.message;
-        }
-        expect(error).to.include('ports variable must be an array');
+  it('should throw an error with wrong ports variable', async () => {
+    let error = '--- managePorts did not throw ---';
+    try {
+      await managePorts({
+        action: 'open',
+        ports: 'not an array',
       });
+    } catch (e) {
+      error = e.message;
+    }
+    expect(error).to.include('kwarg ports must be an array');
+  });
 });

--- a/build/src/test/calls/removePackage.test.js
+++ b/build/src/test/calls/removePackage.test.js
@@ -11,8 +11,7 @@ describe('Call function: removePackage', function() {
   const testDir = 'test_files/';
   const params = {
     REPO_DIR: testDir,
-    DOCKERCOMPOSE_NAME: 'docker-compose.yml',
-    DAPPNODE_PACKAGE_NAME: 'dappnode_package.json',
+    DNCORE_DIR: 'DNCORE',
   };
 
   const id = 'test.dnp.dappnode.eth';

--- a/build/src/test/calls/restartPackage.test.js
+++ b/build/src/test/calls/restartPackage.test.js
@@ -10,8 +10,8 @@ chai.should();
 
 describe('Call function: restartPackage', function() {
   const params = {
+    DNCORE_DIR: 'DNCORE',
     REPO_DIR: 'test_files/',
-    DOCKERCOMPOSE_NAME: 'docker-compose.yml',
   };
 
   const PACKAGE_NAME = 'test.dnp.dappnode.eth';

--- a/build/src/test/calls/restartPackageVolumes.test.js
+++ b/build/src/test/calls/restartPackageVolumes.test.js
@@ -10,8 +10,8 @@ chai.should();
 
 describe('Call function: restartPackageVolumes', function() {
   const params = {
+    DNCORE_DIR: 'DNCORE',
     REPO_DIR: 'test_files/',
-    DOCKERCOMPOSE_NAME: 'docker-compose.yml',
   };
 
   const PACKAGE_NAME = 'test.dnp.dappnode.eth';
@@ -37,22 +37,17 @@ describe('Call function: restartPackageVolumes', function() {
   // Declare stub behaviour. If done chaining methods, sinon returns an erorr:
 
   const dockerList = {
-    listContainers: async () => ([
+    listContainers: async () => [
       {
         name: CORE_PACKAGE_NAME,
         isCORE: true,
-        volumes: [
-          {name: 'vol1'},
-          {name: 'vol2'},
-        ],
+        volumes: [{name: 'vol1'}, {name: 'vol2'}],
       },
       {
         name: PACKAGE_NAME,
-        volumes: [
-          {name: 'vol3'},
-        ],
+        volumes: [{name: 'vol3'}],
       },
-    ]),
+    ],
   };
 
   const restartPackageVolumes = proxyquire('calls/restartPackageVolumes', {

--- a/build/src/test/calls/togglePackage.test.js
+++ b/build/src/test/calls/togglePackage.test.js
@@ -13,21 +13,20 @@ describe('Call function: togglePackage', function() {
   describe('mock test', mockTest);
 });
 
-const dockerComposeTemplate = (`
+const dockerComposeTemplate = `
 version: '3.4'
 services:
     otpweb.dnp.dappnode.eth:
         image: 'chentex/random-logger:latest'
         container_name: DNP_DAPPMANAGER_TEST_CONTAINER
-`).trim();
-
+`.trim();
 
 function mockTest() {
   // const DOCKERCOMPOSE_PATH = getPath.dockerCompose(PACKAGE_NAME, params)
 
   const params = {
+    DNCORE_DIR: 'DNCORE',
     REPO_DIR: 'test_files/',
-    DOCKERCOMPOSE_NAME: 'docker-compose.yml',
   };
 
   const PACKAGE_NAME = 'test.dnp.dappnode.eth';

--- a/build/src/test/calls/updatePackageEnv.test.js
+++ b/build/src/test/calls/updatePackageEnv.test.js
@@ -11,15 +11,16 @@ const validate = require('utils/validate');
 chai.should();
 
 describe('Call function: updatePackageEnv', function() {
-    // This function gets the manifest of a package,
-    // and then gets the avatar refered in the manifest if any
-    // Finally returns this data objectified
+  // This function gets the manifest of a package,
+  // and then gets the avatar refered in the manifest if any
+  // Finally returns this data objectified
   const packageName = 'myPackage.eth';
   const testDirectory = './test_files/';
 
   const params = {
     ...paramsDefault,
     CACHE_DIR: testDirectory,
+    DNCORE_DIR: 'DNCORE',
     REPO_DIR: testDirectory,
   };
 
@@ -53,7 +54,7 @@ describe('Call function: updatePackageEnv', function() {
       sinon.assert.calledWith(docker.compose.up, dockerComposePath);
       // The envs should have been written
       let envString = fs.readFileSync(envFilePath, 'utf8');
-      expect( envString ).to.include('key=val');
+      expect(envString).to.include('key=val');
       // And return correctly
       expect(res).to.be.ok;
       expect(res).to.have.property('message');
@@ -79,10 +80,8 @@ describe('Call function: updatePackageEnv', function() {
     });
 
     after(() => {
-        fs.unlinkSync(dockerComposePath);
-        fs.unlinkSync(envFilePath);
+      fs.unlinkSync(dockerComposePath);
+      fs.unlinkSync(envFilePath);
     });
   });
 });
-
-

--- a/build/src/test/modules/restartPatch.test.js
+++ b/build/src/test/modules/restartPatch.test.js
@@ -3,7 +3,6 @@ const expect = require('chai').expect;
 const getPath = require('utils/getPath');
 const fs = require('fs');
 
-
 describe('Util: restartPatch', () => {
   let dockerComposeUpArg;
   const docker = {
@@ -15,21 +14,19 @@ describe('Util: restartPatch', () => {
   };
   const params = {
     DNCORE_DIR: 'test_files',
-    DOCKERCOMPOSE_NAME: 'docker-compose.yml',
+    REPO_DIR: 'test_files/',
   };
   const IMAGE_NAME = 'dappmanager.tar.xz:0.0.9';
-  const DOCKERCOMPOSE_RESTART_PATH =
-    getPath.dockerCompose('restart.dnp.dappnode.eth', params, true);
+  const DOCKERCOMPOSE_RESTART_PATH = getPath.dockerCompose('restart.dnp.dappnode.eth', params, true);
 
   const restartPatch = proxyquire('modules/restartPatch', {
-    'docker': docker,
-    'params': params,
+    docker: docker,
+    params: params,
   });
 
   it('Should call docker.compose.up with the correct arguments', () => {
     restartPatch(IMAGE_NAME).then(() => {
-      expect(dockerComposeUpArg)
-        .to.be.equal(DOCKERCOMPOSE_RESTART_PATH);
+      expect(dockerComposeUpArg).to.be.equal(DOCKERCOMPOSE_RESTART_PATH);
     });
   });
 

--- a/build/src/test/modules/unlockPorts.test.js
+++ b/build/src/test/modules/unlockPorts.test.js
@@ -5,38 +5,38 @@ const getPath = require('utils/getPath');
 const validate = require('utils/validate');
 
 describe('Module: unlockPorts', function() {
-    const params = {
-        REPO_DIR: 'test_files/',
-        DOCKERCOMPOSE_NAME: 'docker-compose.yml',
-    };
+  const params = {
+    DNCORE_DIR: 'DNCORE',
+    REPO_DIR: 'test_files/',
+  };
 
-    const pkg = {
-        name: 'kovan.dnp.dappnode.eth',
-        ver: '0.1.0',
-        manifest: {
-            image: {
-                ports: ['30303', '30303/udp'],
-            },
-            isCore: false,
-        },
-    };
+  const pkg = {
+    name: 'kovan.dnp.dappnode.eth',
+    ver: '0.1.0',
+    manifest: {
+      image: {
+        ports: ['30303', '30303/udp'],
+      },
+      isCore: false,
+    },
+  };
 
-    const dockerComposePath = getPath.dockerCompose(pkg.name, params);
+  const dockerComposePath = getPath.dockerCompose(pkg.name, params);
 
-    const docker = {
-        compose: {
-            up: async () => {},
-        },
-    };
+  const docker = {
+    compose: {
+      up: async () => {},
+    },
+  };
 
-    const unlockPorts = proxyquire('modules/unlockPorts', {
-        'modules/docker': docker,
-        'params': params,
-    });
+  const unlockPorts = proxyquire('modules/unlockPorts', {
+    'modules/docker': docker,
+    'params': params,
+  });
 
-    before(() => {
-        validate.path(dockerComposePath);
-        const dockerComposeString = `
+  before(() => {
+    validate.path(dockerComposePath);
+    const dockerComposeString = `
 version: '3.4'
 services:
     ${pkg.name}:
@@ -47,20 +47,17 @@ services:
         labels:
             portsToClose: '[{"number":32768,"type":"UDP"},{"number":32768,"type":"TCP"}]'
 `;
-        fs.writeFileSync(dockerComposePath, dockerComposeString);
-    });
+    fs.writeFileSync(dockerComposePath, dockerComposeString);
+  });
 
-    it('should unlock ports and return portsToClose (NON core)', async () => {
-        const portsToClose = await unlockPorts(dockerComposePath);
-        expect(portsToClose).to.deep.equal([
-            {number: 32768, type: 'UDP'},
-            {number: 32768, type: 'TCP'},
-        ]);
-    });
+  it('should unlock ports and return portsToClose (NON core)', async () => {
+    const portsToClose = await unlockPorts(dockerComposePath);
+    expect(portsToClose).to.deep.equal([{number: 32768, type: 'UDP'}, {number: 32768, type: 'TCP'}]);
+  });
 
-    it('should have modified the docker-compose (NON core)', async () => {
-        const dc = fs.readFileSync(dockerComposePath, 'utf8');
-        expect(dc).to.equal(`version: '3.4'
+  it('should have modified the docker-compose (NON core)', async () => {
+    const dc = fs.readFileSync(dockerComposePath, 'utf8');
+    expect(dc).to.equal(`version: '3.4'
 services:
     ${pkg.name}:
         ports:
@@ -68,11 +65,9 @@ services:
             - '30303'
             - '5001:5001'
 `);
-    });
+  });
 
-    after(() => {
-        fs.unlinkSync(dockerComposePath);
-    });
+  after(() => {
+    fs.unlinkSync(dockerComposePath);
+  });
 });
-
-

--- a/build/src/test/utils/getPath.test.js
+++ b/build/src/test/utils/getPath.test.js
@@ -4,40 +4,34 @@ chai.should();
 
 const getPath = require('utils/getPath');
 
+const testDir = 'test_files/';
+
 describe('Util: get paths', function() {
-  const REPO_PATH_MOCK = 'repo/';
   const params = {
-    REPO_DIR: REPO_PATH_MOCK, // ### Temporary name for development
-    DAPPNODE_PACKAGE_NAME: 'dappnode_package.json',
-    DOCKERCOMPOSE_NAME: 'docker-compose.yml',
-    ENV_FILE_EXTENSION: '.env',
+    DNCORE_DIR: 'DNCORE',
+    REPO_DIR: testDir, // ### Temporary name for development
   };
 
   const packageName = 'some_package';
   const imageName = 'some_image.tar.xz';
 
   it('return PACKAGE_REPO_DIR path', () => {
-    getPath.packageRepoDir(packageName, params)
-      .should.equal(REPO_PATH_MOCK + packageName);
+    getPath.packageRepoDir(packageName, params).should.equal(testDir + packageName);
   });
 
   it('return MANIFEST path', () => {
-    getPath.manifest(packageName, params)
-      .should.equal(REPO_PATH_MOCK + packageName + '/' + params.DAPPNODE_PACKAGE_NAME);
+    getPath.manifest(packageName, params).should.equal(testDir + packageName + '/' + 'dappnode_package.json');
   });
 
   it('return DOCKERCOMPOSE path', () => {
-    getPath.dockerCompose(packageName, params)
-      .should.equal(REPO_PATH_MOCK + packageName + '/' + params.DOCKERCOMPOSE_NAME);
+    getPath.dockerCompose(packageName, params).should.equal(testDir + packageName + '/' + 'docker-compose.yml');
   });
 
   it('return ENV_FILE path', () => {
-    getPath.envFile(packageName, params)
-      .should.equal(REPO_PATH_MOCK + packageName + '/' + packageName + params.ENV_FILE_EXTENSION);
+    getPath.envFile(packageName, params).should.equal(testDir + packageName + '/' + packageName + '.env');
   });
 
   it('return IMAGE path', () => {
-    getPath.image(packageName, imageName, params)
-      .should.equal(REPO_PATH_MOCK + packageName + '/' + imageName);
+    getPath.image(packageName, imageName, params).should.equal(testDir + packageName + '/' + imageName);
   });
 });


### PR DESCRIPTION
- Add checks and all calls to ensure that key arguments are defined.
- Restructure the `getPath` utility to avoid doing unnecessary string manipulations
