### PR TITLE
v0.2.2 Release

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -69,8 +69,6 @@ COPY build/entrypoint.sh .
 COPY build/dns_updater.sh /etc/periodic/1min/dns_updater
 RUN crontab -l | { cat; echo "*       *       *       *       *       run-parts   /etc/periodic/1min"; } | crontab -
 
-ENV DB_PATH /usr/src/app/DNCORE/dappmanagerdb.json
-
 # Copy the src the last as it's the more likely layer to change
 COPY --from=build /usr/src/app /usr/src/app
 

--- a/build/src/package.json
+++ b/build/src/package.json
@@ -50,7 +50,7 @@
     "chai": "^4.1.2",
     "coveralls": "^3.0.2",
     "eslint": "^5.16.0",
-    "husky": "^1.3.1",
+    "husky": "^2.3.0",
     "mocha": "^5.2.0",
     "nyc": "^11.8.0",
     "prettier": "^1.16.4",
@@ -60,8 +60,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "npm run pre-commit",
-      "pre-push": "npm run pre-commit"
+      "pre-commit": "npm run pre-commit"
     }
   }
 }

--- a/build/src/src/calls/cleanCache.js
+++ b/build/src/src/calls/cleanCache.js
@@ -1,0 +1,28 @@
+const params = require("params");
+// Utils
+const shell = require("utils/shell");
+
+/**
+ * Cleans the cache files of the DAPPMANAGER:
+ * - local DB
+ * - user action logs
+ * - temp transfer folder
+ */
+const cleanCache = async () => {
+  const pathsToDelete = [
+    params.DB_PATH,
+    params.userActionLogsFilename,
+    params.TEMP_TRANSFER_DIR
+  ];
+  for (const path of pathsToDelete) {
+    await shell(`rm -rf ${path}`);
+  }
+
+  return {
+    message: `Cleaned cache`,
+    logMessage: true,
+    userAction: true
+  };
+};
+
+module.exports = cleanCache;

--- a/build/src/src/calls/cleanCache.js
+++ b/build/src/src/calls/cleanCache.js
@@ -1,4 +1,5 @@
 const params = require("params");
+const restartPatch = require("modules/restartPatch");
 // Utils
 const shell = require("utils/shell");
 
@@ -17,6 +18,8 @@ const cleanCache = async () => {
   for (const path of pathsToDelete) {
     await shell(`rm -rf ${path}`);
   }
+  // Restart DAPPMANAGER to prevent app breaks after deleting the db
+  await restartPatch("dappmanager.dnp.dappnode.eth");
 
   return {
     message: `Cleaned cache`,

--- a/build/src/src/calls/index.js
+++ b/build/src/src/calls/index.js
@@ -6,6 +6,7 @@
 
 module.exports = {
   changeIpfsTimeout: require("./changeIpfsTimeout"),
+  cleanCache: require("./cleanCache"),
   copyFileFrom: require("./copyFileFrom"),
   copyFileTo: require("./copyFileTo"),
   diagnose: require("./diagnose"),

--- a/build/src/src/db.js
+++ b/build/src/src/db.js
@@ -1,7 +1,11 @@
+const params = require("params");
 const low = require("lowdb");
 const FileSync = require("lowdb/adapters/FileSync");
+const validate = require("utils/validate");
 
-const dbPath = process.env.DB_PATH || "./dappmanagerdb.json";
+// Define dbPath and make sure it exists (mkdir -p)
+const dbPath = params.DB_PATH || "./dappmanagerdb.json";
+validate.path(dbPath);
 
 // Initialize db
 const adapter = new FileSync(dbPath);

--- a/build/src/src/modules/dappGet/aggregate/index.js
+++ b/build/src/src/modules/dappGet/aggregate/index.js
@@ -112,8 +112,10 @@ async function aggregate({ req, dnpList, fetch }) {
       dnps[dnpName].isInstalled = true;
       Object.keys(dnps[dnpName].versions).forEach(version => {
         if (
+          // Exclusively apply this condition to semver versions.
           semver.valid(version) &&
           semver.valid(dnp.version) &&
+          // If the new version = "version" is strictly less than the current version "dnp.version", ignore
           semver.lt(version, dnp.version)
         ) {
           delete dnps[dnpName].versions[version];

--- a/build/src/src/modules/dappGet/basic.js
+++ b/build/src/src/modules/dappGet/basic.js
@@ -1,6 +1,7 @@
 const dockerList = require("modules/dockerList");
 const logs = require("logs.js")(module);
 const getManifest = require("modules/getManifest");
+const shouldUpdate = require("./utils/shouldUpdate");
 
 /**
  * The dappGet resolver may cause errors.
@@ -28,9 +29,11 @@ async function dappGetBasic(req) {
   // However it would prevent already installed DNPs from installing
   try {
     const installedDnps = await dockerList.listContainers();
-    for (const { name, version } of installedDnps) {
-      if (name && version && state[name] && state[name] === version)
-        delete state[name];
+    for (const dnp of installedDnps) {
+      const currentVersion = dnp.version;
+      const newVersion = state[dnp.name];
+      if (newVersion && !shouldUpdate(currentVersion, newVersion))
+        delete state[dnp.name];
     }
   } catch (e) {
     logs.error(`Error listing current containers: ${e.stack}`);

--- a/build/src/src/modules/dappGet/index.js
+++ b/build/src/src/modules/dappGet/index.js
@@ -4,6 +4,7 @@ const resolve = require("./resolve");
 const dappGetBasic = require("./basic");
 const dockerList = require("modules/dockerList");
 const logs = require("logs.js")(module);
+const shouldUpdate = require("./utils/shouldUpdate");
 
 /**
  * Aggregates all relevant packages and their info given a specific request.
@@ -88,7 +89,9 @@ async function dappGet(req, options = {}) {
   // Otherwise, format the output
   let alreadyUpdated = {};
   dnpList.forEach(dnp => {
-    if (state[dnp.name] && state[dnp.name] === dnp.version) {
+    const currentVersion = dnp.version;
+    const newVersion = state[dnp.name];
+    if (newVersion && !shouldUpdate(currentVersion, newVersion)) {
       // DNP is already updated.
       // Remove from the success object and add it to the alreadyUpdatedd
       alreadyUpdated[dnp.name] = state[dnp.name];

--- a/build/src/src/modules/dappGet/utils/shouldUpdate.js
+++ b/build/src/src/modules/dappGet/utils/shouldUpdate.js
@@ -1,0 +1,17 @@
+const semver = require("semver");
+
+/**
+ *
+ * @param {String} v1 currentVersion
+ * @param {String} v2 newVersion
+ * @return {Bool}
+ */
+function shouldUpdate(v1, v2) {
+  // Deal with a double IPFS hash case
+  if (v1 && v2 && v1 === v2) return false;
+  v1 = semver.valid(v1) || "999.9.9";
+  v2 = semver.valid(v2) || "9999.9.9";
+  return semver.lt(v1, v2);
+}
+
+module.exports = shouldUpdate;

--- a/build/src/src/modules/packages.js
+++ b/build/src/src/modules/packages.js
@@ -32,21 +32,10 @@ async function download({ pkg, id }) {
   const imageName = manifest.image.path || `${name}_${version}.tar.xz`;
   const imageHash = manifest.image.hash;
   const imageSize = manifest.image.size;
-
-  // Write manifest and docker-compose
-  await writeFile(
-    validate.path(getPath.manifest(name, params, isCore)),
-    generate.manifest(manifest)
-  );
-  await writeFile(
-    validate.path(getPath.dockerCompose(name, params, isCore)),
-    generate.dockerCompose(manifest, params)
-  );
-
-  logUi({ id, name, message: "Starting download..." });
   const imagePath = validate.path(
     getPath.image(name, imageName, params, isCore)
   );
+
   // Keep track of the bytes downloaded. Log UI every 2%
   const onChunk = onChunkFactory(imageSize, 2, function(percent, bytes) {
     const message =
@@ -58,20 +47,56 @@ async function download({ pkg, id }) {
 
   // Wrap in try / catch to format the error
   try {
+    logUi({ id, name, message: "Starting download..." });
     await downloadImage(imageHash, imagePath, { onChunk });
   } catch (e) {
     e.message = `Can't download ${name} image: ${e.message}`;
     throw e;
   }
 
+  // Final log
+  logUi({ id, name, message: "Package downloaded" });
+}
+
+/**
+ * Handles the load of a package files.
+ * @param {object} kwargs which should contain at least
+ * - pkg: packageReq + its manifest. It is expected that in the previous step of the
+ *        installation the manifest is attached to this object.
+ * - id: task id to allow progress updates
+ * @returns {*}
+ */
+async function load({ pkg, id }) {
+  // call IPFS, store the file in the repo's folder
+  // load the image to docker
+  const { manifest } = pkg;
+  const { name, version, isCore } = manifest;
+  // Construct image path, if not provided
+  // "admin.dnp.dappnode.eth_0.2.0.tar.xz"
+  const imageName = manifest.image.path || `${name}_${version}.tar.xz`;
+
+  const imagePath = validate.path(
+    getPath.image(name, imageName, params, isCore)
+  );
+
   logUi({ id, name, message: "Loading image..." });
   await docker.load(imagePath);
+
+  // Write manifest and docker-compose AFTER loading image
+  await writeFile(
+    validate.path(getPath.manifest(name, params, isCore)),
+    generate.manifest(manifest)
+  );
+  await writeFile(
+    validate.path(getPath.dockerCompose(name, params, isCore)),
+    generate.dockerCompose(manifest, params)
+  );
 
   logUi({ id, name, message: "Cleaning files..." });
   await removeFile(imagePath);
 
   // Final log
-  logUi({ id, name, message: "Package downloaded" });
+  logUi({ id, name, message: "Package Loaded" });
 }
 
 /**
@@ -137,5 +162,6 @@ function onChunkFactory(totalAmount, resolution, callback) {
 
 module.exports = {
   download,
+  load,
   run
 };

--- a/build/src/src/params.js
+++ b/build/src/src/params.js
@@ -1,17 +1,28 @@
+const path = require("path");
+
 /**
  * DAPPMANAGER Parameters. This parameters are modified on execution for testing
  */
+
+/**
+ * Main persistent folders, linked with docker volumes
+ * - No need to prefix or sufix with slashes, path.join() is used in the whole app
+ */
+const DNCORE_DIR = "DNCORE"; // Bind volume
+const REPO_DIR = "dnp_repo"; // Named volume
 
 module.exports = {
   // Autobahn parameters
   autobahnUrl: "ws://my.wamp.dnp.dappnode.eth:8080/ws",
   autobahnRealm: "dappnode_admin",
 
-  // Installer paths
-  CACHE_DIR: "./cache/",
-  REPO_DIR: "./dnp_repo/",
-  DNCORE_DIR: "DNCORE",
-  TEMP_TRANSFER_DIR: "DNCORE/.temp-transfer",
+  // File paths
+  REPO_DIR,
+  DNCORE_DIR,
+  userActionLogsFilename: path.join(DNCORE_DIR, "userActionLogs.log"),
+  // lowdb requires an absolute path
+  DB_PATH: path.resolve(DNCORE_DIR, "dappmanagerdb.json"),
+  TEMP_TRANSFER_DIR: path.join(DNCORE_DIR, ".temp-transfer"),
 
   // Docker compose parameters
   DNS_SERVICE: "172.33.1.2",
@@ -26,8 +37,5 @@ module.exports = {
   // Web3 parameters
   WEB3HOSTWS: "ws://my.ethchain.dnp.dappnode.eth:8546",
   WEB3HOSTHTTP: "http://my.ethchain.dnp.dappnode.eth:8545",
-  CHAIN_DATA_UNTIL: 0,
-
-  // User Action Logs filename
-  userActionLogsFilename: "DNCORE/userActionLogs.log"
+  CHAIN_DATA_UNTIL: 0
 };

--- a/build/src/src/utils/getPath.js
+++ b/build/src/src/utils/getPath.js
@@ -93,7 +93,7 @@ function getRepoDirPath(dnpName, params, isCore) {
   if (!params.DNCORE_DIR) throw Error("params.DNCORE_DIR must be defined");
   if (!params.REPO_DIR) throw Error("params.REPO_DIR must be defined");
   if (isCore) return params.DNCORE_DIR;
-  return params.REPO_DIR + dnpName;
+  return path.join(params.REPO_DIR, dnpName);
 }
 
 function getDockerComposeName(dnpName, isCore) {

--- a/build/src/src/watchers/chains/index.js
+++ b/build/src/src/watchers/chains/index.js
@@ -70,7 +70,7 @@ const getDriveApi = {
   // 'http://my.ropsten.dnp.dappnode.eth:8545'
   ethereum: dnpName => `http://my.${dnpName}:8545`,
   // 'my.bitcoin.dnp.dappnode.eth'
-  bitcoin: dnpName => dnpName,
+  bitcoin: dnpName => `my.${dnpName}`,
   // 'http://my.monero.dnp.dappnode.eth:18081'
   monero: dnpName => `http://my.${dnpName}:18081`
 };

--- a/build/src/test/calls/installPackage.test.js
+++ b/build/src/test/calls/installPackage.test.js
@@ -30,6 +30,7 @@ describe("Call function: installPackage", function() {
   // Stub packages module. Resolve always returning nothing
   const packages = {
     download: sinon.fake.resolves(),
+    load: sinon.fake.resolves(),
     run: sinon.fake.resolves()
   };
 
@@ -101,35 +102,37 @@ describe("Call function: installPackage", function() {
     sinon.assert.calledWith(dappGet, { name: pkgName, req: pkgName, ver: "*" });
   });
 
+  const callKwargPkg = {
+    id: pkgName,
+    pkg: { manifest: { ...pkgManifest }, name: pkgName, ver: pkgVer }
+  };
+  const callKwargDep = {
+    id: pkgName,
+    pkg: { manifest: { ...depManifest }, name: depName, ver: depVer }
+  };
   // Step 3: Format the request and filter out already updated packages
   // Step 4: Download requested packages
   it("should have called download", async () => {
     sinon.assert.callCount(packages.download, 2);
     expect(packages.download.getCall(0).args).to.deep.equal(
-      [
-        {
-          id: pkgName,
-          pkg: {
-            manifest: { ...pkgManifest },
-            name: pkgName,
-            ver: pkgVer
-          }
-        }
-      ],
+      [callKwargPkg],
       `should call packages.download first for package ${pkgName}`
     );
     expect(packages.download.getCall(1).args).to.deep.equal(
-      [
-        {
-          id: pkgName,
-          pkg: {
-            manifest: { ...depManifest },
-            name: depName,
-            ver: depVer
-          }
-        }
-      ],
+      [callKwargDep],
       `should call packages.download second for dependency ${depName}`
+    );
+  });
+
+  it("should have called load", async () => {
+    sinon.assert.callCount(packages.load, 2);
+    expect(packages.load.getCall(0).args).to.deep.equal(
+      [callKwargPkg],
+      `should call packages.load first for package ${pkgName}`
+    );
+    expect(packages.load.getCall(1).args).to.deep.equal(
+      [callKwargDep],
+      `should call packages.load second for dependency ${depName}`
     );
   });
 
@@ -137,29 +140,11 @@ describe("Call function: installPackage", function() {
   it("should have called run", async () => {
     sinon.assert.callCount(packages.run, 2);
     expect(packages.run.getCall(0).args).to.deep.equal(
-      [
-        {
-          id: pkgName,
-          pkg: {
-            manifest: { ...pkgManifest },
-            name: pkgName,
-            ver: pkgVer
-          }
-        }
-      ],
+      [callKwargPkg],
       `should call packages.run second for dependency ${depName}`
     );
     expect(packages.run.getCall(1).args).to.deep.equal(
-      [
-        {
-          id: pkgName,
-          pkg: {
-            manifest: { ...depManifest },
-            name: depName,
-            ver: depVer
-          }
-        }
-      ],
+      [callKwargDep],
       `should call packages.run second for dependency ${depName}`
     );
   });

--- a/build/src/test/modules/dappGet/basic.test.js
+++ b/build/src/test/modules/dappGet/basic.test.js
@@ -1,65 +1,346 @@
 const proxyquire = require("proxyquire");
 const expect = require("chai").expect;
-const sinon = require("sinon");
+
+/* eslint-disable max-len */
 
 /**
  * Purpose of the test. Make sure dappGetBasic works
  * This is a lite version of the dappGet, specially though for core updates
  */
 
-const dockerList = {
-  listContainers: sinon.stub().callsFake(async () => {
-    return [
-      { name: "dappmanager.dnp.dappnode.eth", version: "0.1.10" },
-      { name: "admin.dnp.dappnode.eth", version: "0.1.6" },
-      { name: "ethforward.dnp.dappnode.eth", version: "0.1.0" }
-    ];
-  })
-};
-
-const getManifest = sinon.stub().callsFake(async () => {
-  return {
-    name: "core.dnp.dappnode.eth",
-    version: "0.1.0",
-    type: "dncore",
-    dependencies: {
-      "bind.dnp.dappnode.eth": "0.1.4",
-      "ipfs.dnp.dappnode.eth": "0.1.3",
-      "ethchain.dnp.dappnode.eth": "0.1.4",
-      "ethforward.dnp.dappnode.eth": "0.1.1",
-      "vpn.dnp.dappnode.eth": "0.1.11",
-      "wamp.dnp.dappnode.eth": "0.1.0",
-      "admin.dnp.dappnode.eth": "0.1.6",
-      "dappmanager.dnp.dappnode.eth": "0.1.10"
-    }
-  };
-});
-
-const dappGet = proxyquire("modules/dappGet/basic", {
-  "modules/getManifest": getManifest,
-  "modules/dockerList": dockerList
-});
-
 describe("dappGetBasic", () => {
-  it("Resolve the request only fetching first level dependencies", async () => {
-    const { state } = await dappGet({
+  describe("Normal case", () => {
+    const dockerList = {
+      listContainers: async () => [
+        { name: "core.dnp.dappnode.eth", version: "0.1.11" },
+        { name: "dappmanager.dnp.dappnode.eth", version: "0.1.10" },
+        { name: "admin.dnp.dappnode.eth", version: "0.1.6" },
+        { name: "ethforward.dnp.dappnode.eth", version: "0.1.0" }
+        //
+      ]
+    };
+    const getManifest = async () => ({
       name: "core.dnp.dappnode.eth",
-      ver: "0.1.0"
+      version: "0.1.15",
+      type: "dncore",
+      dependencies: {
+        "bind.dnp.dappnode.eth": "0.1.4",
+        "ipfs.dnp.dappnode.eth": "0.1.3",
+        "ethchain.dnp.dappnode.eth": "0.1.4",
+        "ethforward.dnp.dappnode.eth": "0.1.1",
+        "vpn.dnp.dappnode.eth": "0.1.11",
+        "wamp.dnp.dappnode.eth": "0.1.0",
+        "admin.dnp.dappnode.eth": "0.1.6",
+        "dappmanager.dnp.dappnode.eth": "0.1.10"
+      }
     });
-    expect(state).to.deep.equal({
-      "core.dnp.dappnode.eth": "0.1.0",
-      "bind.dnp.dappnode.eth": "0.1.4",
-      "ipfs.dnp.dappnode.eth": "0.1.3",
-      "ethchain.dnp.dappnode.eth": "0.1.4",
-      "ethforward.dnp.dappnode.eth": "0.1.1",
-      "vpn.dnp.dappnode.eth": "0.1.11",
-      "wamp.dnp.dappnode.eth": "0.1.0"
-      // 'admin.dnp.dappnode.eth': '0.1.6',
-      // 'dappmanager.dnp.dappnode.eth': '0.1.10',
+    const dappGet = proxyquire("modules/dappGet/basic", {
+      "modules/getManifest": getManifest,
+      "modules/dockerList": dockerList
+    });
+
+    it("Should request only fetching first level dependencies, ignoring the already updated", async () => {
+      const result = await dappGet({
+        name: "core.dnp.dappnode.eth",
+        ver: "0.1.15"
+      });
+      expect(result.state).to.deep.equal({
+        // Core
+        "core.dnp.dappnode.eth": "0.1.15",
+        // Deps
+        "bind.dnp.dappnode.eth": "0.1.4",
+        "ipfs.dnp.dappnode.eth": "0.1.3",
+        "ethchain.dnp.dappnode.eth": "0.1.4",
+        "ethforward.dnp.dappnode.eth": "0.1.1",
+        "vpn.dnp.dappnode.eth": "0.1.11",
+        "wamp.dnp.dappnode.eth": "0.1.0"
+        // Ignored deps
+        // 'admin.dnp.dappnode.eth': '0.1.6',
+        // 'dappmanager.dnp.dappnode.eth': '0.1.10',
+      });
     });
   });
 
-  it("Should call list containers once", () => {
-    sinon.assert.calledOnce(dockerList.listContainers);
+  describe("0.2.0-alpha => 0.2.0", () => {
+    const dockerList = {
+      listContainers: async () => [
+        { name: "core.dnp.dappnode.eth", version: "0.2.0-alpha" },
+        { name: "bind.dnp.dappnode.eth", version: "0.2.0-alpha" },
+        { name: "ipfs.dnp.dappnode.eth", version: "0.2.0-alpha" },
+        { name: "ethchain.dnp.dappnode.eth", version: "0.2.0-alpha" },
+        { name: "ethforward.dnp.dappnode.eth", version: "0.2.0-alpha" },
+        { name: "vpn.dnp.dappnode.eth", version: "0.2.0-alpha" },
+        { name: "wamp.dnp.dappnode.eth", version: "0.2.0-alpha" },
+        { name: "admin.dnp.dappnode.eth", version: "0.2.0-alpha" },
+        { name: "dappmanager.dnp.dappnode.eth", version: "0.2.0" }
+        //
+      ]
+    };
+    const getManifest = async () => ({
+      name: "core.dnp.dappnode.eth",
+      version: "0.2.0",
+      type: "dncore",
+      dependencies: {
+        "bind.dnp.dappnode.eth": "0.2.0",
+        "ipfs.dnp.dappnode.eth": "0.2.0",
+        "ethchain.dnp.dappnode.eth": "0.2.0",
+        "ethforward.dnp.dappnode.eth": "0.2.0",
+        "vpn.dnp.dappnode.eth": "0.2.0",
+        "wamp.dnp.dappnode.eth": "0.2.0",
+        "admin.dnp.dappnode.eth": "0.2.0",
+        "dappmanager.dnp.dappnode.eth": "0.2.0"
+      }
+    });
+    const dappGet = proxyquire("modules/dappGet/basic", {
+      "modules/getManifest": getManifest,
+      "modules/dockerList": dockerList
+    });
+
+    it("Should request to update all versions from alpha to 0.2.0", async () => {
+      const result = await dappGet({
+        name: "core.dnp.dappnode.eth",
+        ver: "0.2.0"
+      });
+      expect(result.state).to.deep.equal({
+        // Core
+        "core.dnp.dappnode.eth": "0.2.0",
+        // Deps
+        "bind.dnp.dappnode.eth": "0.2.0",
+        "ipfs.dnp.dappnode.eth": "0.2.0",
+        "ethchain.dnp.dappnode.eth": "0.2.0",
+        "ethforward.dnp.dappnode.eth": "0.2.0",
+        "vpn.dnp.dappnode.eth": "0.2.0",
+        "wamp.dnp.dappnode.eth": "0.2.0",
+        "admin.dnp.dappnode.eth": "0.2.0"
+        // Ignored deps
+        // 'dappmanager.dnp.dappnode.eth': '0.2.0',
+      });
+    });
+  });
+
+  describe("0.2.0 => 0.2.0", () => {
+    const dockerList = {
+      listContainers: async () => [
+        { name: "core.dnp.dappnode.eth", version: "0.2.0" },
+        { name: "bind.dnp.dappnode.eth", version: "0.2.0" },
+        { name: "ipfs.dnp.dappnode.eth", version: "0.2.0" },
+        { name: "ethchain.dnp.dappnode.eth", version: "0.2.0" },
+        { name: "ethforward.dnp.dappnode.eth", version: "0.2.0" },
+        { name: "vpn.dnp.dappnode.eth", version: "0.2.0" },
+        { name: "wamp.dnp.dappnode.eth", version: "0.2.0" },
+        { name: "admin.dnp.dappnode.eth", version: "0.2.0" },
+        { name: "dappmanager.dnp.dappnode.eth", version: "0.2.0" }
+        //
+      ]
+    };
+    const getManifest = async () => ({
+      name: "core.dnp.dappnode.eth",
+      version: "0.2.0",
+      type: "dncore",
+      dependencies: {
+        "bind.dnp.dappnode.eth": "0.2.0",
+        "ipfs.dnp.dappnode.eth": "0.2.0",
+        "ethchain.dnp.dappnode.eth": "0.2.0",
+        "ethforward.dnp.dappnode.eth": "0.2.0",
+        "vpn.dnp.dappnode.eth": "0.2.0",
+        "wamp.dnp.dappnode.eth": "0.2.0",
+        "admin.dnp.dappnode.eth": "0.2.0",
+        "dappmanager.dnp.dappnode.eth": "0.2.0"
+      }
+    });
+    const dappGet = proxyquire("modules/dappGet/basic", {
+      "modules/getManifest": getManifest,
+      "modules/dockerList": dockerList
+    });
+
+    it("Should not update any", async () => {
+      const result = await dappGet({
+        name: "core.dnp.dappnode.eth",
+        ver: "0.2.0"
+      });
+      expect(result.state).to.deep.equal({
+        // Core
+        // 'core.dnp.dappnode.eth': '0.2.0',
+        // Deps
+        // Ignored deps
+        // 'bind.dnp.dappnode.eth': '0.2.0',
+        // 'ipfs.dnp.dappnode.eth': '0.2.0',
+        // 'ethchain.dnp.dappnode.eth': '0.2.0',
+        // 'ethforward.dnp.dappnode.eth': '0.2.0',
+        // 'vpn.dnp.dappnode.eth': '0.2.0',
+        // 'wamp.dnp.dappnode.eth': '0.2.0',
+        // 'admin.dnp.dappnode.eth': '0.2.0',
+        // 'dappmanager.dnp.dappnode.eth': '0.2.0',
+      });
+    });
+  });
+
+  describe("0.2.0 => 0.2.0-alpha", () => {
+    const dockerList = {
+      listContainers: async () => [
+        { name: "core.dnp.dappnode.eth", version: "0.2.0" },
+        { name: "bind.dnp.dappnode.eth", version: "0.2.0" },
+        { name: "ipfs.dnp.dappnode.eth", version: "0.2.0" },
+        { name: "ethchain.dnp.dappnode.eth", version: "0.2.0" },
+        { name: "ethforward.dnp.dappnode.eth", version: "0.2.0" },
+        { name: "vpn.dnp.dappnode.eth", version: "0.2.0" },
+        { name: "wamp.dnp.dappnode.eth", version: "0.2.0" },
+        { name: "admin.dnp.dappnode.eth", version: "0.2.0" },
+        { name: "dappmanager.dnp.dappnode.eth", version: "0.2.0" }
+        //
+      ]
+    };
+    const getManifest = async () => ({
+      name: "core.dnp.dappnode.eth",
+      version: "0.2.0-alpha",
+      type: "dncore",
+      dependencies: {
+        "bind.dnp.dappnode.eth": "0.2.0-alpha",
+        "ipfs.dnp.dappnode.eth": "0.2.0-alpha",
+        "ethchain.dnp.dappnode.eth": "0.2.0-alpha",
+        "ethforward.dnp.dappnode.eth": "0.2.0-alpha",
+        "vpn.dnp.dappnode.eth": "0.2.0-alpha",
+        "wamp.dnp.dappnode.eth": "0.2.0-alpha",
+        "admin.dnp.dappnode.eth": "0.2.0-alpha",
+        "dappmanager.dnp.dappnode.eth": "0.2.0-alpha"
+      }
+    });
+    const dappGet = proxyquire("modules/dappGet/basic", {
+      "modules/getManifest": getManifest,
+      "modules/dockerList": dockerList
+    });
+
+    it("Should not update any", async () => {
+      const result = await dappGet({
+        name: "core.dnp.dappnode.eth",
+        ver: "0.2.0-alpha"
+      });
+      expect(result.state).to.deep.equal({
+        // Core
+        // 'core.dnp.dappnode.eth': '0.2.0-alpha',
+        // Deps
+        // Ignored deps
+        // 'bind.dnp.dappnode.eth': '0.2.0',
+        // 'ipfs.dnp.dappnode.eth': '0.2.0',
+        // 'ethchain.dnp.dappnode.eth': '0.2.0',
+        // 'ethforward.dnp.dappnode.eth': '0.2.0',
+        // 'vpn.dnp.dappnode.eth': '0.2.0',
+        // 'wamp.dnp.dappnode.eth': '0.2.0',
+        // 'admin.dnp.dappnode.eth': '0.2.0',
+        // 'dappmanager.dnp.dappnode.eth': '0.2.0',
+      });
+    });
+  });
+
+  describe("0.1.x => 0.2.0-alpha", () => {
+    const dockerList = {
+      listContainers: async () => [
+        { name: "core.dnp.dappnode.eth", version: "0.1.11" },
+        { name: "bind.dnp.dappnode.eth", version: "0.1.9" },
+        { name: "ipfs.dnp.dappnode.eth", version: "0.1.6" },
+        { name: "ethchain.dnp.dappnode.eth", version: "0.1.7" },
+        { name: "ethforward.dnp.dappnode.eth", version: "0.1.2" },
+        { name: "vpn.dnp.dappnode.eth", version: "0.1.12" },
+        { name: "wamp.dnp.dappnode.eth", version: "0.1.1" },
+        { name: "admin.dnp.dappnode.eth", version: "0.1.5" },
+        { name: "dappmanager.dnp.dappnode.eth", version: "0.1.20" }
+        //
+      ]
+    };
+    const getManifest = async () => ({
+      name: "core.dnp.dappnode.eth",
+      version: "0.2.0-alpha",
+      type: "dncore",
+      dependencies: {
+        "bind.dnp.dappnode.eth": "0.2.0-alpha",
+        "ipfs.dnp.dappnode.eth": "0.2.0-alpha",
+        "ethchain.dnp.dappnode.eth": "0.2.0-alpha",
+        "ethforward.dnp.dappnode.eth": "0.2.0-alpha",
+        "vpn.dnp.dappnode.eth": "0.2.0-alpha",
+        "wamp.dnp.dappnode.eth": "0.2.0-alpha",
+        "admin.dnp.dappnode.eth": "0.2.0-alpha",
+        "dappmanager.dnp.dappnode.eth": "0.2.0-alpha"
+      }
+    });
+    const dappGet = proxyquire("modules/dappGet/basic", {
+      "modules/getManifest": getManifest,
+      "modules/dockerList": dockerList
+    });
+
+    it("Should update all to 0.2.0-alpha", async () => {
+      const result = await dappGet({
+        name: "core.dnp.dappnode.eth",
+        ver: "0.2.0-alpha"
+      });
+      expect(result.state).to.deep.equal({
+        // Core
+        "core.dnp.dappnode.eth": "0.2.0-alpha",
+        // Deps
+        "bind.dnp.dappnode.eth": "0.2.0-alpha",
+        "ipfs.dnp.dappnode.eth": "0.2.0-alpha",
+        "ethchain.dnp.dappnode.eth": "0.2.0-alpha",
+        "ethforward.dnp.dappnode.eth": "0.2.0-alpha",
+        "vpn.dnp.dappnode.eth": "0.2.0-alpha",
+        "wamp.dnp.dappnode.eth": "0.2.0-alpha",
+        "admin.dnp.dappnode.eth": "0.2.0-alpha",
+        "dappmanager.dnp.dappnode.eth": "0.2.0-alpha"
+      });
+    });
+  });
+
+  describe("0.1.x => 0.2.0", () => {
+    const dockerList = {
+      listContainers: async () => [
+        { name: "core.dnp.dappnode.eth", version: "0.1.11" },
+        { name: "bind.dnp.dappnode.eth", version: "0.1.9" },
+        { name: "ipfs.dnp.dappnode.eth", version: "0.1.6" },
+        { name: "ethchain.dnp.dappnode.eth", version: "0.1.7" },
+        { name: "ethforward.dnp.dappnode.eth", version: "0.1.2" },
+        { name: "vpn.dnp.dappnode.eth", version: "0.1.12" },
+        { name: "wamp.dnp.dappnode.eth", version: "0.1.1" },
+        { name: "admin.dnp.dappnode.eth", version: "0.1.5" },
+        { name: "dappmanager.dnp.dappnode.eth", version: "0.1.20" }
+        //
+      ]
+    };
+    const getManifest = async () => ({
+      name: "core.dnp.dappnode.eth",
+      version: "0.2.0",
+      type: "dncore",
+      dependencies: {
+        "bind.dnp.dappnode.eth": "0.2.0",
+        "ipfs.dnp.dappnode.eth": "0.2.0",
+        "ethchain.dnp.dappnode.eth": "0.2.0",
+        "ethforward.dnp.dappnode.eth": "0.2.0",
+        "vpn.dnp.dappnode.eth": "0.2.0",
+        "wamp.dnp.dappnode.eth": "0.2.0",
+        "admin.dnp.dappnode.eth": "0.2.0",
+        "dappmanager.dnp.dappnode.eth": "0.2.0"
+      }
+    });
+    const dappGet = proxyquire("modules/dappGet/basic", {
+      "modules/getManifest": getManifest,
+      "modules/dockerList": dockerList
+    });
+
+    it("Should update all to 0.2.0", async () => {
+      const result = await dappGet({
+        name: "core.dnp.dappnode.eth",
+        ver: "0.2.0"
+      });
+      expect(result.state).to.deep.equal({
+        // Core
+        "core.dnp.dappnode.eth": "0.2.0",
+        // Deps
+        "bind.dnp.dappnode.eth": "0.2.0",
+        "ipfs.dnp.dappnode.eth": "0.2.0",
+        "ethchain.dnp.dappnode.eth": "0.2.0",
+        "ethforward.dnp.dappnode.eth": "0.2.0",
+        "vpn.dnp.dappnode.eth": "0.2.0",
+        "wamp.dnp.dappnode.eth": "0.2.0",
+        "admin.dnp.dappnode.eth": "0.2.0",
+        "dappmanager.dnp.dappnode.eth": "0.2.0"
+      });
+    });
   });
 });

--- a/build/src/test/modules/packages.test.js
+++ b/build/src/test/modules/packages.test.js
@@ -84,7 +84,7 @@ describe("Util: package install / download", () => {
     }
   };
 
-  const { download, run } = proxyquire("modules/packages", {
+  const { download, load, run } = proxyquire("modules/packages", {
     "modules/downloadImage": downloadImage,
     "modules/docker": docker,
     "utils/generate": generate,
@@ -95,6 +95,20 @@ describe("Util: package install / download", () => {
 
   describe(".download", () => {
     download({
+      pkg: {
+        name: PACKAGE_NAME,
+        manifest: dnpManifest
+      }
+    });
+
+    // downloadImageSpy - IMAGE_HASH, IMAGE_PATH
+    it("ipfs.download should be called with IMAGE_HASH, IMAGE_PATH", () => {
+      sinon.assert.calledWith(downloadImageSpy, IMAGE_HASH, IMAGE_PATH);
+    });
+  });
+
+  describe(".load", () => {
+    load({
       pkg: {
         name: PACKAGE_NAME,
         manifest: dnpManifest
@@ -126,11 +140,6 @@ describe("Util: package install / download", () => {
         DOCKERCOMPOSE_PATH,
         DockerCompose
       ]);
-    });
-
-    // downloadImageSpy - IMAGE_HASH, IMAGE_PATH
-    it("ipfs.download should be called with IMAGE_HASH, IMAGE_PATH", () => {
-      sinon.assert.calledWith(downloadImageSpy, IMAGE_HASH, IMAGE_PATH);
     });
 
     it("docker.load should be called with IMAGE_PATH", () => {

--- a/build/src/yarn.lock
+++ b/build/src/yarn.lock
@@ -406,6 +406,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.45.tgz#4c49ba34106bc7dced77ff6bae8eb6543cde8351"
   integrity sha512-tGVTbA+i3qfXsLbq9rEq/hezaHY55QxQLeXQL2ejNgFAxxrgu8eMmYIOsRcl7hN1uTLVsKOOYacV/rcJM3sfgQ==
 
+"@types/normalize-package-data@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
+  integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
+
 "@uphold/request-logger@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@uphold/request-logger/-/request-logger-2.0.0.tgz#c585c0bdb94210198945c6597e4fe23d6e63e084"
@@ -1597,14 +1602,14 @@ cors@^2.8.1:
     object-assign "^4"
     vary "^1"
 
-cosmiconfig@^5.0.7:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.0.tgz#45038e4d28a7fe787203aede9c25bca4a08b12c8"
-  integrity sha512-nxt+Nfc3JAqf4WIWd0jXLjTJZmsPLrA9DDc4nRw2KFJQJK7DNooqSXrNI7tzLG50CF8axczly5UV929tBmh/7g==
+cosmiconfig@^5.2.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.1.tgz#040f726809c591e77a17c0a3626ca45b4f168b1a"
+  integrity sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==
   dependencies:
     import-fresh "^2.0.0"
     is-directory "^0.3.1"
-    js-yaml "^3.13.0"
+    js-yaml "^3.13.1"
     parse-json "^4.0.0"
 
 coveralls@^3.0.2:
@@ -2947,10 +2952,10 @@ get-stdin@^4.0.1:
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
   integrity sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=
 
-get-stdin@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
-  integrity sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==
+get-stdin@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-7.0.0.tgz#8d5de98f15171a125c5e516643c7a6d0ea8a96f6"
+  integrity sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==
 
 get-stream@3.0.0, get-stream@^3.0.0:
   version "3.0.0"
@@ -3278,21 +3283,21 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-husky@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-1.3.1.tgz#26823e399300388ca2afff11cfa8a86b0033fae0"
-  integrity sha512-86U6sVVVf4b5NYSZ0yvv88dRgBSSXXmHaiq5pP4KDj5JVzdwKgBjEtUPOm8hcoytezFwbU+7gotXNhpHdystlg==
+husky@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-2.3.0.tgz#8b78ed24d763042df7fd899991985d65a976dd13"
+  integrity sha512-A/ZQSEILoq+mQM3yC3RIBSaw1bYXdkKnyyKVSUiJl+iBjVZc5LQEXdGY1ZjrDxC4IzfRPiJ0IqzEQGCN5TQa/A==
   dependencies:
-    cosmiconfig "^5.0.7"
+    cosmiconfig "^5.2.0"
     execa "^1.0.0"
     find-up "^3.0.0"
-    get-stdin "^6.0.0"
+    get-stdin "^7.0.0"
     is-ci "^2.0.0"
-    pkg-dir "^3.0.0"
+    pkg-dir "^4.1.0"
     please-upgrade-node "^3.1.1"
-    read-pkg "^4.0.1"
+    read-pkg "^5.1.1"
     run-node "^1.0.0"
-    slash "^2.0.0"
+    slash "^3.0.0"
 
 iconv-lite@0.4.23:
   version "0.4.23"
@@ -4031,7 +4036,7 @@ js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
-js-yaml@^3.11.0, js-yaml@^3.13.0:
+js-yaml@^3.11.0, js-yaml@^3.13.0, js-yaml@^3.13.1:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
@@ -4911,7 +4916,7 @@ nofilter@^1.0.1:
   resolved "https://registry.yarnpkg.com/nofilter/-/nofilter-1.0.2.tgz#d2887b9e76531fa251f20038c3843b993f1b3e26"
   integrity sha512-d38SORxm9UNoDsnPXajV9nBEebKX4/paXAlyRGnSjZuFbLLZDFUO4objr+tbybqsbqGXDWllb6gQoKUDc9q3Cg==
 
-normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
+normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-data@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
   integrity sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==
@@ -5475,10 +5480,10 @@ pkg-dir@^1.0.0:
   dependencies:
     find-up "^1.0.0"
 
-pkg-dir@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-3.0.0.tgz#2749020f239ed990881b1f71210d51eb6523bea3"
-  integrity sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==
+pkg-dir@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.1.0.tgz#aaeb91c0d3b9c4f74a44ad849f4de34781ae01de"
+  integrity sha512-55k9QN4saZ8q518lE6EFgYiu95u3BWkSajCifhdQjvLvmr8IpnRbhI+UGpWJQfa0KzDguHeeWT1ccO1PmkOi3A==
   dependencies:
     find-up "^3.0.0"
 
@@ -5758,14 +5763,15 @@ read-pkg@^1.0.0:
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
 
-read-pkg@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-4.0.1.tgz#963625378f3e1c4d48c85872b5a6ec7d5d093237"
-  integrity sha1-ljYlN48+HE1IyFhytabsfV0JMjc=
+read-pkg@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-5.1.1.tgz#5cf234dde7a405c90c88a519ab73c467e9cb83f5"
+  integrity sha512-dFcTLQi6BZ+aFUaICg7er+/usEoqFdQxiEBsEMNGoipenihtxxtdrQuBXvyANCEI8VuUIVYFgeHGx9sLLvim4w==
   dependencies:
-    normalize-package-data "^2.3.2"
+    "@types/normalize-package-data" "^2.4.0"
+    normalize-package-data "^2.5.0"
     parse-json "^4.0.0"
-    pify "^3.0.0"
+    type-fest "^0.4.1"
 
 "readable-stream@2 || 3", readable-stream@^3.0.0, readable-stream@^3.0.1, readable-stream@^3.0.2, readable-stream@^3.1.1:
   version "3.3.0"
@@ -6304,10 +6310,10 @@ sinon@^5.0.10:
     supports-color "^5.4.0"
     type-detect "^4.0.8"
 
-slash@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
-  integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
+slash@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
+  integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
 slice-ansi@^2.1.0:
   version "2.1.0"
@@ -6941,6 +6947,11 @@ type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5, type-detect@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
+
+type-fest@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.4.1.tgz#8bdf77743385d8a4f13ba95f610f5ccd68c728f8"
+  integrity sha512-IwzA/LSfD2vC1/YDYMv/zHP4rDF1usCwllsDpbolT3D4fUepIO7f9K70jjmUewU/LmGUKJcwcVtDCpnKk4BPMw==
 
 type-is@~1.6.16:
   version "1.6.16"

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,6 +1,6 @@
 {
   "name": "dappmanager.dnp.dappnode.eth",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Dappnode package responsible for providing the DappNode Package Manager",
   "avatar": "/ipfs/QmdT2GX9ybaoE25HBk7is8CDnfn2KaFTpZVkLdfkAQs1PN",
   "type": "dncore",
@@ -22,7 +22,11 @@
     "Eduardo Antuña <eduadiez@gmail.com> (https://github.com/eduadiez)",
     "DAppLion <dapplion@giveth.io> (https://github.com/dapplion)"
   ],
-  "keywords": ["DAppNodeCore", "Manager", "Installer"],
+  "keywords": [
+    "DAppNodeCore",
+    "Manager",
+    "Installer"
+  ],
   "links": {
     "ui": "http://my.dappnode/",
     "homepage": "https://github.com/dappnode/DNP_DAPPMANAGER#readme"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,25 +1,26 @@
-version: "3.4"
+version: '3.4'
 networks:
-  network:
-    driver: bridge
-    ipam:
-      config:
-        - subnet: 172.33.0.0/16
+    network:
+        driver: bridge
+        ipam:
+            config:
+                -
+                    subnet: 172.33.0.0/16
 volumes:
-  dappmanagerdnpdappnodeeth_data: {}
+    dappmanagerdnpdappnodeeth_data: {}
 services:
-  dappmanager.dnp.dappnode.eth:
-    build:
-      context: .
-      dockerfile: ./build/Dockerfile
-    image: "dappmanager.dnp.dappnode.eth:0.2.1"
-    container_name: DAppNodeCore-dappmanager.dnp.dappnode.eth
-    restart: always
-    volumes:
-      - "dappmanagerdnpdappnodeeth_data:/usr/src/app/dnp_repo/"
-      - "/usr/src/dappnode/DNCORE/:/usr/src/app/DNCORE/"
-      - "/var/run/docker.sock:/var/run/docker.sock"
-    dns: 172.33.1.2
-    networks:
-      network:
-        ipv4_address: 172.33.1.7
+    dappmanager.dnp.dappnode.eth:
+        build:
+            context: .
+            dockerfile: ./build/Dockerfile
+        image: 'dappmanager.dnp.dappnode.eth:0.2.2'
+        container_name: DAppNodeCore-dappmanager.dnp.dappnode.eth
+        restart: always
+        volumes:
+            - 'dappmanagerdnpdappnodeeth_data:/usr/src/app/dnp_repo/'
+            - '/usr/src/dappnode/DNCORE/:/usr/src/app/DNCORE/'
+            - '/var/run/docker.sock:/var/run/docker.sock'
+        dns: 172.33.1.2
+        networks:
+            network:
+                ipv4_address: 172.33.1.7


### PR DESCRIPTION
# Changelog

- Prevent DNP installation dangerous intermediate stage on download error https://github.com/dappnode/DNP_DAPPMANAGER/issues/205
- Fix bitcoin's API RPC typo. Fixes https://github.com/dappnode/DNP_ADMIN/issues/268
- Do not downgrade on dappget. Fixes https://github.com/dappnode/DNP_DAPPMANAGER/issues/202
- Fix dependency import order, which causes the lockPorts module to crash. Fixed https://github.com/dappnode/DNP_ADMIN/issues/281
- Add clean DAPPMANAGER's cache RPC. Fixes #210