### PR TITLE
Prevent directories from merging into destination

### DIFF
--- a/build/src/hostScripts/migrate_volume.sh
+++ b/build/src/hostScripts/migrate_volume.sh
@@ -29,9 +29,8 @@ fi
 FROM_PATH=${DOCKER_ROOT_DIR}/volumes/${FROM_VOLUME_NAME}
 TO_PATH=${DOCKER_ROOT_DIR}/volumes/${TO_VOLUME_NAME}
 
-if [[ -d TO_PATH ]]
-then
-  echo "TO_PATH already exists"
+if [[ -d "${TO_PATH}" ]]; then
+  echo "Error: ${TO_PATH} already exists."
   exit 1
 fi
 

--- a/build/src/hostScripts/migrate_volume.sh
+++ b/build/src/hostScripts/migrate_volume.sh
@@ -26,6 +26,13 @@ if [[ -z "${DOCKER_ROOT_DIR}" ]]; then
   exit 1
 fi
 
+FROM_PATH=${DOCKER_ROOT_DIR}/volumes/${FROM_VOLUME_NAME}
+TO_PATH=${DOCKER_ROOT_DIR}/volumes/${TO_VOLUME_NAME}
 
+if [[ -d TO_PATH ]]
+then
+  echo "TO_PATH already exists"
+  exit 1
+fi
 
-mv "${DOCKER_ROOT_DIR}/volumes/${FROM_VOLUME_NAME}" "${DOCKER_ROOT_DIR}/volumes/${TO_VOLUME_NAME}"
+mv "${FROM_PATH}" "${TO_PATH}"


### PR DESCRIPTION
During a test migration, the resulting docker volumes dir looked like

```
[root@DAppNodeLion:/var/lib/docker/volumes]# tree -L 2 openethereumdnpdappnodeeth_data/
openethereumdnpdappnodeeth_data/
├── _data
│   ├── cache
│   ├── chains
│   ├── keys
│   ├── network
│   └── signer
└── dncore_ethchaindnpdappnodeeth_data
    └── _data
```

Seems that the migration moved the directory `dncore_ethchaindnpdappnodeeth_data` to `openethereumdnpdappnodeeth_data` but since this last directory already existed, the first directory was placed inside instead of renamed.

### Proposed fix

Make sure the destination directory does not exist. @vdo:
- Is there an option of a flag for `mv` to prevent the behavior of placing the from a directory inside the target directory?
- Is this the best policy? Should we return an error and prevent overwriting the to directory or allow overwriting it?