### PR TITLE
Increase max buffer limit for docker logs

### DIFF
--- a/build/src/src/modules/docker/dockerCommands.ts
+++ b/build/src/src/modules/docker/dockerCommands.ts
@@ -104,7 +104,9 @@ export function dockerLogs(
   if (options && options.timestamps) optionsString += " --timestamps";
   if (options && options.tail && !isNaN(options.tail))
     optionsString += ` --tail ${options.tail}`;
-  return shell(`docker logs ${containerNameOrId} ${optionsString} 2>&1`);
+  return shell(`docker logs ${containerNameOrId} ${optionsString} 2>&1`, {
+    maxBuffer: 1024 * 1024 * 10 // 10 MB
+  });
 }
 
 // File manager, copy command

--- a/build/src/src/modules/docker/shell.ts
+++ b/build/src/src/modules/docker/shell.ts
@@ -11,7 +11,7 @@ const logs = Logs(module);
 
 export default async function shellWrap(
   cmd: string,
-  options?: { timeout?: number }
+  options?: { timeout?: number; maxBuffer?: number }
 ): Promise<string> {
   try {
     return await shell(cmd, options);

--- a/build/src/src/utils/shell.ts
+++ b/build/src/src/utils/shell.ts
@@ -18,12 +18,13 @@ const exec = util.promisify(child.exec);
  */
 const defaultTimeout = 15 * 60 * 1000; // ms
 
-export default function shell(
+export default async function shell(
   cmd: string,
-  options?: { timeout?: number }
+  options?: { timeout?: number; maxBuffer?: number }
 ): Promise<string> {
   const timeout = options && options.timeout ? options.timeout : defaultTimeout;
-  return exec(cmd, { timeout })
+  const maxBuffer = options && options.maxBuffer;
+  return exec(cmd, { timeout, maxBuffer })
     .then(res => (res.stdout || "").trim())
     .catch(err => {
       if (err.signal === "SIGTERM") {


### PR DESCRIPTION
Increases the limit from 200Kb - 1MB (documentation is not clear) to 10MB
Fixes https://github.com/dappnode/DNP_DAPPMANAGER/issues/302