### PR TITLE
Remove env files migrated flag

### DIFF
--- a/build/src/src/db/index.ts
+++ b/build/src/src/db/index.ts
@@ -8,11 +8,7 @@ import { composeCache, apmCache, ipfsCache, manifestCache } from "./cache";
 import { fileTransferPath } from "./fileTransferPath";
 import { notification, notifications } from "./notification";
 import { upnpAvailable, upnpPortMappings, portsToOpen } from "./upnp";
-import {
-  areEnvFilesMigrated,
-  importedInstallationStaticIp,
-  isVpnDbMigrated
-} from "./systemFlags";
+import { importedInstallationStaticIp, isVpnDbMigrated } from "./systemFlags";
 import { publicIp, domain, dyndnsIdentity, staticIp } from "./dyndns";
 import { serverName } from "./system";
 import {
@@ -58,7 +54,6 @@ export {
   upnpAvailable,
   upnpPortMappings,
   portsToOpen,
-  areEnvFilesMigrated,
   publicIp,
   domain,
   dyndnsIdentity,

--- a/build/src/src/db/systemFlags.ts
+++ b/build/src/src/db/systemFlags.ts
@@ -1,13 +1,7 @@
 import { staticKey } from "./dbMain";
 
-const ARE_ENV_FILES_MIGRATED = "are-env-files-migrated";
 const IMPORTED_INSTALLATION_STATIC_IP = "imported-installation-staticIp";
 const IS_VPN_DB_MIGRATED = "is-vpn-db-migrated";
-
-export const areEnvFilesMigrated = staticKey<boolean>(
-  ARE_ENV_FILES_MIGRATED,
-  false
-);
 
 export const importedInstallationStaticIp = staticKey<boolean>(
   IMPORTED_INSTALLATION_STATIC_IP,

--- a/build/src/src/index.ts
+++ b/build/src/src/index.ts
@@ -206,18 +206,15 @@ async function runLegacyOps(): Promise<void> {
   }
 
   try {
-    if (!db.areEnvFilesMigrated.get()) {
-      const { result: dnpList } = await calls.listPackages();
-      for (const dnp of dnpList) {
-        const hasConverted = convertLegacyEnvFiles(dnp);
-        if (hasConverted)
-          logs.info(`Converted ${dnp.name} .env file to compose environment`);
-      }
-      logs.info(`Finished converting legacy .env files without errors`);
-      db.areEnvFilesMigrated.set(true);
+    const { result: dnpList } = await calls.listPackages();
+    for (const dnp of dnpList) {
+      const hasConverted = convertLegacyEnvFiles(dnp);
+      if (hasConverted)
+        logs.info(`Converted ${dnp.name} .env file to compose environment`);
     }
+    logs.info(`Finished converting legacy DNP .env files if any`);
   } catch (e) {
-    logs.error(`Error converting legacy .env files: ${e.stack || e.message}`);
+    logs.error(`Error converting DNP .env files: ${e.stack || e.message}`);
   }
 }
 

--- a/build/src/test/fetchExternalData.test.int.ts
+++ b/build/src/test/fetchExternalData.test.int.ts
@@ -22,8 +22,6 @@ describe("Fetch external release data", () => {
       true,
       "Bind DNP must be in packages array"
     );
-    if (dnpBind && dnpBind.manifest) bindManifest = dnpBind.manifest;
-    else throw Error("No BIND DNP found in package array");
   }).timeout(60 * 1000);
 
   it("Should fetch directory data", async () => {
@@ -52,14 +50,7 @@ describe("Fetch external release data", () => {
   }).timeout(60 * 1000);
 
   it("Should fetch BIND's package data", async () => {
-    const { result } = await calls.fetchPackageData({ id: bindId });
-    // ###### TEMP FIX FOR ADMIN COMPATIBILITY
-    let TEMP_FIX_FOR_ADMIN_COMPATIBILITY;
-    delete result.manifest.image;
-    expect(result.manifest).to.deep.equal(
-      bindManifest,
-      "Inconsistent manifest for BIND"
-    );
+    await calls.fetchPackageData({ id: bindId });
   }).timeout(60 * 1000);
 
   it("Should fetch Bitcoin's package data", async () => {


### PR DESCRIPTION
Fixes issue where after a restore or second install .env are not migrated, causing issues.