### PR TITLE
Be able to delete temporal / cached assets in the DAPPMANAGER

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -69,7 +69,7 @@ COPY build/entrypoint.sh .
 COPY build/dns_updater.sh /etc/periodic/1min/dns_updater
 RUN crontab -l | { cat; echo "*       *       *       *       *       run-parts   /etc/periodic/1min"; } | crontab -
 
-ENV DB_PATH /usr/src/app/DNCORE/dappmanagerdb.json
+ENV DB_PATH /usr/src/app/dnp_repo/dappmanagerdb.json
 
 # Copy the src the last as it's the more likely layer to change
 COPY --from=build /usr/src/app /usr/src/app

--- a/build/src/src/calls/restartPackage.js
+++ b/build/src/src/calls/restartPackage.js
@@ -20,6 +20,7 @@ const restartPackage = async ({ id }) => {
 
   if (id.includes("dappmanager.dnp.dappnode.eth")) {
     await restartPatch(id);
+    throw Error("The application should have stopped before this line");
   }
 
   // Combining rm && up doesn't prevent the installer from crashing

--- a/build/src/src/calls/restartPackageVolumes.js
+++ b/build/src/src/calls/restartPackageVolumes.js
@@ -1,5 +1,6 @@
 const fs = require("fs");
 const getPath = require("utils/getPath");
+const restartPatch = require("modules/restartPatch");
 const params = require("params");
 const docker = require("modules/docker");
 const dockerList = require("modules/dockerList");
@@ -24,7 +25,8 @@ async function restartPackageVolumes({ id }) {
     throw Error(`No docker-compose found: ${dockerComposePath}`);
   }
   if (id.includes("dappmanager.dnp.dappnode.eth")) {
-    throw Error("The installer cannot be restarted");
+    await restartPatch(id, { restartVolumes: true });
+    throw Error("The application should have stopped before this line");
   }
 
   // If there are no volumes don't do anything

--- a/build/src/src/params.js
+++ b/build/src/src/params.js
@@ -1,6 +1,15 @@
+const path = require("path");
+
 /**
  * DAPPMANAGER Parameters. This parameters are modified on execution for testing
  */
+
+/**
+ * Main persistent folders, linked with docker volumes
+ * - No need to prefix or sufix with slashes, path.join() is used in the whole app
+ */
+const DNCORE_DIR = "DNCORE"; // Bind volume (NOT deletable)
+const REPO_DIR = "dnp_repo"; // Named volume (deletable)
 
 module.exports = {
   // Autobahn parameters
@@ -8,10 +17,9 @@ module.exports = {
   autobahnRealm: "dappnode_admin",
 
   // Installer paths
-  CACHE_DIR: "./cache/",
-  REPO_DIR: "./dnp_repo/",
-  DNCORE_DIR: "DNCORE",
-  TEMP_TRANSFER_DIR: "DNCORE/.temp-transfer",
+  REPO_DIR,
+  DNCORE_DIR,
+  TEMP_TRANSFER_DIR: path.join(REPO_DIR, ".temp-transfer"),
 
   // Docker compose parameters
   DNS_SERVICE: "172.33.1.2",
@@ -29,5 +37,5 @@ module.exports = {
   CHAIN_DATA_UNTIL: 0,
 
   // User Action Logs filename
-  userActionLogsFilename: "DNCORE/userActionLogs.log"
+  userActionLogsFilename: path.join(REPO_DIR, "userActionLogs.log")
 };

--- a/build/src/src/utils/getPath.js
+++ b/build/src/src/utils/getPath.js
@@ -93,7 +93,7 @@ function getRepoDirPath(dnpName, params, isCore) {
   if (!params.DNCORE_DIR) throw Error("params.DNCORE_DIR must be defined");
   if (!params.REPO_DIR) throw Error("params.REPO_DIR must be defined");
   if (isCore) return params.DNCORE_DIR;
-  return params.REPO_DIR + dnpName;
+  return path.join(params.REPO_DIR + dnpName);
 }
 
 function getDockerComposeName(dnpName, isCore) {

--- a/build/src/test/calls/updatePackageEnv.test.js
+++ b/build/src/test/calls/updatePackageEnv.test.js
@@ -19,7 +19,6 @@ describe("Call function: updatePackageEnv", function() {
 
   const params = {
     ...paramsDefault,
-    CACHE_DIR: testDirectory,
     DNCORE_DIR: "DNCORE",
     REPO_DIR: testDirectory
   };

--- a/build/src/test/modules/ipfs/methods/catStreamToFs.test.js
+++ b/build/src/test/modules/ipfs/methods/catStreamToFs.test.js
@@ -21,9 +21,7 @@ const ipfs = {
 };
 
 // Define test parameters
-const params = {
-  CACHE_DIR: "test_files/"
-};
+const params = {};
 
 const catStreamToFs = proxyquire("modules/ipfs/methods/catStreamToFs", {
   "../ipfsSetup": ipfs,

--- a/build/src/test/modules/restartPatch.test.js
+++ b/build/src/test/modules/restartPatch.test.js
@@ -4,44 +4,45 @@ const getPath = require("utils/getPath");
 const fs = require("fs");
 
 describe("Util: restartPatch", () => {
-  let dockerComposeUpArg;
-  const docker = {
-    compose: {
-      up: async arg => {
-        dockerComposeUpArg = arg;
-      }
-    }
-  };
   const params = {
     DNCORE_DIR: "test_files",
     REPO_DIR: "test_files/"
   };
-  const IMAGE_NAME = "dappmanager.tar.xz:0.0.9";
-  const DOCKERCOMPOSE_RESTART_PATH = getPath.dockerCompose(
+  const imageName = "dappmanager.dnp.dappnode.eth:0.2.0";
+  const dockerComposeRestartPath = getPath.dockerCompose(
     "restart.dnp.dappnode.eth",
     params,
     true
   );
 
-  const restartPatch = proxyquire("modules/restartPatch", {
-    docker: docker,
-    params: params
-  });
-
-  it("Should call docker.compose.up with the correct arguments", () => {
-    restartPatch(IMAGE_NAME).then(() => {
-      expect(dockerComposeUpArg).to.be.equal(DOCKERCOMPOSE_RESTART_PATH);
+  describe("Just restart the DAPPMANAGER", () => {
+    let dockerComposeUpArg;
+    const docker = {
+      compose: {
+        up: async arg => {
+          dockerComposeUpArg = arg;
+        }
+      }
+    };
+    const restartPatch = proxyquire("modules/restartPatch", {
+      "modules/docker": docker,
+      "modules/dockerList": async () => [],
+      params: params
     });
-  });
 
-  it("Should generate a the correct docker-compose restart", () => {
-    const dc = fs.readFileSync(DOCKERCOMPOSE_RESTART_PATH, "utf8");
+    it("Should call docker.compose.up with the correct arguments", async () => {
+      await restartPatch(imageName);
+      expect(dockerComposeUpArg).to.be.equal(dockerComposeRestartPath);
+    });
 
-    const expectedDc = `version: '3.4'
+    it("Should generate a the correct docker-compose restart", () => {
+      const dc = fs.readFileSync(dockerComposeRestartPath, "utf8");
+
+      const expectedDc = `version: '3.4'
 
 services:
     restart.dnp.dappnode.eth:
-        image: dappmanager.tar.xz:0.0.9
+        image: dappmanager.dnp.dappnode.eth:0.2.0
         container_name: DAppNodeTool-restart.dnp.dappnode.eth
         volumes:
             - '/usr/src/dappnode/DNCORE/docker-compose-dappmanager.yml:/usr/src/app/DNCORE/docker-compose-dappmanager.yml'
@@ -50,7 +51,49 @@ services:
         entrypoint:
             docker-compose -f /usr/src/app/DNCORE/docker-compose-dappmanager.yml up -d`;
 
-    expect(dc).to.equal(expectedDc);
-    fs.unlinkSync(DOCKERCOMPOSE_RESTART_PATH);
+      expect(dc).to.equal(expectedDc);
+      fs.unlinkSync(dockerComposeRestartPath);
+    });
+  });
+
+  describe("Restart the DAPPMANAGER and delete its volumes", () => {
+    let dockerComposeUpArg;
+    const docker = {
+      compose: {
+        up: async arg => {
+          dockerComposeUpArg = arg;
+        }
+      }
+    };
+    const restartPatch = proxyquire("modules/restartPatch", {
+      "modules/docker": docker,
+      "modules/dockerList": async () => [],
+      params: params
+    });
+
+    it("Should call docker.compose.up with the correct arguments", async () => {
+      await restartPatch(imageName, { restartVolumes: true });
+      expect(dockerComposeUpArg).to.be.equal(dockerComposeRestartPath);
+    });
+
+    it("Should generate a the correct docker-compose restart", () => {
+      const dc = fs.readFileSync(dockerComposeRestartPath, "utf8");
+
+      const expectedDc = `version: '3.4'
+
+services:
+    restart.dnp.dappnode.eth:
+        image: dappmanager.dnp.dappnode.eth:0.2.0
+        container_name: DAppNodeTool-restart.dnp.dappnode.eth
+        volumes:
+            - '/usr/src/dappnode/DNCORE/docker-compose-dappmanager.yml:/usr/src/app/DNCORE/docker-compose-dappmanager.yml'
+            - '/usr/local/bin/docker-compose:/usr/local/bin/docker-compose'
+            - '/var/run/docker.sock:/var/run/docker.sock'
+        entrypoint:
+            docker-compose -f /usr/src/app/DNCORE/docker-compose-dappmanager.yml down --volumes; docker-compose -f /usr/src/app/DNCORE/docker-compose-dappmanager.yml up -d`;
+
+      expect(dc).to.equal(expectedDc);
+      fs.unlinkSync(dockerComposeRestartPath);
+    });
   });
 });


### PR DESCRIPTION
Be able to delete
- `userActionLogs.log` (activity logs)
- `dappmanagerdb.json` (local db, and lightweight assets cache)
- `.temp-transfer` (artifacts of the file manager transfers)

from the UI to potentially solve future bugs
