### PR TITLE
v0.2.13 Release - Volume path hotfix

### DIFF
--- a/build/src/src/utils/configFiles.ts
+++ b/build/src/src/utils/configFiles.ts
@@ -16,7 +16,8 @@ import {
   parseServiceName,
   parseService,
   mergeVolumeArrays,
-  mergePortArrays
+  mergePortArrays,
+  mergeUserSetVolumes
 } from "./dockerComposeParsers";
 import params from "../params";
 import {
@@ -88,8 +89,10 @@ export function mergeUserSetToCompose(
           ...parseEnvironment(previousEnvs),
           ...userSetDnpEnvs
         }),
-        volumes: mergeVolumeArrays(previousVolumes, defaultVolumes).map(
-          vol => userSetDnpVols[vol] || vol
+        // Volumes are normalized on the mergeVolumeArrays
+        volumes: mergeUserSetVolumes(
+          mergeVolumeArrays(previousVolumes, defaultVolumes),
+          userSetDnpVols
         ),
         ports: mergePortArrays(previousPorts, defaultPorts).map(
           port => userSetDnpPorts[port] || port

--- a/build/src/test/utils/configFiles.test.ts
+++ b/build/src/test/utils/configFiles.test.ts
@@ -43,8 +43,8 @@ describe("Util > configFiles", () => {
         "30304:30304": "30304"
       };
       const userSetDnpVols = {
-        "kovan:/root/.local/share/io.parity.ethereum/":
-          "different_path:/root/.local/share/io.parity.ethereum/"
+        "kovan:/root/.local/share/io.parity.ethereum//":
+          "different_path:/root/.local/share/io.parity.ethereum//"
       };
 
       const serviceName = parseServiceName(mockCompose);
@@ -68,7 +68,7 @@ describe("Util > configFiles", () => {
             environment: ["ENV1=USER_SET_VAL1", "ENV2=PREVIOUS_SET_VAL2"],
             ports: ["31313:30303", "31313:30303/udp", "30304", "3000:8080"],
             volumes: [
-              "different_path:/root/.local/share/io.parity.ethereum/",
+              "different_path:/root/.local/share/io.parity.ethereum",
               "/dev1:/root/.sync"
             ],
             labels: writeDefaultsToLabels({

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,6 +1,6 @@
 {
   "name": "dappmanager.dnp.dappnode.eth",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "description": "Dappnode package responsible for providing the DappNode Package Manager",
   "avatar": "/ipfs/QmfTpBLzoSdrG88ETRnDus27DTDRUrTXyyVmhXDuMNYVaN",
   "type": "dncore",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     build:
       context: .
       dockerfile: ./build/Dockerfile
-    image: 'dappmanager.dnp.dappnode.eth:0.2.12'
+    image: 'dappmanager.dnp.dappnode.eth:0.2.13'
     container_name: DAppNodeCore-dappmanager.dnp.dappnode.eth
     restart: always
     volumes:


### PR DESCRIPTION
# Changelog
- Make sure all docker volume paths are normalized before applying logic to them. If the developer slightly changes the path of a volume, this can be merged with a pre-existing path and docker consider the compose bad and freeze the package. 
```
# Normalization example
from: ethchaindnpdappnodeeth_geth:/root/.ethereum/
to  : ethchaindnpdappnodeeth_geth:/root/.ethereum
```