### PR TITLE
Add signing function to API

### DIFF
--- a/build/src/src/modules/docker/dockerApi.ts
+++ b/build/src/src/modules/docker/dockerApi.ts
@@ -14,6 +14,7 @@ export interface DockerApiListContainerOptions {
     health?: string; // "(starting|healthy|unhealthy|none)";
     // MUST be an array of: [byId]
     id?: string[]; // "<ID> a container's ID";
+    ip?: string[]; // "<IP> a container's IP'"
     isolation?: string; // "(default|process|hyperv) (Windows daemon only)";
     "is-task"?: string; //"(true|false)";
     label?: string; // "key or label='key=value' of a container label";

--- a/build/src/src/params.ts
+++ b/build/src/src/params.ts
@@ -41,11 +41,14 @@ const params = {
   GLOBAL_ENVS_PATH_CORE: path.join(".", GLOBAL_ENVS_FILE_NAME),
   GLOBAL_ENVS_PATH_DNP: path.join("../../", DNCORE_DIR, GLOBAL_ENVS_FILE_NAME),
   GLOBAL_ENVS_PATH_NODE: path.join(DNCORE_DIR, GLOBAL_ENVS_FILE_NAME),
-  PRIVATE_KEY_PATH: path.join(DNCORE_DIR, ".indentity.private.key"),
+
   // Host script paths
   HOST_SCRIPTS_DIR_FROM_HOST: path.join(HOST_HOME, "DNCORE/scripts/host"),
   HOST_SCRIPTS_DIR: "DNCORE/scripts/host",
   HOST_SCRIPTS_SOURCE_DIR: "hostScripts",
+
+  PRIVATE_KEY_PATH: path.join(DNCORE_DIR, ".identity.private.key"),
+  SIGNATURE_PREFIX: "\x1dDappnode Signed Message:\n",
 
   // HTTP API parameters
   apiUrl: "http://dappmanager.dappnode",

--- a/build/src/src/utils/sign.ts
+++ b/build/src/src/utils/sign.ts
@@ -1,0 +1,20 @@
+import EthCrypto from "eth-crypto";
+import fs from "fs";
+import params from "../params";
+
+const privateKeyPath = params.PRIVATE_KEY_PATH;
+
+export default function signWithPrivateKey(data: string): string {
+  if (!fs.existsSync(privateKeyPath))
+    throw Error(`Private key not found at: ${privateKeyPath}`);
+  const privateKey = fs.readFileSync(privateKeyPath, "utf8");
+
+  // Adding a custom prefix to signature to prevent signing arbitrary data.
+  // See https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_sign
+  return EthCrypto.sign(
+    privateKey,
+    EthCrypto.hash.keccak256(
+      params.SIGNATURE_PREFIX + String(data.length) + data
+    )
+  );
+}


### PR DESCRIPTION
Allow DAppNode packages to request the DAPPMANAGER to sign arbitrary (prefixed) data by doing a HTTP GET request to `:3000/sign`