### PR TITLE
Add port mapping functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ build/src/test_files/*
 
 # Extra
 node_modules/\.yarn-integrity
+
+# Typescript build artifacts
+build/src/dist/

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,6 @@
-FROM node:10.15.3-alpine as build
+# Layer 1: Build the dependencies
+#####################################
+FROM node:10.15.3-alpine as build-deps
 
 RUN apk add --no-cache git python build-base bind-tools docker bash jq
 
@@ -9,15 +11,36 @@ COPY build/src/package.json ./
 COPY build/src/yarn.lock ./
 RUN yarn install --production
 
-# Add source
-COPY build/src .
-
 # Get this DNP version and git hash. Results in /usr/src/app/.version.json
 COPY .git .git
 COPY dappnode_package.json .
+COPY build/src/getVersionData.sh .
 RUN ./getVersionData.sh
 
-# This results in a single layer image
+
+# Layer 2: Build the source .ts files
+#####################################
+FROM node:10.15.3-alpine as build-src
+
+RUN apk add --no-cache git python build-base bind-tools docker bash jq
+
+WORKDIR /usr/src/app
+
+# Add source
+COPY build/src/package.json ./
+COPY build/src/yarn.lock ./
+RUN yarn add typescript
+COPY build/src .
+RUN yarn build
+
+# Typescript files
+# While there is mixed content, .ts files get compiled in the same location
+# to .js files, so the .ts should be ignored (deleted)
+RUN rm src/**/*.ts
+
+
+# Layer 3: Final layer
+#####################################
 FROM node:10.15.3-alpine
 
 ENV DOCKER_COMPOSE_VERSION 1.20.1
@@ -25,51 +48,53 @@ ENV DOCKER_COMPOSE_VERSION 1.20.1
 RUN apk add --no-cache curl bind-dev xz libltdl miniupnpc zip unzip
 
 RUN ALPINE_GLIBC_BASE_URL="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" && \
-    ALPINE_GLIBC_PACKAGE_VERSION="2.28-r0" && \
-    ALPINE_GLIBC_BASE_PACKAGE_FILENAME="glibc-$ALPINE_GLIBC_PACKAGE_VERSION.apk" && \
-    ALPINE_GLIBC_BIN_PACKAGE_FILENAME="glibc-bin-$ALPINE_GLIBC_PACKAGE_VERSION.apk" && \
-    ALPINE_GLIBC_I18N_PACKAGE_FILENAME="glibc-i18n-$ALPINE_GLIBC_PACKAGE_VERSION.apk" && \
-    apk add --no-cache --virtual=.build-dependencies wget ca-certificates && \
-    wget --no-verbose \
-    "https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub" \
-    -O "/etc/apk/keys/sgerrand.rsa.pub" && \
-    wget --no-verbose \
-    "$ALPINE_GLIBC_BASE_URL/$ALPINE_GLIBC_PACKAGE_VERSION/$ALPINE_GLIBC_BASE_PACKAGE_FILENAME" \
-    "$ALPINE_GLIBC_BASE_URL/$ALPINE_GLIBC_PACKAGE_VERSION/$ALPINE_GLIBC_BIN_PACKAGE_FILENAME" \
-    "$ALPINE_GLIBC_BASE_URL/$ALPINE_GLIBC_PACKAGE_VERSION/$ALPINE_GLIBC_I18N_PACKAGE_FILENAME" && \
-    apk add --no-cache \
-    "$ALPINE_GLIBC_BASE_PACKAGE_FILENAME" \
-    "$ALPINE_GLIBC_BIN_PACKAGE_FILENAME" \
-    "$ALPINE_GLIBC_I18N_PACKAGE_FILENAME" && \
-    \
-    rm "/etc/apk/keys/sgerrand.rsa.pub" && \
-    /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true && \
-    echo "export LANG=$LANG" > /etc/profile.d/locale.sh && \
-    \
-    apk del glibc-i18n && \
-    \
-    rm "/root/.wget-hsts" && \
-    apk del .build-dependencies && \
-    rm \
-    "$ALPINE_GLIBC_BASE_PACKAGE_FILENAME" \
-    "$ALPINE_GLIBC_BIN_PACKAGE_FILENAME" \
-    "$ALPINE_GLIBC_I18N_PACKAGE_FILENAME"
+  ALPINE_GLIBC_PACKAGE_VERSION="2.28-r0" && \
+  ALPINE_GLIBC_BASE_PACKAGE_FILENAME="glibc-$ALPINE_GLIBC_PACKAGE_VERSION.apk" && \
+  ALPINE_GLIBC_BIN_PACKAGE_FILENAME="glibc-bin-$ALPINE_GLIBC_PACKAGE_VERSION.apk" && \
+  ALPINE_GLIBC_I18N_PACKAGE_FILENAME="glibc-i18n-$ALPINE_GLIBC_PACKAGE_VERSION.apk" && \
+  apk add --no-cache --virtual=.build-dependencies wget ca-certificates && \
+  wget --no-verbose \
+  "https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub" \
+  -O "/etc/apk/keys/sgerrand.rsa.pub" && \
+  wget --no-verbose \
+  "$ALPINE_GLIBC_BASE_URL/$ALPINE_GLIBC_PACKAGE_VERSION/$ALPINE_GLIBC_BASE_PACKAGE_FILENAME" \
+  "$ALPINE_GLIBC_BASE_URL/$ALPINE_GLIBC_PACKAGE_VERSION/$ALPINE_GLIBC_BIN_PACKAGE_FILENAME" \
+  "$ALPINE_GLIBC_BASE_URL/$ALPINE_GLIBC_PACKAGE_VERSION/$ALPINE_GLIBC_I18N_PACKAGE_FILENAME" && \
+  apk add --no-cache \
+  "$ALPINE_GLIBC_BASE_PACKAGE_FILENAME" \
+  "$ALPINE_GLIBC_BIN_PACKAGE_FILENAME" \
+  "$ALPINE_GLIBC_I18N_PACKAGE_FILENAME" && \
+  \
+  rm "/etc/apk/keys/sgerrand.rsa.pub" && \
+  /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true && \
+  echo "export LANG=$LANG" > /etc/profile.d/locale.sh && \
+  \
+  apk del glibc-i18n && \
+  \
+  rm "/root/.wget-hsts" && \
+  apk del .build-dependencies && \
+  rm \
+  "$ALPINE_GLIBC_BASE_PACKAGE_FILENAME" \
+  "$ALPINE_GLIBC_BIN_PACKAGE_FILENAME" \
+  "$ALPINE_GLIBC_I18N_PACKAGE_FILENAME"
 
 RUN curl -L https://github.com/docker/compose/releases/download/$DOCKER_COMPOSE_VERSION/docker-compose-Linux-x86_64 > /usr/local/bin/docker-compose \
-    && chmod +x /usr/local/bin/docker-compose
+  && chmod +x /usr/local/bin/docker-compose
 
 # Copy files and do things that can change
 
 WORKDIR /usr/src/app
 
-COPY --from=build /usr/bin/nsupdate /usr/bin/nsupdate
-COPY --from=build /usr/bin/docker /usr/bin/docker
+COPY --from=build-deps /usr/bin/nsupdate /usr/bin/nsupdate
+COPY --from=build-deps /usr/bin/docker /usr/bin/docker
 
 COPY build/entrypoint.sh .
 COPY build/dns_updater.sh /etc/periodic/1min/dns_updater
 RUN crontab -l | { cat; echo "*       *       *       *       *       run-parts   /etc/periodic/1min"; } | crontab -
 
 # Copy the src last as it's the layer most likely to change
-COPY --from=build /usr/src/app /usr/src/app
+COPY --from=build-deps /usr/src/app /usr/src/app
+COPY build/src/test /usr/src/app/test
+COPY --from=build-src /usr/src/app/src /usr/src/app/src
 
 ENTRYPOINT /usr/src/app/entrypoint.sh

--- a/build/src/package.json
+++ b/build/src/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "NODE_PATH=src node src/index.js",
     "dev": "NODE_ENV=development npm start",
+    "build": "node_modules/.bin/tsc && npm run lint",
     "file": "NODE_PATH=src node",
     "test": "NODE_PATH=src TEST=true mocha --exit \"./{,!(node_modules)/**}/*.test.js\" ",
     "test:file": "NODE_PATH=src TEST=true mocha --exit ",
@@ -52,6 +53,9 @@
     "yamljs": "^0.3.0"
   },
   "devDependencies": {
+    "@types/express": "^4.17.0",
+    "@types/node": "^12.7.1",
+    "@types/yamljs": "^0.2.30",
     "chai": "^4.1.2",
     "coveralls": "^3.0.2",
     "eslint": "^5.16.0",
@@ -63,7 +67,8 @@
     "prettier": "^1.16.4",
     "proxyquire": "^2.0.1",
     "sinon": "^5.0.10",
-    "sinon-chai": "^3.1.0"
+    "sinon-chai": "^3.1.0",
+    "typescript": "^3.5.3"
   },
   "husky": {
     "hooks": {

--- a/build/src/src/calls/index.js
+++ b/build/src/src/calls/index.js
@@ -35,5 +35,6 @@ module.exports = {
   restartPackage: require("./restartPackage"),
   restartPackageVolumes: require("./restartPackageVolumes"),
   togglePackage: require("./togglePackage"),
-  updatePackageEnv: require("./updatePackageEnv")
+  updatePackageEnv: require("./updatePackageEnv"),
+  updatePortMappings: require("./updatePortMappings")
 };

--- a/build/src/src/calls/listPackages.js
+++ b/build/src/src/calls/listPackages.js
@@ -8,6 +8,7 @@ const docker = require("modules/docker");
 const parseDockerSystemDf = require("utils/parseDockerSystemDf");
 const getPath = require("utils/getPath");
 const envsHelper = require("utils/envsHelper");
+const appendIsPortDeletable = require("utils/appendIsPortDeletable");
 
 // This call can fail because of:
 //   Error response from daemon: a disk usage operation is already running
@@ -36,9 +37,9 @@ async function dockerSystemDf() {
  *   name: "admin.dnp.dappnode.eth", {string}
  *   shortName: "admin", {string}
  *   ports: [{
- *     PrivatePort: 2222, {number}
- *     PublicPort: 3333, {number}
- *     Type: "tcp" {string}
+ *     host: 2222, {number}
+ *     container: 3333, {number}
+ *     protocol: "TCP" {string}
  *   }, ... ], {array}
  *   volumes: [{
  *     type: "bind", {string}
@@ -89,6 +90,12 @@ const listPackages = async () => {
         const manifestFileData = fs.readFileSync(manifestPath, "utf8");
         try {
           dnp.manifest = JSON.parse(manifestFileData);
+
+          /**
+           * Add logic to know if a port is deletable
+           * = Not declared in the manifest
+           */
+          dnp.ports = appendIsPortDeletable(dnp.ports, dnp.manifest);
         } catch (e) {
           // Silence parsing errors
         }

--- a/build/src/src/calls/updatePortMappings.js
+++ b/build/src/src/calls/updatePortMappings.js
@@ -1,6 +1,6 @@
 const lockPorts = require("modules/lockPorts");
 // Utils
-const dockerComposeFile = require("utils/dockerComposeFile");
+const { getComposeInstance } = require("utils/dockerComposeFile");
 // External call
 const restartPackage = require("./restartPackage");
 const { eventBus, eventBusTag } = require("eventBus");
@@ -46,8 +46,8 @@ const updatePortMappings = async ({ id, portMappings }) => {
    *   { host: 30444, container: 30303, protocol: "UDP" }
    * ]
    */
-  const compose = dockerComposeFile(id);
-  compose.mergePortMappings(portMappings);
+  const compose = getComposeInstance(id);
+  compose.mergePortMapping(portMappings);
 
   // restartPackage triggers a eventBus.emit(eventBusTag.emitPackages);
   await restartPackage({ id });

--- a/build/src/src/calls/updatePortMappings.js
+++ b/build/src/src/calls/updatePortMappings.js
@@ -15,7 +15,7 @@ const { eventBus, eventBusTag } = require("eventBus");
  * ]
  * #### !!!!! NOTE take into account existing ephemeral ports
  */
-const updatePortMappings = async ({ id, portMappings }) => {
+const updatePortMappings = async ({ id, portMappings, options = {} }) => {
   if (!id) throw Error("kwarg id must be defined");
   if (!Array.isArray(portMappings))
     throw Error("kwarg portMappings must be an array");
@@ -47,7 +47,8 @@ const updatePortMappings = async ({ id, portMappings }) => {
    * ]
    */
   const compose = getComposeInstance(id);
-  compose.mergePortMapping(portMappings);
+  if (options.merge) compose.mergePortMapping(portMappings);
+  else compose.setPortMappings(portMappings);
 
   // restartPackage triggers a eventBus.emit(eventBusTag.emitPackages);
   await restartPackage({ id });

--- a/build/src/src/calls/updatePortMappings.js
+++ b/build/src/src/calls/updatePortMappings.js
@@ -1,0 +1,86 @@
+const params = require("params");
+// Modules
+const dockerList = require("modules/dockerList");
+// Utils
+const parse = require("utils/parse");
+const getPath = require("utils/getPath");
+const { stringIncludes } = require("utils/strings");
+// External call
+const restartPackage = require("./restartPackage");
+
+/**
+ * Updates the .env file of a package. If requested, also re-ups it
+ *
+ * @param {string} id DNP .eth name
+ * @param {array} portMappings [
+ *   { host: 30444, container: 30303, protocol: "UDP" },
+ *   { host: 4000, container: 4000, protocol: "TCP" }
+ * ]
+ * #### !!!!! NOTE take into account existing ephemeral ports
+ */
+const updatePortMappings = async ({ id, portMappings }) => {
+  if (!id) throw Error("kwarg id must be defined");
+  if (!Array.isArray(portMappings))
+    throw Error("kwarg portMappings must be an array");
+
+  /**
+   * 1. Fetch existing port mappings
+   * @param {array} dcPorts = [
+   *   { host: 30444, container: 30303, protocol: "UDP" }
+   * ]
+   */
+  const dnpList = await dockerList.listContainers();
+  const dnp = dnpList.find(_dnp => stringIncludes(_dnp.name, id));
+  if (!dnp) {
+    throw Error(`No DNP was found for name ${id}`);
+  }
+  const dockerComposePath = getPath.dockerCompose(dnp.name, params, dnp.isCore);
+  const dcPorts = parse.dockerComposePorts(dockerComposePath);
+
+  /**
+   * 2. Merge existing port mappings with new port mappings
+   * - Has to compute mergedPortMappings
+   * - [Ports to close]: Maybe not since the new natRenewal will automatically drop them
+   * - [Ports to open]: Can the natRenewal be triggered for a specific DNP?
+   * - [Locked ports]: The object in the container label has to be edited
+   * #### TODO: Since now there is the natRenewal, is the portsToClose array necessary anymore?
+   */
+  const mergedPortMappings = mergePortMappings(dcPorts, portMappings);
+
+  /**
+   * 3. Apply new merged port mappings
+   */
+  const dcObject = parse.editDockerComposePorts(
+    dockerComposePath,
+    mergedPortMappings
+  );
+  parse.writeDockerCompose(dockerComposePath, dcObject);
+
+  // restartPackage triggers a eventBus.emit(eventBusTag.emitPackages);
+  await restartPackage({ id });
+
+  return {
+    message: `Updated ${id} port mappings`,
+    logMessage: true,
+    userAction: true
+  };
+};
+
+// Utils
+
+function mergePortMappings(portMappings1, portMappings2) {
+  return Object.values({
+    ...transformPortMappingToObject(portMappings1),
+    ...transformPortMappingToObject(portMappings2)
+  });
+}
+
+function transformPortMappingToObject(portMappings) {
+  portMappings.reduce((obj, portMapping) => {
+    if (!container) throw Error(`Invalid portMapping, key container is null`);
+    const { container, type = "tcp" } = portMapping;
+    return { ...obj, [`${container}/${type.toLowerCase()}`]: portMapping };
+  }, {});
+}
+
+module.exports = updatePortMappings;

--- a/build/src/src/calls/updatePortMappings.js
+++ b/build/src/src/calls/updatePortMappings.js
@@ -21,11 +21,8 @@ const updatePortMappings = async ({ id, portMappings, options = {} }) => {
   if (!Array.isArray(portMappings))
     throw Error("kwarg portMappings must be an array");
 
-  if (
-    id === "dappmanager.dnp.dappnode.eth" &&
-    portMappings.find(({ host }) => !host)
-  )
-    throw Error("Can't assign ephemeral ports to the DAPPAMANAGER");
+  if (id === "dappmanager.dnp.dappnode.eth")
+    throw Error("Can not edit DAPPAMANAGER ports");
 
   /**
    * [NOTE]

--- a/build/src/src/eventBus.js
+++ b/build/src/src/eventBus.js
@@ -21,7 +21,8 @@ const eventBusTag = {
   call: "INTERNAL_CALL",
   logUserAction: "EVENT_BUS_LOGUSERACTION",
   emitChainData: "EMIT_CHAIN_DATA",
-  pushNotification: "PUSH_NOTIFICATION"
+  pushNotification: "PUSH_NOTIFICATION",
+  runNatRenewal: "RUN_NAT_RENEWAL"
 };
 
 /**

--- a/build/src/src/modules/docker/dockerSafe.js
+++ b/build/src/src/modules/docker/dockerSafe.js
@@ -44,6 +44,8 @@ async function dockerComposeUpSafe(dockerComposePath, options) {
           // Trigger a natRenewal update to open ports if necessary
           eventBus.emit(eventBusTag.runNatRenewal);
         }
+      } else {
+        throw e;
       }
     } else {
       throw e;

--- a/build/src/src/modules/docker/dockerSafe.js
+++ b/build/src/src/modules/docker/dockerSafe.js
@@ -34,18 +34,15 @@ async function dockerComposeUpSafe(dockerComposePath, options) {
 
         // unlockPorts will modify the docker-compose to remove the port bidnings
         // in order to let docker to assign new ones
-        const portsToClose = await unlockPorts(dockerComposePath);
-        if (portsToClose.length) {
-          const kwargs = { action: "close", ports: portsToClose };
-          eventBus.emit(eventBusTag.call, { callId: "managePorts", kwargs });
-        }
+        // The natRenewal loop will close them by not renewing the mapping
+        await unlockPorts(dockerComposePath);
 
         // Up the package and lock the ports again
         await docker.compose.up(dockerComposePath);
-        const portsToOpen = await lockPorts({ dockerComposePath });
-        if (portsToOpen.length) {
-          const kwargs = { action: "open", ports: portsToOpen };
-          eventBus.emit(eventBusTag.call, { callId: "managePorts", kwargs });
+        const newPortMappings = await lockPorts({ dockerComposePath });
+        if (newPortMappings.length) {
+          // Trigger a natRenewal update to open ports if necessary
+          eventBus.emit(eventBusTag.runNatRenewal);
         }
       }
     } else {

--- a/build/src/src/modules/dockerList.js
+++ b/build/src/src/modules/dockerList.js
@@ -257,6 +257,14 @@ async function listContainers() {
   return dnpListExtended;
 }
 
+async function getContainer(id) {
+  const dnpList = await listContainers();
+  return dnpList.find(
+    dnp => (dnp.name || "").includes(id) || (dnp.id || "").includes(id)
+  );
+}
+
 module.exports = {
-  listContainers
+  listContainers,
+  getContainer
 };

--- a/build/src/src/modules/dockerList.js
+++ b/build/src/src/modules/dockerList.js
@@ -188,7 +188,13 @@ async function listContainers() {
         image: c.Image,
         name: name,
         shortName: shortName(name),
-        ports: c.Ports,
+        ports: c.Ports.map(({ IP, PrivatePort, PublicPort, Type }) => ({
+          host: PublicPort || null,
+          container: PrivatePort || null,
+          protocol: Type === "udp" ? "UDP" : "TCP",
+          ephemeral: Boolean(PublicPort && PublicPort >= 32768),
+          ip: IP || "0.0.0.0"
+        })),
         volumes: c.Mounts.map(({ Type, Name, Source, Destination }) => ({
           type: Type,
           path: Source,

--- a/build/src/src/modules/lockPorts.js
+++ b/build/src/src/modules/lockPorts.js
@@ -42,10 +42,10 @@ const logs = require("logs.js")(module);
  *       name: "ipfs.dnp.dappnode.eth",
  *       ports: [
  *         {
- *           "IP": "0.0.0.0"
- *           "PrivatePort": 5000, // container port
- *           "PublicPort": 32769, // host port
- *           "Type": "tcp"
+ *           "ip": "0.0.0.0"
+ *           "container": 5000,
+ *           "host": 32769,
+ *           "protocol": "TCP"
  *         },
  *         ...
  *       ],
@@ -91,11 +91,10 @@ async function lockPorts(id) {
   // port = "5000/udp"
   const newPortMappings = ephemeralPortMappings.map(
     ({ container, protocol }) => {
-      // portNumber or p.PrivatePort may be of type integer
       const currentPort = dnp.ports.find(
         p =>
-          String(p.PrivatePort) === String(container) &&
-          stringIncludes(protocol, p.Type)
+          String(p.container) === String(container) &&
+          stringIncludes(protocol, p.protocol)
       );
       if (!currentPort) {
         throw Error(
@@ -106,7 +105,7 @@ async function lockPorts(id) {
       }
 
       // Now convert "30303/udp" to "32769:30303/udp"
-      return { host: String(currentPort.PublicPort), container, protocol };
+      return { host: String(currentPort.host), container, protocol };
     }
   );
 

--- a/build/src/src/params.js
+++ b/build/src/src/params.js
@@ -8,8 +8,13 @@ const path = require("path");
  * Main persistent folders, linked with docker volumes
  * - No need to prefix or sufix with slashes, path.join() is used in the whole app
  */
-const DNCORE_DIR = "DNCORE"; // Bind volume
-const REPO_DIR = "dnp_repo"; // Named volume
+let DNCORE_DIR = "DNCORE"; // Bind volume
+let REPO_DIR = "dnp_repo"; // Named volume
+
+if (process.env.TEST) {
+  DNCORE_DIR = "test_files/";
+  REPO_DIR = "test_files/";
+}
 
 module.exports = {
   // Autobahn parameters

--- a/build/src/src/utils/appendIsPortDeletable.js
+++ b/build/src/src/utils/appendIsPortDeletable.js
@@ -1,0 +1,16 @@
+const { parsePortMappings } = require("utils/dockerComposeParsers");
+
+function appendIsPortDeletable(portMappings, manifest) {
+  const parsedManifestPorts = parsePortMappings(manifest.image.ports || []);
+
+  return portMappings.map(port => ({
+    ...port,
+    deletable: !parsedManifestPorts.find(
+      manifestPort =>
+        manifestPort.container == port.container &&
+        manifestPort.protocol == port.protocol
+    )
+  }));
+}
+
+module.exports = appendIsPortDeletable;

--- a/build/src/src/utils/asyncFlows.js
+++ b/build/src/src/utils/asyncFlows.js
@@ -1,0 +1,23 @@
+const async = require("async");
+
+function runOnlyOneSequentially(fn) {
+  // create a cargo object with an infinite payload
+  var cargo = async.cargo(function(tasks, callback) {
+    fn(...tasks[0].args).then(() => {
+      callback();
+    });
+  }, 1e9);
+
+  return function(...args) {
+    cargo.push({ args });
+  };
+}
+
+function pause(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+module.exports = {
+  runOnlyOneSequentially,
+  pause
+};

--- a/build/src/src/utils/dockerComposeFile.js
+++ b/build/src/src/utils/dockerComposeFile.js
@@ -1,75 +1,75 @@
-const parse = require("utils/parse");
-const getPath = require("utils/getPath");
-const { stringIncludes } = require("utils/strings");
-
+"use strict";
+var __importDefault =
+  (this && this.__importDefault) ||
+  function(mod) {
+    return mod && mod.__esModule ? mod : { default: mod };
+  };
+Object.defineProperty(exports, "__esModule", { value: true });
+const dockerComposeParsers_1 = require("./dockerComposeParsers");
+const fs_1 = __importDefault(require("fs"));
+const path_1 = __importDefault(require("path"));
+const yamljs_1 = __importDefault(require("yamljs"));
+const params = require("params");
 /**
  * Utils to read or edit a docker-compose file
  */
-
-/**
- * Internal methods that purely modify JSON
- */
-
-function mergePortMappings(portMappings1, portMappings2) {
-  return Object.values({
-    ...transformPortMappingToObject(portMappings1),
-    ...transformPortMappingToObject(portMappings2)
-  });
+function getDockerComposePath(id) {
+  const composeCorePath = path_1.default.join(
+    params.DNCORE_DIR,
+    `docker-compose-${(id || "").split(".")[0]}.yml`
+  );
+  const dnpPath = path_1.default.join(
+    params.REPO_DIR,
+    id,
+    "docker-compose.yml"
+  );
+  if (fs_1.default.existsSync(composeCorePath)) return composeCorePath;
+  else if (fs_1.default.existsSync(dnpPath)) return dnpPath;
+  else throw Error(`No docker-compose found for ${id}`);
 }
-
-function transformPortMappingToObject(portMappings) {
-  portMappings.reduce((obj, portMapping) => {
-    if (!container) throw Error(`Invalid portMapping, key container is null`);
-    const { container, type = "tcp" } = portMapping;
-    return { ...obj, [`${container}/${type.toLowerCase()}`]: portMapping };
-  }, {});
+function readComposeObj(dockerComposePath) {
+  const dcString = fs_1.default.readFileSync(dockerComposePath, "utf-8");
+  return yamljs_1.default.parse(dcString);
 }
-
-function mergePortMappingWithInstance(id, portMappings) {
-  const compose = getComposeInstance(id);
-  compose.mergePortMapping(portMappings);
-  compose.write();
+function writeComposeObj(dockerComposePath, composeObj) {
+  const composeString = yamljs_1.default.stringify(composeObj, 8, 2);
+  fs_1.default.writeFileSync(dockerComposePath, composeString, "utf-8");
 }
-
 function getComposeInstance(idOrObject) {
+  let dockerComposePath = "";
   let composeObj;
-  if (typeof idOrObject === "string") composeObj = readcomposeObj(idOrObject);
-  else if (typeof idOrObject === "object") composeObj = idOrObject;
-  else throw Error(`Invalid type for idOrObject: ${typeof idOrObject}`);
-
+  if (typeof idOrObject === "string") {
+    dockerComposePath = getDockerComposePath(idOrObject);
+    composeObj = readComposeObj(dockerComposePath);
+  } else if (typeof idOrObject === "object") {
+    composeObj = idOrObject;
+  } else {
+    throw Error(`Invalid type for idOrObject: ${typeof idOrObject}`);
+  }
   const dnpName = Object.getOwnPropertyNames(composeObj.services)[0];
   const service = composeObj.services[dnpName];
-
-  function getService() {
-    return composeObj.services[dnpName];
+  function write() {
+    composeObj.services[dnpName] = service;
+    writeComposeObj(dockerComposePath, composeObj);
   }
-
-  function getPorts() {
-    return getService().ports || [];
+  function getPortMappings() {
+    return dockerComposeParsers_1.parsePortMappings(service.ports || []);
   }
-
-  function parsePortMappings() {
-    const ports = service.ports || [];
-    return ports.map(portString => {
-      const [portMapping, type = "tcp"] = portString.split("/");
-      const [host, container] = portMapping.split(":");
-      // HOST:CONTAINER/type, return [HOST, CONTAINER/type]
-      if (container) return { host, container, type };
-      // CONTAINER/type, return [null, CONTAINER/type]
-      else return { container: host, type };
-    });
-  }
-
-  function mergePortMapping(portMappings) {
-    const currentPortMappings = parsePortMappings(composeObj);
-    const mergedPortMappings = mergePortMappings(
-      currentPortMappings,
-      portMappings
+  function mergePortMapping(newPortMappings) {
+    service.ports = dockerComposeParsers_1.stringifyPortMappings(
+      dockerComposeParsers_1.mergePortMappings(
+        getPortMappings(),
+        newPortMappings
+      )
     );
-    composeObj = writePortMappings(composeObj, mergedPortMappings);
+    write();
   }
-
   return {
-    mergePortMapping
+    getPortMappings,
+    mergePortMapping,
+    write,
+    // Constant getter
+    dockerComposePath
   };
 }
+exports.getComposeInstance = getComposeInstance;

--- a/build/src/src/utils/dockerComposeFile.js
+++ b/build/src/src/utils/dockerComposeFile.js
@@ -13,7 +13,7 @@ const params = require("params");
 /**
  * Utils to read or edit a docker-compose file
  */
-function getDockerComposePath(id) {
+function getDockerComposePath(id, newFile) {
   const composeCorePath = path_1.default.join(
     params.DNCORE_DIR,
     `docker-compose-${(id || "").split(".")[0]}.yml`
@@ -25,8 +25,10 @@ function getDockerComposePath(id) {
   );
   if (fs_1.default.existsSync(composeCorePath)) return composeCorePath;
   else if (fs_1.default.existsSync(dnpPath)) return dnpPath;
+  else if (newFile) return dnpPath;
   else throw Error(`No docker-compose found for ${id}`);
 }
+exports.getDockerComposePath = getDockerComposePath;
 function readComposeObj(dockerComposePath) {
   const dcString = fs_1.default.readFileSync(dockerComposePath, "utf-8");
   return yamljs_1.default.parse(dcString);

--- a/build/src/src/utils/dockerComposeFile.js
+++ b/build/src/src/utils/dockerComposeFile.js
@@ -1,0 +1,75 @@
+const parse = require("utils/parse");
+const getPath = require("utils/getPath");
+const { stringIncludes } = require("utils/strings");
+
+/**
+ * Utils to read or edit a docker-compose file
+ */
+
+/**
+ * Internal methods that purely modify JSON
+ */
+
+function mergePortMappings(portMappings1, portMappings2) {
+  return Object.values({
+    ...transformPortMappingToObject(portMappings1),
+    ...transformPortMappingToObject(portMappings2)
+  });
+}
+
+function transformPortMappingToObject(portMappings) {
+  portMappings.reduce((obj, portMapping) => {
+    if (!container) throw Error(`Invalid portMapping, key container is null`);
+    const { container, type = "tcp" } = portMapping;
+    return { ...obj, [`${container}/${type.toLowerCase()}`]: portMapping };
+  }, {});
+}
+
+function mergePortMappingWithInstance(id, portMappings) {
+  const compose = getComposeInstance(id);
+  compose.mergePortMapping(portMappings);
+  compose.write();
+}
+
+function getComposeInstance(idOrObject) {
+  let composeObj;
+  if (typeof idOrObject === "string") composeObj = readcomposeObj(idOrObject);
+  else if (typeof idOrObject === "object") composeObj = idOrObject;
+  else throw Error(`Invalid type for idOrObject: ${typeof idOrObject}`);
+
+  const dnpName = Object.getOwnPropertyNames(composeObj.services)[0];
+  const service = composeObj.services[dnpName];
+
+  function getService() {
+    return composeObj.services[dnpName];
+  }
+
+  function getPorts() {
+    return getService().ports || [];
+  }
+
+  function parsePortMappings() {
+    const ports = service.ports || [];
+    return ports.map(portString => {
+      const [portMapping, type = "tcp"] = portString.split("/");
+      const [host, container] = portMapping.split(":");
+      // HOST:CONTAINER/type, return [HOST, CONTAINER/type]
+      if (container) return { host, container, type };
+      // CONTAINER/type, return [null, CONTAINER/type]
+      else return { container: host, type };
+    });
+  }
+
+  function mergePortMapping(portMappings) {
+    const currentPortMappings = parsePortMappings(composeObj);
+    const mergedPortMappings = mergePortMappings(
+      currentPortMappings,
+      portMappings
+    );
+    composeObj = writePortMappings(composeObj, mergedPortMappings);
+  }
+
+  return {
+    mergePortMapping
+  };
+}

--- a/build/src/src/utils/dockerComposeFile.ts
+++ b/build/src/src/utils/dockerComposeFile.ts
@@ -23,7 +23,7 @@ interface ComposeObj {
  * Utils to read or edit a docker-compose file
  */
 
-function getDockerComposePath(id: string) {
+export function getDockerComposePath(id: string, newFile?: boolean) {
   const composeCorePath = path.join(
     params.DNCORE_DIR,
     `docker-compose-${(id || "").split(".")[0]}.yml`
@@ -32,6 +32,7 @@ function getDockerComposePath(id: string) {
 
   if (fs.existsSync(composeCorePath)) return composeCorePath;
   else if (fs.existsSync(dnpPath)) return dnpPath;
+  else if (newFile) return dnpPath;
   else throw Error(`No docker-compose found for ${id}`);
 }
 

--- a/build/src/src/utils/dockerComposeFile.ts
+++ b/build/src/src/utils/dockerComposeFile.ts
@@ -1,0 +1,86 @@
+import {
+  parsePortMappings,
+  stringifyPortMappings,
+  mergePortMappings,
+  PortMapping
+} from "./dockerComposeParsers";
+import fs from "fs";
+import path from "path";
+import yaml from "yamljs";
+const params = require("params");
+
+interface Service {
+  ports: string[];
+}
+
+interface ComposeObj {
+  services: {
+    [dnpName: string]: Service;
+  };
+}
+
+/**
+ * Utils to read or edit a docker-compose file
+ */
+
+function getDockerComposePath(id: string) {
+  const composeCorePath = path.join(
+    params.DNCORE_DIR,
+    `docker-compose-${(id || "").split(".")[0]}.yml`
+  );
+  const dnpPath = path.join(params.REPO_DIR, id, "docker-compose.yml");
+
+  if (fs.existsSync(composeCorePath)) return composeCorePath;
+  else if (fs.existsSync(dnpPath)) return dnpPath;
+  else throw Error(`No docker-compose found for ${id}`);
+}
+
+function readComposeObj(dockerComposePath: string) {
+  const dcString = fs.readFileSync(dockerComposePath, "utf-8");
+  return yaml.parse(dcString);
+}
+
+function writeComposeObj(dockerComposePath: string, composeObj: ComposeObj) {
+  const composeString = yaml.stringify(composeObj, 8, 2);
+  fs.writeFileSync(dockerComposePath, composeString, "utf-8");
+}
+
+export function getComposeInstance(idOrObject: string | ComposeObj) {
+  let dockerComposePath: string = "";
+  let composeObj: ComposeObj;
+  if (typeof idOrObject === "string") {
+    dockerComposePath = getDockerComposePath(idOrObject);
+    composeObj = readComposeObj(dockerComposePath);
+  } else if (typeof idOrObject === "object") {
+    composeObj = idOrObject;
+  } else {
+    throw Error(`Invalid type for idOrObject: ${typeof idOrObject}`);
+  }
+
+  const dnpName = Object.getOwnPropertyNames(composeObj.services)[0];
+  const service: Service = composeObj.services[dnpName];
+
+  function write() {
+    composeObj.services[dnpName] = service;
+    writeComposeObj(dockerComposePath, composeObj);
+  }
+
+  function getPortMappings() {
+    return parsePortMappings(service.ports || []);
+  }
+
+  function mergePortMapping(newPortMappings: PortMapping[]) {
+    service.ports = stringifyPortMappings(
+      mergePortMappings(getPortMappings(), newPortMappings)
+    );
+    write();
+  }
+
+  return {
+    getPortMappings,
+    mergePortMapping,
+    write,
+    // Constant getter
+    dockerComposePath
+  };
+}

--- a/build/src/src/utils/dockerComposeFile.ts
+++ b/build/src/src/utils/dockerComposeFile.ts
@@ -77,9 +77,15 @@ export function getComposeInstance(idOrObject: string | ComposeObj) {
     write();
   }
 
+  function setPortMappings(newPortMappings: PortMapping[]) {
+    service.ports = stringifyPortMappings(newPortMappings);
+    write();
+  }
+
   return {
     getPortMappings,
     mergePortMapping,
+    setPortMappings,
     write,
     // Constant getter
     dockerComposePath

--- a/build/src/src/utils/dockerComposeParsers.js
+++ b/build/src/src/utils/dockerComposeParsers.js
@@ -1,0 +1,22 @@
+function parsePortMappings(portsArray) {
+  return portsArray.map(portString => {
+    const [portMapping, type = "tcp"] = portString.split("/");
+    const [host, container] = portMapping.split(":");
+    // HOST:CONTAINER/type, return [HOST, CONTAINER/type]
+    if (container) return { host, container, type };
+    // CONTAINER/type, return [null, CONTAINER/type]
+    else return { container: host, type };
+  });
+}
+
+function stringifyPortMappings(portMappings) {
+  // Stringify ports
+  return portMappings.map(({ host, container, type }) => {
+    const parsedType = (type || "").toLowerCase() === "udp" ? "/udp" : "";
+    return host
+      ? // HOST:CONTAINER/type, if HOST
+        [host, container].join(":") + parsedType
+      : // CONTAINER/type, if no HOST
+        container + parsedType;
+  });
+}

--- a/build/src/src/utils/dockerComposeParsers.ts
+++ b/build/src/src/utils/dockerComposeParsers.ts
@@ -1,8 +1,15 @@
-"use strict";
 /**
  * Internal methods that purely modify JSON
  */
-Object.defineProperty(exports, "__esModule", { value: true });
+
+type PortProtocol = "UDP" | "TCP";
+
+export interface PortMapping {
+  container: string;
+  host?: string;
+  protocol: PortProtocol;
+}
+
 /**
  * Parses a port string array from a docker-compose.yml
  *
@@ -12,22 +19,25 @@ Object.defineProperty(exports, "__esModule", { value: true });
  *   [{ host: 30444, container: 30303, protocol: "UDP" }, ...]
  *
  */
-function parsePortMappings(portsArray) {
+export function parsePortMappings(portsArray: string[]): PortMapping[] {
   return portsArray.map(portString => {
     const [portMapping, protocolString = ""] = portString.split("/");
+
     // Make sure the protocol is correct
     const protocolParsed =
       protocolString.toLowerCase() === "udp" ? "UDP" : "TCP";
     // Cast the protocolString to a PortProtocol type
-    const protocol = protocolParsed;
+    const protocol: PortProtocol = protocolParsed as PortProtocol;
+
     let [host, container] = portMapping.split(":");
+
     // HOST:CONTAINER/protocol, return [HOST, CONTAINER/protocol]
     if (container) return { host, container, protocol };
     // CONTAINER/protocol, return [null, CONTAINER/protocol]
     else return { container: host, protocol };
   });
 }
-exports.parsePortMappings = parsePortMappings;
+
 /**
  * Stringifies a PortMapping array to be compatible for a docker-compose.yml
  *
@@ -36,7 +46,7 @@ exports.parsePortMappings = parsePortMappings;
  * @returns portsArray ready for a docker-compose.yml
  *   ["30505:4001/udp", "30505:4001"]
  */
-function stringifyPortMappings(portMappings) {
+export function stringifyPortMappings(portMappings: PortMapping[]): string[] {
   // Stringify ports
   return portMappings.map(({ host, container, protocol }) => {
     const parsedProtocol =
@@ -48,7 +58,7 @@ function stringifyPortMappings(portMappings) {
         container + parsedProtocol;
   });
 }
-exports.stringifyPortMappings = stringifyPortMappings;
+
 /**
  * Merges two port mapping arrays ensuring container ports are unique.
  * If there are duplicate mappings for the same container port number and protocol,
@@ -58,29 +68,29 @@ exports.stringifyPortMappings = stringifyPortMappings;
  * @param portMappings2 PortMapping array with MORE priority
  * @returns merged PortMapping array
  */
-function mergePortMappings(portMappings1, portMappings2) {
+export function mergePortMappings(
+  portMappings1: PortMapping[],
+  portMappings2: PortMapping[]
+): PortMapping[] {
   // Give each port mapping a deterministic key so mappings targeting
   // the same container port number and protocol get overwritten
-  function transformPortMappingToObject(portMappings) {
+  function transformPortMappingToObject(portMappings: PortMapping[]) {
     return portMappings.reduce((obj, portMapping) => {
       const { container, protocol } = portMapping;
       if (!container) throw Error(`Invalid portMapping, key container is null`);
       // Construct a unique key per container port number and protocol
-      return Object.assign({}, obj, {
-        [`${container}/${protocol || "TCP"}`]: portMapping
-      });
+      return { ...obj, [`${container}/${protocol || "TCP"}`]: portMapping };
     }, {});
   }
-  const mergedPortMappings = Object.values(
-    Object.assign(
-      {},
-      transformPortMappingToObject(portMappings1),
-      transformPortMappingToObject(portMappings2)
-    )
-  );
+
+  const mergedPortMappings: PortMapping[] = Object.values({
+    ...transformPortMappingToObject(portMappings1),
+    ...transformPortMappingToObject(portMappings2)
+  });
+
   // Make the order deterministic, by port number and then TCP first
-  return mergedPortMappings.sort(function(a, b) {
-    function numGetter(portMapping) {
+  return mergedPortMappings.sort(function(a: PortMapping, b: PortMapping) {
+    function numGetter(portMapping: PortMapping) {
       return (
         parseInt(portMapping.container) +
         (portMapping.protocol === "UDP" ? 0.5 : 0)
@@ -89,4 +99,3 @@ function mergePortMappings(portMappings1, portMappings2) {
     return numGetter(a) - numGetter(b);
   });
 }
-exports.mergePortMappings = mergePortMappings;

--- a/build/src/src/utils/parse.js
+++ b/build/src/src/utils/parse.js
@@ -79,6 +79,32 @@ function dockerComposePorts(dockerComposePath) {
   });
 }
 
+/**
+ * Edit the ports of an existing docker-compose.yml
+ * @param {string} dockerComposePath
+ * @param {array} dcPorts [
+ *   { host: 30444, container: 30303, protocol: "UDP" },
+ *   { host: 4000, container: 4000, protocol: "TCP" }
+ * ]
+ * @returns {object} dcObject, docker-compose.yml json object
+ */
+function editDockerComposePorts(dockerComposePath, dcPorts) {
+  // Stringify ports
+  const stringifiedPorts = dcPorts.map(({ host, container, type }) => {
+    const parsedType = (type || "").toLowerCase() === "udp" ? "/udp" : "";
+    return host
+      ? // HOST:CONTAINER/type, if HOST
+        [host, container].join(":") + parsedType
+      : // CONTAINER/type, if no HOST
+        container + parsedType;
+  });
+
+  const dc = readDockerCompose(dockerComposePath);
+  const packageName = Object.getOwnPropertyNames(dc.services)[0];
+  dc.services[packageName].ports = stringifiedPorts;
+  return dc;
+}
+
 function envFile(envFileData = "") {
   // Parses key1=value1 files, splited by new line
   //        key2=value2
@@ -173,6 +199,7 @@ module.exports = {
   serviceVolumes,
   containerName,
   dockerComposePorts,
+  editDockerComposePorts,
   envFile,
   stringifyEnvs,
   packageReq,

--- a/build/src/src/watchers/natRenewal/getPortsToOpen.js
+++ b/build/src/src/watchers/natRenewal/getPortsToOpen.js
@@ -32,24 +32,21 @@ async function getPortsToOpen() {
      *   isCore: false, {bool}
      *   name: "admin.dnp.dappnode.eth", {string}
      *   ports: [{
-     *     PrivatePort: 2222, {number}
-     *     PublicPort: 3333, {number}
-     *     Type: "tcp" {string}
+     *     container: 2222, {number}
+     *     host: 3333, {number}
+     *     protocol: "tcp" {string}
      *   }, ... ], {array}
      *   running: true, {bool}
      *   portsToClose: [ {portNumber: 30303, protocol: 'UDP'}, ...], {array}
      * }, ... ]
-     *
-     * [NOTE]: PublicPort is the host's port
      */
     const dnpList = await dockerList.listContainers();
     for (const dnp of dnpList) {
       if (dnp.running) {
         // If DNP is running the port mapping is available in the dnpList
         for (const port of dnp.ports || []) {
-          // PublicPort is the host's port
-          if (port.PublicPort) {
-            addPort(port.Type, port.PublicPort);
+          if (port.host) {
+            addPort(port.protocol, port.host);
           }
         }
       } else {
@@ -64,7 +61,7 @@ async function getPortsToOpen() {
            * @param {array} dockerComposePorts = [{
            *   host: "32638",
            *   container: "30303",
-           *   type: "udp"
+           *   protocol: "udp"
            * }]
            */
           const dockerComposePorts = parse.dockerComposePorts(

--- a/build/src/test/calls/installPackage.test.js
+++ b/build/src/test/calls/installPackage.test.js
@@ -57,8 +57,8 @@ describe("Call function: installPackage", function() {
   };
 
   // Simulate that only the dependency has p2p ports
-  const lockPorts = sinon.stub().callsFake(async ({ pkg }) => {
-    if (pkg.name === depName) return depPortsToOpen;
+  const lockPorts = sinon.stub().callsFake(async id => {
+    if (id === depName) return depPortsToOpen;
     else return [];
   });
 
@@ -155,17 +155,8 @@ describe("Call function: installPackage", function() {
     // eventBus should be called once to open ports, and then to emitPackages
     sinon.assert.callCount(eventBusPackage.eventBus.emit, 3);
     expect(eventBusPackage.eventBus.emit.getCall(0).args).to.deep.equal(
-      [
-        eventBusTag.call,
-        {
-          callId: "managePorts",
-          kwargs: {
-            action: "open",
-            ports: depPortsToOpen
-          }
-        }
-      ],
-      `eventBus.emit first call must be to open the dependencies' ports`
+      [eventBusTag.runNatRenewal],
+      `eventBus.emit first call must be a NAT renewal call`
     );
   });
 

--- a/build/src/test/calls/managePorts.test.js
+++ b/build/src/test/calls/managePorts.test.js
@@ -13,7 +13,8 @@ describe("Call function: managePorts", function() {
   };
 
   const managePorts = proxyquire("calls/managePorts", {
-    "modules/upnpc": upnpc
+    "modules/upnpc": upnpc,
+    "utils/getLocalIp": async () => "0.0.0.0"
   });
 
   it("should open the requested ports", async () => {

--- a/build/src/test/modules/dockerList.test.js
+++ b/build/src/test/modules/dockerList.test.js
@@ -34,8 +34,11 @@ describe("dockerList", function() {
         shortName: "otpweb",
         ports: [
           {
-            PrivatePort: 80,
-            Type: "tcp"
+            host: null,
+            container: 80,
+            protocol: "TCP",
+            ephemeral: false,
+            ip: "0.0.0.0"
           }
         ],
         volumes: [],
@@ -56,40 +59,38 @@ describe("dockerList", function() {
         shortName: "nginx-proxy",
         ports: [
           {
-            IP: "0.0.0.0",
-            PrivatePort: 443,
-            PublicPort: 443,
-            Type: "tcp"
+            host: 443,
+            container: 443,
+            protocol: "TCP",
+            ephemeral: false,
+            ip: "0.0.0.0"
           },
           {
-            IP: "0.0.0.0",
-            PrivatePort: 80,
-            PublicPort: 80,
-            Type: "tcp"
+            host: 80,
+            container: 80,
+            protocol: "TCP",
+            ephemeral: false,
+            ip: "0.0.0.0"
           }
         ],
         volumes: [
-          {
-            type: "bind",
-            path: "/root/certs",
-            dest: "/etc/nginx/certs"
-          },
+          { type: "bind", path: "/root/certs", dest: "/etc/nginx/certs" },
           {
             type: "volume",
-            name:
-              "1f6ceacbdb011451622aa4a5904309765dc2bfb0f4affe163f4e22cba4f7725b",
             path: "",
             dest: "/etc/nginx/dhparam",
+            name:
+              "1f6ceacbdb011451622aa4a5904309765dc2bfb0f4affe163f4e22cba4f7725b",
             users: ["nginx-proxy.dnp.dappnode.eth"],
             owner: "nginx-proxy.dnp.dappnode.eth",
             isOwner: true
           },
           {
             type: "volume",
-            name: "nginxproxydnpdappnodeeth_vhost.d",
             path:
               "/var/lib/docker/volumes/nginxproxydnpdappnodeeth_vhost.d/_data",
             dest: "/etc/nginx/vhost.d",
+            name: "nginxproxydnpdappnodeeth_vhost.d",
             users: [
               "nginx-proxy.dnp.dappnode.eth",
               "letsencrypt-nginx.dnp.dappnode.eth"
@@ -104,9 +105,9 @@ describe("dockerList", function() {
           },
           {
             type: "volume",
-            name: "nginxproxydnpdappnodeeth_html",
             path: "/var/lib/docker/volumes/nginxproxydnpdappnodeeth_html/_data",
             dest: "/usr/share/nginx/html",
+            name: "nginxproxydnpdappnodeeth_html",
             users: [
               "nginx-proxy.dnp.dappnode.eth",
               "letsencrypt-nginx.dnp.dappnode.eth"
@@ -134,10 +135,10 @@ describe("dockerList", function() {
         volumes: [
           {
             type: "volume",
-            name: "dncore_ethchaindnpdappnodeeth_data",
             path:
               "/var/lib/docker/volumes/dncore_ethchaindnpdappnodeeth_data/_data",
             dest: "/app/.ethchain",
+            name: "dncore_ethchaindnpdappnodeeth_data",
             users: ["vipnode.dnp.dappnode.eth", "ethchain.dnp.dappnode.eth"],
             owner: "ethchain.dnp.dappnode.eth",
             isOwner: false
@@ -181,23 +182,27 @@ describe("dockerList", function() {
         shortName: "admin",
         ports: [
           {
-            IP: "0.0.0.0",
-            PrivatePort: 8090,
-            PublicPort: 8090,
-            Type: "tcp"
+            host: 8090,
+            container: 8090,
+            protocol: "TCP",
+            ephemeral: false,
+            ip: "0.0.0.0"
           },
           {
-            PrivatePort: 80,
-            Type: "tcp"
+            host: null,
+            container: 80,
+            protocol: "TCP",
+            ephemeral: false,
+            ip: "0.0.0.0"
           }
         ],
         volumes: [
           {
             type: "volume",
-            name: "dncore_vpndnpdappnodeeth_shared",
             path:
               "/var/lib/docker/volumes/dncore_vpndnpdappnodeeth_shared/_data",
             dest: "/usr/www/openvpn/cred",
+            name: "dncore_vpndnpdappnodeeth_shared",
             users: ["admin.dnp.dappnode.eth", "vpn.dnp.dappnode.eth"],
             owner: "vpn.dnp.dappnode.eth",
             isOwner: false
@@ -219,33 +224,26 @@ describe("dockerList", function() {
         shortName: "vpn",
         ports: [
           {
-            IP: "0.0.0.0",
-            PrivatePort: 1194,
-            PublicPort: 1194,
-            Type: "udp"
+            host: 1194,
+            container: 1194,
+            protocol: "UDP",
+            ephemeral: false,
+            ip: "0.0.0.0"
           }
         ],
         volumes: [
           {
             type: "volume",
-            name: "dncore_vpndnpdappnodeeth_config",
             path:
               "/var/lib/docker/volumes/dncore_vpndnpdappnodeeth_config/_data",
             dest: "/etc/openvpn",
+            name: "dncore_vpndnpdappnodeeth_config",
             users: ["vpn.dnp.dappnode.eth"],
             owner: "vpn.dnp.dappnode.eth",
             isOwner: true
           },
-          {
-            type: "bind",
-            path: "/etc/hostname",
-            dest: "/etc/vpnname"
-          },
-          {
-            type: "bind",
-            path: "/lib/modules",
-            dest: "/lib/modules"
-          },
+          { type: "bind", path: "/etc/hostname", dest: "/etc/vpnname" },
+          { type: "bind", path: "/lib/modules", dest: "/lib/modules" },
           {
             type: "bind",
             path: "/usr/src/dappnode/config",
@@ -253,9 +251,9 @@ describe("dockerList", function() {
           },
           {
             type: "volume",
-            name: "dncore_vpndnpdappnodeeth_data",
             path: "/var/lib/docker/volumes/dncore_vpndnpdappnodeeth_data/_data",
             dest: "/usr/src/app/secrets",
+            name: "dncore_vpndnpdappnodeeth_data",
             users: ["vpn.dnp.dappnode.eth"],
             owner: "vpn.dnp.dappnode.eth",
             isOwner: true
@@ -267,10 +265,10 @@ describe("dockerList", function() {
           },
           {
             type: "volume",
-            name: "dncore_vpndnpdappnodeeth_shared",
             path:
               "/var/lib/docker/volumes/dncore_vpndnpdappnodeeth_shared/_data",
             dest: "/var/spool/openvpn",
+            name: "dncore_vpndnpdappnodeeth_shared",
             users: ["admin.dnp.dappnode.eth", "vpn.dnp.dappnode.eth"],
             owner: "vpn.dnp.dappnode.eth",
             isOwner: true
@@ -299,10 +297,10 @@ describe("dockerList", function() {
           },
           {
             type: "volume",
-            name: "dncore_dappmanagerdnpdappnodeeth_data",
             path:
               "/var/lib/docker/volumes/dncore_dappmanagerdnpdappnodeeth_data/_data",
             dest: "/usr/src/app/dnp_repo",
+            name: "dncore_dappmanagerdnpdappnodeeth_data",
             users: ["dappmanager.dnp.dappnode.eth"],
             owner: "dappmanager.dnp.dappnode.eth",
             isOwner: true
@@ -329,17 +327,20 @@ describe("dockerList", function() {
         shortName: "bind",
         ports: [
           {
-            PrivatePort: 53,
-            Type: "udp"
+            host: null,
+            container: 53,
+            protocol: "UDP",
+            ephemeral: false,
+            ip: "0.0.0.0"
           }
         ],
         volumes: [
           {
             type: "volume",
-            name: "dncore_binddnpdappnodeeth_data",
             path:
               "/var/lib/docker/volumes/dncore_binddnpdappnodeeth_data/_data",
             dest: "/etc/bind",
+            name: "dncore_binddnpdappnodeeth_data",
             users: ["bind.dnp.dappnode.eth"],
             owner: "bind.dnp.dappnode.eth",
             isOwner: true
@@ -361,31 +362,34 @@ describe("dockerList", function() {
         shortName: "ethchain",
         ports: [
           {
-            IP: "0.0.0.0",
-            PrivatePort: 30303,
-            PublicPort: 30303,
-            Type: "tcp"
+            host: 30303,
+            container: 30303,
+            protocol: "TCP",
+            ephemeral: false,
+            ip: "0.0.0.0"
           },
           {
-            IP: "0.0.0.0",
-            PrivatePort: 30303,
-            PublicPort: 30303,
-            Type: "udp"
+            host: 30303,
+            container: 30303,
+            protocol: "UDP",
+            ephemeral: false,
+            ip: "0.0.0.0"
           },
           {
-            IP: "0.0.0.0",
-            PrivatePort: 30304,
-            PublicPort: 30304,
-            Type: "udp"
+            host: 30304,
+            container: 30304,
+            protocol: "UDP",
+            ephemeral: false,
+            ip: "0.0.0.0"
           }
         ],
         volumes: [
           {
             type: "volume",
-            name: "dncore_ethchaindnpdappnodeeth_data",
             path:
               "/var/lib/docker/volumes/dncore_ethchaindnpdappnodeeth_data/_data",
             dest: "/root/.local/share/io.parity.ethereum",
+            name: "dncore_ethchaindnpdappnodeeth_data",
             users: ["vipnode.dnp.dappnode.eth", "ethchain.dnp.dappnode.eth"],
             owner: "ethchain.dnp.dappnode.eth",
             isOwner: true
@@ -407,47 +411,58 @@ describe("dockerList", function() {
         shortName: "ipfs",
         ports: [
           {
-            PrivatePort: 5001,
-            Type: "tcp"
+            host: null,
+            container: 5001,
+            protocol: "TCP",
+            ephemeral: false,
+            ip: "0.0.0.0"
           },
           {
-            PrivatePort: 8080,
-            Type: "tcp"
+            host: null,
+            container: 8080,
+            protocol: "TCP",
+            ephemeral: false,
+            ip: "0.0.0.0"
           },
           {
-            PrivatePort: 8081,
-            Type: "tcp"
+            host: null,
+            container: 8081,
+            protocol: "TCP",
+            ephemeral: false,
+            ip: "0.0.0.0"
           },
           {
-            IP: "0.0.0.0",
-            PrivatePort: 4001,
-            PublicPort: 4001,
-            Type: "tcp"
+            host: 4001,
+            container: 4001,
+            protocol: "TCP",
+            ephemeral: false,
+            ip: "0.0.0.0"
           },
           {
-            IP: "0.0.0.0",
-            PrivatePort: 4002,
-            PublicPort: 4002,
-            Type: "udp"
+            host: 4002,
+            container: 4002,
+            protocol: "UDP",
+            ephemeral: false,
+            ip: "0.0.0.0"
           }
         ],
         volumes: [
           {
             type: "volume",
-            name: "dncore_ipfsdnpdappnodeeth_data",
             path:
               "/var/lib/docker/volumes/dncore_ipfsdnpdappnodeeth_data/_data",
             dest: "/data/ipfs",
+            name: "dncore_ipfsdnpdappnodeeth_data",
             users: ["ipfs.dnp.dappnode.eth"],
             owner: "ipfs.dnp.dappnode.eth",
             isOwner: true
           },
           {
             type: "volume",
-            name: "dncore_ipfsdnpdappnodeeth_export",
             path:
               "/var/lib/docker/volumes/dncore_ipfsdnpdappnodeeth_export/_data",
             dest: "/export",
+            name: "dncore_ipfsdnpdappnodeeth_export",
             users: ["ipfs.dnp.dappnode.eth"],
             owner: "ipfs.dnp.dappnode.eth",
             isOwner: true
@@ -486,24 +501,26 @@ describe("dockerList", function() {
         shortName: "swarm",
         ports: [
           {
-            IP: "0.0.0.0",
-            PrivatePort: 30399,
-            PublicPort: 30399,
-            Type: "tcp"
+            host: 30399,
+            container: 30399,
+            protocol: "TCP",
+            ephemeral: false,
+            ip: "0.0.0.0"
           },
           {
-            IP: "0.0.0.0",
-            PrivatePort: 30399,
-            PublicPort: 30399,
-            Type: "udp"
+            host: 30399,
+            container: 30399,
+            protocol: "UDP",
+            ephemeral: false,
+            ip: "0.0.0.0"
           }
         ],
         volumes: [
           {
             type: "volume",
-            name: "swarmdnpdappnodeeth_swarm",
             path: "/var/lib/docker/volumes/swarmdnpdappnodeeth_swarm/_data",
             dest: "/root/.ethereum",
+            name: "swarmdnpdappnodeeth_swarm",
             users: ["swarm.dnp.dappnode.eth"],
             owner: "swarm.dnp.dappnode.eth",
             isOwner: true
@@ -516,9 +533,7 @@ describe("dockerList", function() {
         id: "b7f32fcefcd4bfb34d0c293378993e4a40eb3e62d8a928c4f183065834a10fb2",
         packageName: "DAppNodePackage-letsencrypt-nginx.dnp.dappnode.eth",
         version: "0.0.4",
-        dependencies: {
-          "nginx-proxy.dnp.dappnode.eth": "latest"
-        },
+        dependencies: { "nginx-proxy.dnp.dappnode.eth": "latest" },
         portsToClose: [],
         isDnp: true,
         isCore: false,
@@ -528,17 +543,13 @@ describe("dockerList", function() {
         shortName: "letsencrypt-nginx",
         ports: [],
         volumes: [
-          {
-            type: "bind",
-            path: "/root/certs",
-            dest: "/etc/nginx/certs"
-          },
+          { type: "bind", path: "/root/certs", dest: "/etc/nginx/certs" },
           {
             type: "volume",
-            name: "nginxproxydnpdappnodeeth_vhost.d",
             path:
               "/var/lib/docker/volumes/nginxproxydnpdappnodeeth_vhost.d/_data",
             dest: "/etc/nginx/vhost.d",
+            name: "nginxproxydnpdappnodeeth_vhost.d",
             users: [
               "nginx-proxy.dnp.dappnode.eth",
               "letsencrypt-nginx.dnp.dappnode.eth"
@@ -548,9 +559,9 @@ describe("dockerList", function() {
           },
           {
             type: "volume",
-            name: "nginxproxydnpdappnodeeth_html",
             path: "/var/lib/docker/volumes/nginxproxydnpdappnodeeth_html/_data",
             dest: "/usr/share/nginx/html",
+            name: "nginxproxydnpdappnodeeth_html",
             users: [
               "nginx-proxy.dnp.dappnode.eth",
               "letsencrypt-nginx.dnp.dappnode.eth"
@@ -583,10 +594,10 @@ describe("dockerList", function() {
         volumes: [
           {
             type: "volume",
-            name: "ipfsreplicatordnpdappnodeeth_pin-data",
             path:
               "/var/lib/docker/volumes/ipfsreplicatordnpdappnodeeth_pin-data/_data",
             dest: "/usr/src/app/data",
+            name: "ipfsreplicatordnpdappnodeeth_pin-data",
             users: ["ipfs-replicator.dnp.dappnode.eth"],
             owner: "ipfs-replicator.dnp.dappnode.eth",
             isOwner: true
@@ -601,18 +612,9 @@ describe("dockerList", function() {
         version: "0.2.2",
         chain: "ethereum",
         portsToClose: [
-          {
-            number: 32769,
-            type: "TCP"
-          },
-          {
-            number: 32771,
-            type: "UDP"
-          },
-          {
-            number: 32770,
-            type: "UDP"
-          }
+          { number: 32769, type: "TCP" },
+          { number: 32771, type: "UDP" },
+          { number: 32770, type: "UDP" }
         ],
         isDnp: true,
         isCore: false,
@@ -622,31 +624,34 @@ describe("dockerList", function() {
         shortName: "goerli-geth",
         ports: [
           {
-            IP: "0.0.0.0",
-            PrivatePort: 30303,
-            PublicPort: 32769,
-            Type: "tcp"
+            host: 32769,
+            container: 30303,
+            protocol: "TCP",
+            ephemeral: true,
+            ip: "0.0.0.0"
           },
           {
-            IP: "0.0.0.0",
-            PrivatePort: 30303,
-            PublicPort: 32771,
-            Type: "udp"
+            host: 32771,
+            container: 30303,
+            protocol: "UDP",
+            ephemeral: true,
+            ip: "0.0.0.0"
           },
           {
-            IP: "0.0.0.0",
-            PrivatePort: 30304,
-            PublicPort: 32770,
-            Type: "udp"
+            host: 32770,
+            container: 30304,
+            protocol: "UDP",
+            ephemeral: true,
+            ip: "0.0.0.0"
           }
         ],
         volumes: [
           {
             type: "volume",
-            name: "goerligethdnpdappnodeeth_goerli",
             path:
               "/var/lib/docker/volumes/goerligethdnpdappnodeeth_goerli/_data",
             dest: "/goerli",
+            name: "goerligethdnpdappnodeeth_goerli",
             users: ["goerli-geth.dnp.dappnode.eth"],
             owner: "goerli-geth.dnp.dappnode.eth",
             isOwner: true
@@ -659,9 +664,7 @@ describe("dockerList", function() {
         id: "94bde8655e2d8daca033486ef46e7d270c4f4b6f6c18b820d80c2cbf211130bd",
         packageName: "DAppNodePackage-ln.dnp.dappnode.eth",
         version: "0.1.1",
-        dependencies: {
-          "bitcoin.dnp.dappnode.eth": "latest"
-        },
+        dependencies: { "bitcoin.dnp.dappnode.eth": "latest" },
         portsToClose: [],
         isDnp: true,
         isCore: false,
@@ -671,27 +674,34 @@ describe("dockerList", function() {
         shortName: "ln",
         ports: [
           {
-            PrivatePort: 80,
-            Type: "tcp"
+            host: null,
+            container: 80,
+            protocol: "TCP",
+            ephemeral: false,
+            ip: "0.0.0.0"
           },
           {
-            IP: "0.0.0.0",
-            PrivatePort: 9735,
-            PublicPort: 9735,
-            Type: "tcp"
+            host: 9735,
+            container: 9735,
+            protocol: "TCP",
+            ephemeral: false,
+            ip: "0.0.0.0"
           },
           {
-            PrivatePort: 10009,
-            Type: "tcp"
+            host: null,
+            container: 10009,
+            protocol: "TCP",
+            ephemeral: false,
+            ip: "0.0.0.0"
           }
         ],
         volumes: [
           {
             type: "volume",
-            name: "lndnpdappnodeeth_lndconfig_data",
             path:
               "/var/lib/docker/volumes/lndnpdappnodeeth_lndconfig_data/_data",
             dest: "/root/.lnd",
+            name: "lndnpdappnodeeth_lndconfig_data",
             users: ["ln.dnp.dappnode.eth"],
             owner: "ln.dnp.dappnode.eth",
             isOwner: true
@@ -713,12 +723,18 @@ describe("dockerList", function() {
         shortName: "wamp",
         ports: [
           {
-            PrivatePort: 8000,
-            Type: "tcp"
+            host: null,
+            container: 8000,
+            protocol: "TCP",
+            ephemeral: false,
+            ip: "0.0.0.0"
           },
           {
-            PrivatePort: 8080,
-            Type: "tcp"
+            host: null,
+            container: 8080,
+            protocol: "TCP",
+            ephemeral: false,
+            ip: "0.0.0.0"
           }
         ],
         volumes: [],

--- a/build/src/test/modules/lockPorts.test.js
+++ b/build/src/test/modules/lockPorts.test.js
@@ -3,45 +3,18 @@ const expect = require("chai").expect;
 const fs = require("fs");
 const getPath = require("utils/getPath");
 const validate = require("utils/validate");
+const params = require("params");
+const { createTestDir, cleanTestDir } = require("../testUtils");
 
 describe("Module: lockPorts", function() {
-  const params = {
-    DNCORE_DIR: "DNCORE",
-    REPO_DIR: "test_files/"
-  };
+  const normalDnpName = "kovan.dnp.dappnode.eth";
+  const normalDnpPorts = ["30303", "30303/udp"];
 
-  const pkg = {
-    name: "kovan.dnp.dappnode.eth",
-    ver: "0.1.0",
-    manifest: {
-      image: {
-        ports: ["30303", "30303/udp"]
-      },
-      isCore: false
-    }
-  };
-  const corePkg = {
-    name: "ethchain.dnp.dappnode.eth",
-    ver: "0.1.0",
-    manifest: {
-      image: {
-        ports: ["30303", "30303/udp"]
-      },
-      isCore: false
-    }
-  };
-  const nonPortsPkg = {
-    name: "ipfs.dnp.dappnode.eth",
-    ver: "0.1.0",
-    manifest: {
-      image: {
-        ports: ["4001:4001", "4002:4002/udp"]
-      }
-    }
-  };
+  const coreDnpName = "ethchain.dnp.dappnode.eth";
+  const coreDnpPorts = ["30303", "30303/udp"];
 
-  const dockerComposePath = getPath.dockerCompose(pkg.name, params);
-  const coreDockerComposePath = getPath.dockerCompose(corePkg.name, params);
+  const noPortsDnpName = "ipfs.dnp.dappnode.eth";
+  const noPortsPorts = ["4001:4001", "4002:4002/udp"];
 
   let ephemeralPort = {
     tcp: 32768,
@@ -60,20 +33,28 @@ describe("Module: lockPorts", function() {
         };
       });
   }
-  const listContainersResult = [
-    {
-      name: pkg.name,
-      ports: getListContainerPorts(pkg.manifest.image.ports)
-    },
-    {
-      name: corePkg.name,
-      isCore: true,
-      ports: getListContainerPorts(corePkg.manifest.image.ports)
-    }
-  ];
+
   const dockerList = {
-    listContainers: async () => listContainersResult
+    getContainer: async id => {
+      if (id === normalDnpName)
+        return {
+          name: normalDnpName,
+          ports: getListContainerPorts(normalDnpPorts)
+        };
+      if (id === coreDnpName)
+        return {
+          name: coreDnpName,
+          isCore: true,
+          ports: getListContainerPorts(coreDnpPorts)
+        };
+      if (id === noPortsDnpName)
+        return {
+          name: noPortsDnpName,
+          ports: getListContainerPorts(noPortsPorts)
+        };
+    }
   };
+
   const docker = {
     compose: {
       up: async () => {}
@@ -82,82 +63,98 @@ describe("Module: lockPorts", function() {
 
   const lockPorts = proxyquire("modules/lockPorts", {
     "modules/dockerList": dockerList,
-    "modules/docker": docker,
-    params: params
+    "modules/docker": docker
   });
 
-  before(() => {
-    validate.path(dockerComposePath);
-    const dockerComposeString = `
-version: '3.4'
+  before(async () => {
+    await createTestDir();
+
+    for (const [name, composeString, isCore] of [
+      [
+        normalDnpName,
+        `version: '3.4'
 services:
-    ${pkg.name}:
-        ports:
-            - '30303/udp'
-            - '30303'
-`;
-    fs.writeFileSync(dockerComposePath, dockerComposeString);
-    validate.path(coreDockerComposePath);
-    const coreDockerComposeString = `
-version: '3.4'
+  ${normalDnpName}:
+    ports:
+      - '30303/udp'
+      - '30303'`
+      ],
+      [
+        coreDnpName,
+        `version: '3.4'
 services:
-    ${corePkg.name}:
-        ports:
-            - '30303/udp'
-            - '30303'
-`;
-    fs.writeFileSync(coreDockerComposePath, coreDockerComposeString);
+  ${coreDnpName}:
+    ports:
+      - '30303/udp'
+      - '30303'`,
+        true
+      ],
+      [
+        noPortsDnpName,
+        `version: '3.4'
+services:
+  ${noPortsDnpName}:
+    ports:
+      - '4001:4001'
+      - '4002:4002/udp'`
+      ]
+    ]) {
+      const composePath = getPath.dockerCompose(name, params, isCore);
+      validate.path(composePath);
+      fs.writeFileSync(composePath, composeString);
+    }
   });
 
   it("should lock ports and return portsToOpen (NON core)", async () => {
-    const portsToOpen = await lockPorts({ pkg });
+    const portsToOpen = await lockPorts(normalDnpName);
     expect(portsToOpen).to.deep.equal([
-      { portNumber: 32768, protocol: "UDP" },
-      { portNumber: 32768, protocol: "TCP" }
+      { host: "32768", container: "30303", protocol: "UDP" },
+      { host: "32768", container: "30303", protocol: "TCP" }
     ]);
   });
 
   it("should have modified the docker-compose (NON core)", async () => {
-    const dc = fs.readFileSync(dockerComposePath, "utf8");
+    const dc = fs.readFileSync(
+      getPath.dockerCompose(normalDnpName, params),
+      "utf8"
+    );
     expect(dc).to.equal(`version: '3.4'
 services:
-    ${pkg.name}:
-        ports:
-            - '32768:30303/udp'
-            - '32768:30303'
-        labels:
-            portsToClose: '[{"portNumber":32768,"protocol":"UDP"},{"portNumber":32768,"protocol":"TCP"}]'
+  ${normalDnpName}:
+    ports:
+      - '32768:30303'
+      - '32768:30303/udp'
 `);
   });
 
   it("should lock ports and return portsToOpen (core)", async () => {
-    const portsToOpen = await lockPorts({ pkg: corePkg });
+    const portsToOpen = await lockPorts(coreDnpName);
     expect(portsToOpen).to.deep.equal([
-      { portNumber: 32769, protocol: "UDP" },
-      { portNumber: 32769, protocol: "TCP" }
+      { host: "32769", container: "30303", protocol: "UDP" },
+      { host: "32769", container: "30303", protocol: "TCP" }
     ]);
   });
 
   it("should have modified the docker-compose (core)", async () => {
-    const dc = fs.readFileSync(coreDockerComposePath, "utf8");
+    const dc = fs.readFileSync(
+      getPath.dockerCompose(coreDnpName, params, true),
+      "utf8"
+    );
     expect(dc).to.equal(`version: '3.4'
 services:
-    ${corePkg.name}:
-        ports:
-            - '32769:30303/udp'
-            - '32769:30303'
-        labels:
-            portsToClose: '[{"portNumber":32769,"protocol":"UDP"},{"portNumber":32769,"protocol":"TCP"}]'
+  ${coreDnpName}:
+    ports:
+      - '32769:30303'
+      - '32769:30303/udp'
 `);
   });
 
   it("should skip the process early on a package without ephemeral ports", async () => {
-    const portsToOpen = await lockPorts({ pkg: nonPortsPkg });
-    expect(portsToOpen).to.deep.equal([]);
+    const earlyReturn = await lockPorts(noPortsDnpName);
+    expect(earlyReturn).to.equal(undefined);
   });
 
-  after(() => {
-    fs.unlinkSync(dockerComposePath);
-    fs.unlinkSync(coreDockerComposePath);
+  after(async () => {
+    await cleanTestDir();
   });
 });

--- a/build/src/test/modules/lockPorts.test.js
+++ b/build/src/test/modules/lockPorts.test.js
@@ -26,10 +26,10 @@ describe("Module: lockPorts", function() {
       .map(port => {
         let [portNumber, portType = "tcp"] = port.split("/");
         return {
-          IP: "0.0.0.0",
-          PrivatePort: portNumber, // container port
-          PublicPort: ephemeralPort[portType]++, // host port
-          Type: portType
+          ip: "0.0.0.0",
+          container: portNumber,
+          host: ephemeralPort[portType]++,
+          protocol: portType
         };
       });
   }

--- a/build/src/test/modules/unlockPorts.test.js
+++ b/build/src/test/modules/unlockPorts.test.js
@@ -44,21 +44,12 @@ services:
             - '32768:30303/udp'
             - '32768:30303'
             - '5001:5001'
-        labels:
-            portsToClose: '[{"portNumber":32768,"protocol":"UDP"},{"portNumber":32768,"protocol":"TCP"}]'
 `;
     fs.writeFileSync(dockerComposePath, dockerComposeString);
   });
 
-  it("should unlock ports and return portsToClose (NON core)", async () => {
-    const portsToClose = await unlockPorts(dockerComposePath);
-    expect(portsToClose).to.deep.equal([
-      { portNumber: 32768, protocol: "UDP" },
-      { portNumber: 32768, protocol: "TCP" }
-    ]);
-  });
-
   it("should have modified the docker-compose (NON core)", async () => {
+    await unlockPorts(dockerComposePath);
     const dc = fs.readFileSync(dockerComposePath, "utf8");
     expect(dc).to.equal(`version: '3.4'
 services:

--- a/build/src/test/testUtils.js
+++ b/build/src/test/testUtils.js
@@ -1,4 +1,5 @@
 const shell = require("utils/shell");
+const path = require("path");
 
 const testDir = "./test_files/";
 
@@ -20,9 +21,14 @@ async function createTestDir() {
   await shell(`mkdir -p ${testDir}`);
 }
 
+async function createDirP(filePath) {
+  await shell(`mkdir -p ${path.parse(filePath).dir}`);
+}
+
 module.exports = {
   testDir,
   cleanTestDir,
   createTestDir,
+  createDirP,
   ignoreErrors
 };

--- a/build/src/test/utils/appendIsPortDeletable.test.js
+++ b/build/src/test/utils/appendIsPortDeletable.test.js
@@ -1,0 +1,101 @@
+const expect = require("chai").expect;
+
+const appendIsPortDeletable = require("utils/appendIsPortDeletable");
+
+// module.exports = {
+//     load: loadEnvs,
+//     write: writeEnvs,
+//     getManifestEnvs,
+//   };
+
+describe("Util: appendIsPortDeletable", () => {
+  it("should flag deletable for a normal case (Swarm)", () => {
+    const manifest = {
+      name: "swarm.dnp.dappnode.eth",
+      image: {
+        ports: ["30399:30399", "30399:30399/udp"]
+      }
+    };
+
+    const portMappings = [
+      {
+        host: 30399,
+        container: 30399,
+        protocol: "TCP",
+        ephemeral: false,
+        ip: "0.0.0.0"
+      },
+      {
+        host: 30399,
+        container: 30399,
+        protocol: "UDP",
+        ephemeral: false,
+        ip: "0.0.0.0"
+      },
+      {
+        host: 8080,
+        container: 8080,
+        protocol: "TCP",
+        ephemeral: false,
+        ip: "0.0.0.0"
+      }
+    ];
+    const newPortMappings = appendIsPortDeletable(portMappings, manifest);
+
+    expect(newPortMappings).to.deep.equal([
+      {
+        host: 30399,
+        container: 30399,
+        protocol: "TCP",
+        ephemeral: false,
+        ip: "0.0.0.0",
+        deletable: false
+      },
+      {
+        host: 30399,
+        container: 30399,
+        protocol: "UDP",
+        ephemeral: false,
+        ip: "0.0.0.0",
+        deletable: false
+      },
+      {
+        host: 8080,
+        container: 8080,
+        protocol: "TCP",
+        ephemeral: false,
+        ip: "0.0.0.0",
+        deletable: true
+      }
+    ]);
+  });
+
+  it("should flag deletable for a case without manifest ports (Ethforward)", () => {
+    const manifest = {
+      name: "ethforward.dnp.dappnode.eth",
+      image: {}
+    };
+
+    const portMappings = [
+      {
+        host: 80,
+        container: 80,
+        protocol: "TCP",
+        ephemeral: false,
+        ip: "0.0.0.0"
+      }
+    ];
+    const newPortMappings = appendIsPortDeletable(portMappings, manifest);
+
+    expect(newPortMappings).to.deep.equal([
+      {
+        host: 80,
+        container: 80,
+        protocol: "TCP",
+        ephemeral: false,
+        ip: "0.0.0.0",
+        deletable: true
+      }
+    ]);
+  });
+});

--- a/build/src/test/utils/dockerComposeFile.test.js
+++ b/build/src/test/utils/dockerComposeFile.test.js
@@ -1,0 +1,64 @@
+const expect = require("chai").expect;
+const fs = require("fs");
+const { createTestDir, cleanTestDir, createDirP } = require("../testUtils");
+
+const {
+  getComposeInstance,
+  getDockerComposePath
+} = require("utils/dockerComposeFile");
+
+describe("Util: dockerComposeFile", () => {
+  const id = "test-dnp.dnp.dappnode.eth";
+  const portMappings = [
+    // Add a new port
+    { container: "4004:4001", protocol: "TCP" },
+    // Modify the mapping of two port protocols
+    { host: "30673", container: "30303", protocol: "TCP" },
+    { host: "30673", container: "30303", protocol: "UDP" },
+    // Make one mapped port ephemeral
+    { container: "16001", protocol: "TCP" }
+  ];
+
+  before("write compose", async () => {
+    await createTestDir();
+    const dockerComposePath = getDockerComposePath(id, true);
+    await createDirP(dockerComposePath);
+    fs.writeFileSync(
+      dockerComposePath,
+      `version: '3.4'
+services:
+  ${id}:
+    ports:
+      - '8090:80'
+      - '16001:16001'
+      - '30303:30303'
+      - '30303:30303/udp'
+`
+    );
+  });
+
+  it("should merge a ports array into a docker-compose", () => {
+    const compose = getComposeInstance(id);
+    compose.mergePortMapping(portMappings);
+
+    const newComposeString = fs.readFileSync(compose.dockerComposePath, "utf8");
+
+    expect(newComposeString).to.equal(
+      `version: '3.4'
+services:
+  ${id}:
+    ports:
+      - '8090:80'
+      - '4004:4001'
+      - '16001'
+      - '30673:30303'
+      - '30673:30303/udp'
+`,
+      "Wrong new compose"
+    );
+  });
+
+  after(async () => {
+    await cleanTestDir();
+  });
+});

--- a/build/src/test/utils/dockerComposeParsers.test.js
+++ b/build/src/test/utils/dockerComposeParsers.test.js
@@ -1,0 +1,74 @@
+const expect = require("chai").expect;
+
+const {
+  parsePortMappings,
+  stringifyPortMappings,
+  mergePortMappings
+} = require("utils/dockerComposeParsers");
+
+describe("Util: dockerComposeParsers", () => {
+  it("should parse and stringify port mappings", () => {
+    const portArray = ["4001", "5001/udp", "30303:30303", "30303:30303/udp"];
+    const portMappings = [
+      { container: "4001", protocol: "TCP" },
+      { container: "5001", protocol: "UDP" },
+      { host: "30303", container: "30303", protocol: "TCP" },
+      { host: "30303", container: "30303", protocol: "UDP" }
+    ];
+
+    expect(parsePortMappings(portArray)).to.deep.equal(
+      portMappings,
+      "Wrong parse"
+    );
+
+    expect(stringifyPortMappings(portMappings)).to.deep.equal(
+      portArray,
+      "Wrong stringify"
+    );
+  });
+
+  it("should merge port mappings", () => {
+    const portMappings1 = [
+      { container: "4001", protocol: "TCP" },
+      { host: "30303", container: "30303", protocol: "TCP" },
+      { host: "30303", container: "30303", protocol: "UDP" },
+      { host: "60606", container: "60606", protocol: "TCP" }
+    ];
+
+    const portMappings2 = [
+      { container: "5001", protocol: "UDP" },
+      { host: "30304", container: "30303", protocol: "TCP" },
+      { host: "30304", container: "30303", protocol: "UDP" },
+      { container: "60606", protocol: "TCP" }
+    ];
+
+    const mergedPortMappings = mergePortMappings(portMappings1, portMappings2);
+
+    expect(mergedPortMappings).to.deep.equal([
+      { container: "4001", protocol: "TCP" },
+      { container: "5001", protocol: "UDP" },
+      { host: "30304", container: "30303", protocol: "TCP" },
+      { host: "30304", container: "30303", protocol: "UDP" },
+      { container: "60606", protocol: "TCP" }
+    ]);
+  });
+
+  it("should parse, merge and stringify two port arrays", () => {
+    const portArray1 = ["4001:4001", "30303:30303/udp"];
+    // Change the host of a port and add another one.
+    const portArray2 = ["30656:30303/udp", "8080:8080"];
+
+    const mergedPortMappings = stringifyPortMappings(
+      mergePortMappings(
+        parsePortMappings(portArray1),
+        parsePortMappings(portArray2)
+      )
+    );
+
+    expect(mergedPortMappings).to.deep.equal([
+      "4001:4001",
+      "8080:8080",
+      "30656:30303/udp"
+    ]);
+  });
+});

--- a/build/src/test/watchers/natRenewal/getPortsToOpen.test.js
+++ b/build/src/test/watchers/natRenewal/getPortsToOpen.test.js
@@ -16,34 +16,34 @@ describe("Watchers > natRenewal > getPortsToOpen", () => {
           {
             isCore: true,
             name: "admin.dnp.dappnode.eth",
-            ports: [{ PublicPort: 8090, Type: "tcp" }],
+            ports: [{ host: 8090, protocol: "tcp" }],
             running: true
           },
           {
             isCore: true,
             name: "vpn.dnp.dappnode.eth",
-            ports: [{ PublicPort: 1194, Type: "udp" }],
+            ports: [{ host: 1194, protocol: "udp" }],
             running: true
           },
           {
             isCore: true,
             name: "vpn.dnp.dappnode.eth2",
-            ports: [{ PublicPort: 1194, Type: "udp" }],
+            ports: [{ host: 1194, protocol: "udp" }],
             running: true
           },
           {
             isCore: false,
             name: "goerli.dnp.dappnode.eth",
             ports: [
-              { PublicPort: 32769, Type: "tcp" },
-              { PublicPort: 32771, Type: "udp" },
-              { PublicPort: 32770, Type: "udp" }
+              { host: 32769, protocol: "tcp" },
+              { host: 32771, protocol: "udp" },
+              { host: 32770, protocol: "udp" }
             ],
             running: true,
             portsToClose: [
-              { portNumber: 32769, Type: "TCP" },
-              { portNumber: 32771, Type: "UDP" },
-              { portNumber: 32770, Type: "UDP" }
+              { portNumber: 32769, protocol: "TCP" },
+              { portNumber: 32771, protocol: "UDP" },
+              { portNumber: 32770, protocol: "UDP" }
             ]
           },
           {
@@ -107,7 +107,7 @@ describe("Watchers > natRenewal > getPortsToOpen", () => {
           {
             isCore: true,
             name: "admin.dnp.dappnode.eth",
-            ports: [{ PublicPort: 8090, Type: "tcp" }],
+            ports: [{ host: 8090, protocol: "tcp" }],
             running: true
           },
           {

--- a/build/src/tsconfig.json
+++ b/build/src/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "module": "commonjs",
+    "strict": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/build/src/yarn.lock
+++ b/build/src/yarn.lock
@@ -399,6 +399,43 @@
   dependencies:
     "@types/node" "*"
 
+"@types/body-parser@*":
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.17.0.tgz#9f5c9d9bd04bb54be32d5eb9fc0d8c974e6cf58c"
+  integrity sha512-a2+YeUjPkztKJu5aIF2yArYFQQp8d51wZ7DavSHjFuY1mqVgidGyzEQ41JIVNy82fXj8yPgy2vJmfIywgESW6w==
+  dependencies:
+    "@types/connect" "*"
+    "@types/node" "*"
+
+"@types/connect@*":
+  version "3.4.32"
+  resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.32.tgz#aa0e9616b9435ccad02bc52b5b454ffc2c70ba28"
+  integrity sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==
+  dependencies:
+    "@types/node" "*"
+
+"@types/express-serve-static-core@*":
+  version "4.16.7"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.16.7.tgz#50ba6f8a691c08a3dd9fa7fba25ef3133d298049"
+  integrity sha512-847KvL8Q1y3TtFLRTXcVakErLJQgdpFSaq+k043xefz9raEf0C7HalpSY7OW5PyjCnY8P7bPW5t/Co9qqp+USg==
+  dependencies:
+    "@types/node" "*"
+    "@types/range-parser" "*"
+
+"@types/express@^4.17.0":
+  version "4.17.0"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.0.tgz#49eaedb209582a86f12ed9b725160f12d04ef287"
+  integrity sha512-CjaMu57cjgjuZbh9DpkloeGxV45CnMGlVd+XpG7Gm9QgVrd7KFq+X4HY0vM+2v0bczS48Wg7bvnMY5TN+Xmcfw==
+  dependencies:
+    "@types/body-parser" "*"
+    "@types/express-serve-static-core" "*"
+    "@types/serve-static" "*"
+
+"@types/mime@*":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.1.tgz#dc488842312a7f075149312905b5e3c0b054c79d"
+  integrity sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw==
+
 "@types/node@*":
   version "11.13.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-11.13.0.tgz#b0df8d6ef9b5001b2be3a94d909ce3c29a80f9e1"
@@ -409,6 +446,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.4.tgz#1c586b991457cbb58fef51bc4e0cfcfa347714b5"
   integrity sha512-DT25xX/YgyPKiHFOpNuANIQIVvYEwCWXgK2jYYwqgaMrYE6+tq+DtmMwlD3drl6DJbUwtlIDnn0d7tIn/EbXBg==
 
+"@types/node@^12.7.1":
+  version "12.7.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.1.tgz#3b5c3a26393c19b400844ac422bd0f631a94d69d"
+  integrity sha512-aK9jxMypeSrhiYofWWBf/T7O+KwaiAHzM4sveCdWPn71lzUSMimRnKzhXDKfKwV1kWoBo2P1aGgaIYGLf9/ljw==
+
 "@types/node@^8.0.7":
   version "8.10.45"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.45.tgz#4c49ba34106bc7dced77ff6bae8eb6543cde8351"
@@ -418,6 +460,24 @@
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
   integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
+
+"@types/range-parser@*":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
+  integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
+
+"@types/serve-static@*":
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.2.tgz#f5ac4d7a6420a99a6a45af4719f4dcd8cd907a48"
+  integrity sha512-/BZ4QRLpH/bNYgZgwhKEh+5AsboDBcUdlBYgzoLX0fpj3Y2gp6EApyOlM3bK53wQS/OE1SrdSYBAbux2D1528Q==
+  dependencies:
+    "@types/express-serve-static-core" "*"
+    "@types/mime" "*"
+
+"@types/yamljs@^0.2.30":
+  version "0.2.30"
+  resolved "https://registry.yarnpkg.com/@types/yamljs/-/yamljs-0.2.30.tgz#d034e1d329e46e8d0f737c9a8db97f68f81b5382"
+  integrity sha1-0DTh0ynkbo0Pc3yajbl/aPgbU4I=
 
 "@uphold/request-logger@^2.0.0":
   version "2.0.0"
@@ -7378,6 +7438,11 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
+typescript@^3.5.3:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
+  integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
 
 uglify-js@^3.1.4:
   version "3.5.3"


### PR DESCRIPTION
New RPC `updatePortMappings.dappmanager.dnp.dappnode.eth`. Allows the user to modify the port mappings in a DAppNode Package's `docker-compose.yml`. Protection measures include:
- It protects against port collisions with a try-catch that in case of error will rollback to the previous port mapping configuration and try to up the container again.
- It dis-allows the user from editing the DAPPMANAGER ports in any way because a port collision could render the DAppNode unusable.
----

The new code written for this change is in typescript. It required to modify the Dockerfile and package.json in order to support it. Now the image build has 3 stages:
1. Dependency build
2. Source build (typescript)
3. Final stage

This change also required to:
- Simplify the ephemeral port locking functionality
- Simplify how ports where opened. Now the NAT renewal loop is triggered every time a port has to be opened, instead of explicitly calling the managePort function directly.