### PR TITLE
dont load DNP until all downloads are successful

### DIFF
--- a/build/src/src/modules/packages.js
+++ b/build/src/src/modules/packages.js
@@ -32,21 +32,10 @@ async function download({ pkg, id }) {
   const imageName = manifest.image.path || `${name}_${version}.tar.xz`;
   const imageHash = manifest.image.hash;
   const imageSize = manifest.image.size;
-
-  // Write manifest and docker-compose
-  await writeFile(
-    validate.path(getPath.manifest(name, params, isCore)),
-    generate.manifest(manifest)
-  );
-  await writeFile(
-    validate.path(getPath.dockerCompose(name, params, isCore)),
-    generate.dockerCompose(manifest, params)
-  );
-
-  logUi({ id, name, message: "Starting download..." });
   const imagePath = validate.path(
     getPath.image(name, imageName, params, isCore)
   );
+
   // Keep track of the bytes downloaded. Log UI every 2%
   const onChunk = onChunkFactory(imageSize, 2, function(percent, bytes) {
     const message =
@@ -58,11 +47,47 @@ async function download({ pkg, id }) {
 
   // Wrap in try / catch to format the error
   try {
+    logUi({ id, name, message: "Starting download..." });
     await downloadImage(imageHash, imagePath, { onChunk });
   } catch (e) {
     e.message = `Can't download ${name} image: ${e.message}`;
     throw e;
   }
+
+  // Final log
+  logUi({ id, name, message: "Package downloaded" });
+}
+
+/**
+ * Handles the load of a package files.
+ * @param {object} kwargs which should contain at least
+ * - pkg: packageReq + its manifest. It is expected that in the previous step of the
+ *        installation the manifest is attached to this object.
+ * - id: task id to allow progress updates
+ * @returns {*}
+ */
+async function load({ pkg, id }) {
+  // call IPFS, store the file in the repo's folder
+  // load the image to docker
+  const { manifest } = pkg;
+  const { name, version, isCore } = manifest;
+  // Construct image path, if not provided
+  // "admin.dnp.dappnode.eth_0.2.0.tar.xz"
+  const imageName = manifest.image.path || `${name}_${version}.tar.xz`;
+
+  // Write manifest and docker-compose
+  await writeFile(
+    validate.path(getPath.manifest(name, params, isCore)),
+    generate.manifest(manifest)
+  );
+  await writeFile(
+    validate.path(getPath.dockerCompose(name, params, isCore)),
+    generate.dockerCompose(manifest, params)
+  );
+
+  const imagePath = validate.path(
+    getPath.image(name, imageName, params, isCore)
+  );
 
   logUi({ id, name, message: "Loading image..." });
   await docker.load(imagePath);
@@ -71,7 +96,7 @@ async function download({ pkg, id }) {
   await removeFile(imagePath);
 
   // Final log
-  logUi({ id, name, message: "Package downloaded" });
+  logUi({ id, name, message: "Package Loaded" });
 }
 
 /**
@@ -137,5 +162,6 @@ function onChunkFactory(totalAmount, resolution, callback) {
 
 module.exports = {
   download,
+  load,
   run
 };

--- a/build/src/src/modules/packages.js
+++ b/build/src/src/modules/packages.js
@@ -75,7 +75,14 @@ async function load({ pkg, id }) {
   // "admin.dnp.dappnode.eth_0.2.0.tar.xz"
   const imageName = manifest.image.path || `${name}_${version}.tar.xz`;
 
-  // Write manifest and docker-compose
+  const imagePath = validate.path(
+    getPath.image(name, imageName, params, isCore)
+  );
+
+  logUi({ id, name, message: "Loading image..." });
+  await docker.load(imagePath);
+
+  // Write manifest and docker-compose AFTER loading image
   await writeFile(
     validate.path(getPath.manifest(name, params, isCore)),
     generate.manifest(manifest)
@@ -84,13 +91,6 @@ async function load({ pkg, id }) {
     validate.path(getPath.dockerCompose(name, params, isCore)),
     generate.dockerCompose(manifest, params)
   );
-
-  const imagePath = validate.path(
-    getPath.image(name, imageName, params, isCore)
-  );
-
-  logUi({ id, name, message: "Loading image..." });
-  await docker.load(imagePath);
 
   logUi({ id, name, message: "Cleaning files..." });
   await removeFile(imagePath);

--- a/build/src/test/calls/installPackage.test.js
+++ b/build/src/test/calls/installPackage.test.js
@@ -30,6 +30,7 @@ describe("Call function: installPackage", function() {
   // Stub packages module. Resolve always returning nothing
   const packages = {
     download: sinon.fake.resolves(),
+    load: sinon.fake.resolves(),
     run: sinon.fake.resolves()
   };
 
@@ -101,35 +102,37 @@ describe("Call function: installPackage", function() {
     sinon.assert.calledWith(dappGet, { name: pkgName, req: pkgName, ver: "*" });
   });
 
+  const callKwargPkg = {
+    id: pkgName,
+    pkg: { manifest: { ...pkgManifest }, name: pkgName, ver: pkgVer }
+  };
+  const callKwargDep = {
+    id: pkgName,
+    pkg: { manifest: { ...depManifest }, name: depName, ver: depVer }
+  };
   // Step 3: Format the request and filter out already updated packages
   // Step 4: Download requested packages
   it("should have called download", async () => {
     sinon.assert.callCount(packages.download, 2);
     expect(packages.download.getCall(0).args).to.deep.equal(
-      [
-        {
-          id: pkgName,
-          pkg: {
-            manifest: { ...pkgManifest },
-            name: pkgName,
-            ver: pkgVer
-          }
-        }
-      ],
+      [callKwargPkg],
       `should call packages.download first for package ${pkgName}`
     );
     expect(packages.download.getCall(1).args).to.deep.equal(
-      [
-        {
-          id: pkgName,
-          pkg: {
-            manifest: { ...depManifest },
-            name: depName,
-            ver: depVer
-          }
-        }
-      ],
+      [callKwargDep],
       `should call packages.download second for dependency ${depName}`
+    );
+  });
+
+  it("should have called load", async () => {
+    sinon.assert.callCount(packages.load, 2);
+    expect(packages.load.getCall(0).args).to.deep.equal(
+      [callKwargPkg],
+      `should call packages.load first for package ${pkgName}`
+    );
+    expect(packages.load.getCall(1).args).to.deep.equal(
+      [callKwargDep],
+      `should call packages.load second for dependency ${depName}`
     );
   });
 
@@ -137,29 +140,11 @@ describe("Call function: installPackage", function() {
   it("should have called run", async () => {
     sinon.assert.callCount(packages.run, 2);
     expect(packages.run.getCall(0).args).to.deep.equal(
-      [
-        {
-          id: pkgName,
-          pkg: {
-            manifest: { ...pkgManifest },
-            name: pkgName,
-            ver: pkgVer
-          }
-        }
-      ],
+      [callKwargPkg],
       `should call packages.run second for dependency ${depName}`
     );
     expect(packages.run.getCall(1).args).to.deep.equal(
-      [
-        {
-          id: pkgName,
-          pkg: {
-            manifest: { ...depManifest },
-            name: depName,
-            ver: depVer
-          }
-        }
-      ],
+      [callKwargDep],
       `should call packages.run second for dependency ${depName}`
     );
   });

--- a/build/src/test/modules/packages.test.js
+++ b/build/src/test/modules/packages.test.js
@@ -84,7 +84,7 @@ describe("Util: package install / download", () => {
     }
   };
 
-  const { download, run } = proxyquire("modules/packages", {
+  const { download, load, run } = proxyquire("modules/packages", {
     "modules/downloadImage": downloadImage,
     "modules/docker": docker,
     "utils/generate": generate,
@@ -95,6 +95,20 @@ describe("Util: package install / download", () => {
 
   describe(".download", () => {
     download({
+      pkg: {
+        name: PACKAGE_NAME,
+        manifest: dnpManifest
+      }
+    });
+
+    // downloadImageSpy - IMAGE_HASH, IMAGE_PATH
+    it("ipfs.download should be called with IMAGE_HASH, IMAGE_PATH", () => {
+      sinon.assert.calledWith(downloadImageSpy, IMAGE_HASH, IMAGE_PATH);
+    });
+  });
+
+  describe(".load", () => {
+    load({
       pkg: {
         name: PACKAGE_NAME,
         manifest: dnpManifest
@@ -126,11 +140,6 @@ describe("Util: package install / download", () => {
         DOCKERCOMPOSE_PATH,
         DockerCompose
       ]);
-    });
-
-    // downloadImageSpy - IMAGE_HASH, IMAGE_PATH
-    it("ipfs.download should be called with IMAGE_HASH, IMAGE_PATH", () => {
-      sinon.assert.calledWith(downloadImageSpy, IMAGE_HASH, IMAGE_PATH);
     });
 
     it("docker.load should be called with IMAGE_PATH", () => {


### PR DESCRIPTION
If you install DNP_A which depends on DNP_B, it is very possible that DNP_A download succeeds but DNP_B doesn't because it's not available or it hasn't propagated yet. If that happened, DNP_A will be loaded and it's manifest and docker-compose will be changed. But the install will error.

To fix this dangerous intermediate state, now the installation is split in 3 steps:
1. Download: download all of DNP's images. If a single image is not available the installation will stop at this stage.
2. Load: load the docker image and overwrite the manifest and docker-compose of each DNP.
3. Run: docker-compose up each DNP