### PR TITLE
Check if global envs are in the VPN environment

### DIFF
--- a/build/src/src/db/index.ts
+++ b/build/src/src/db/index.ts
@@ -11,8 +11,7 @@ import { upnpAvailable, upnpPortMappings, portsToOpen } from "./upnp";
 import {
   areEnvFilesMigrated,
   importedInstallationStaticIp,
-  isVpnDbMigrated,
-  hasRestartedVpnToInjectEnvs
+  isVpnDbMigrated
 } from "./systemFlags";
 import { publicIp, domain, dyndnsIdentity, staticIp } from "./dyndns";
 import { serverName } from "./system";
@@ -66,7 +65,6 @@ export {
   staticIp,
   importedInstallationStaticIp,
   isVpnDbMigrated,
-  hasRestartedVpnToInjectEnvs,
   serverName,
   noNatLoopback,
   doubleNat,

--- a/build/src/src/db/systemFlags.ts
+++ b/build/src/src/db/systemFlags.ts
@@ -3,7 +3,6 @@ import { staticKey } from "./dbMain";
 const ARE_ENV_FILES_MIGRATED = "are-env-files-migrated";
 const IMPORTED_INSTALLATION_STATIC_IP = "imported-installation-staticIp";
 const IS_VPN_DB_MIGRATED = "is-vpn-db-migrated";
-const HAS_RESTARTED_VPN_TO_INJECT_ENVS = "has-restarted-vpn-to-inject-envs";
 
 export const areEnvFilesMigrated = staticKey<boolean>(
   ARE_ENV_FILES_MIGRATED,
@@ -16,8 +15,3 @@ export const importedInstallationStaticIp = staticKey<boolean>(
 );
 
 export const isVpnDbMigrated = staticKey<boolean>(IS_VPN_DB_MIGRATED, false);
-
-export const hasRestartedVpnToInjectEnvs = staticKey<boolean>(
-  HAS_RESTARTED_VPN_TO_INJECT_ENVS,
-  false
-);


### PR DESCRIPTION
More defensive approach where if only if all is good the VPN will not be reseted.

---

To test, do a VPN -> DAPPMANAGER migration twice and make sure you see the correct logs
If a migration HAD to happen
```
Added global ENVs and restarted the VPN
```
If the migration has already happened
```
Globals ENVs are already set in the VPN environment
```