### PR TITLE
Remove prepended bytes added to each line by the docker API

### DIFF
--- a/build/src/src/modules/docker/dockerApi.ts
+++ b/build/src/src/modules/docker/dockerApi.ts
@@ -1,5 +1,6 @@
 import Docker from "dockerode";
 import memoize from "memoizee";
+import { stripDockerApiLogsHeader } from "./utils";
 
 const dockerApi = new Docker({ socketPath: "/var/run/docker.sock" });
 
@@ -226,6 +227,8 @@ export async function logContainer(
   const res = await container.logs({ stdout: true, stderr: true, ...options });
   // Return is incorrectly typed as NodeJS.ReadableStream, but it's string
   /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-  const data: string = res as any;
-  return data;
+  const data: string = (res as any) || "";
+
+  // Remove prepended bytes added to each line by the docker API
+  return stripDockerApiLogsHeader(data);
 }

--- a/build/src/src/modules/docker/utils.ts
+++ b/build/src/src/modules/docker/utils.ts
@@ -1,0 +1,45 @@
+/**
+ * When fetching logs from the API, each line is prefixed by a Header
+ *
+ * It is encoded on the first 8 bytes like this:
+ *
+ *    header := [8]byte{STREAM_TYPE, 0, 0, 0, SIZE1, SIZE2, SIZE3, SIZE4}
+ *
+ * `STREAM_TYPE` can be:
+ *
+ * -   0: stdin (will be written on stdout)
+ * -   1: stdout
+ * -   2: stderr
+ *
+ * `SIZE1, SIZE2, SIZE3, SIZE4` are the 4 bytes of
+ * the uint32 size encoded as big endian.
+ *
+ * Example:
+ *
+ * \u0001\u0000\u0000\u0000\u0000\u0000\u0000O\u001b[32minfo\u001b[39m Starting cache DB cacheDbPath: \"/usr/src/app/data/cachedb.json\"\n\n
+ * \u0001\u0000\u0000\u0000\u0000\u0000\u0000L\u001b[32minfo\u001b[39m IPFS HTTP API httpApiUrl: \"http://ipfs.dappnode:5001/api/v0\"\n
+ * \u0001\u0000\u0000\u0000\u0000\u0000\u0000X\u001b[32minfo\u001b[39m IPFS Cluster HTTP API clusterApiUrl: \"http://ipfs-cluster.dappnode:9094\"\n
+ * \u0001\u0000\u0000\u0000\u0000\u0000\u0000N\u001b[32minfo\u001b[39m Web3 connected (ethers 4.0.39): http://fullnode.dappnode:8545 \n
+ * \u0001\u0000\u0000\u0000\u0000\u0000\u00003\u001b[32minfo\u001b[39m Webserver on 80, /usr/src/app/dist \n
+ *
+ * Where
+ *
+ * \u0001\u0000\u0000\u0000\u0000\u0000\u0000O
+ *
+ * is the header
+ */
+export function stripDockerApiLogsHeader(logs: string): string {
+  return logs
+    .split("\n")
+    .map(stripDockerApiLogHeader)
+    .join("\n");
+}
+
+function stripDockerApiLogHeader(line: string): string {
+  if (line[1] === "\u0000" && line[2] === "\u0000" && line[3] === "\u0000") {
+    // Has log, remove first 8 bytes
+    return line.substring(8);
+  } else {
+    return line;
+  }
+}

--- a/build/src/test/modules/docker/utils.test.ts
+++ b/build/src/test/modules/docker/utils.test.ts
@@ -1,0 +1,32 @@
+import "mocha";
+import { expect } from "chai";
+
+import { stripDockerApiLogsHeader } from "../../../src/modules/docker/utils";
+
+describe("docker API > utils", () => {
+  describe("stripDockerApiLogsHeader", () => {
+    const logSample = `
+\u0001\u0000\u0000\u0000\u0000\u0000\u0000O\u001b[32minfo\u001b[39m Starting cache DB cacheDbPath: \"/usr/src/app/data/cachedb.json\"\n
+\u0001\u0000\u0000\u0000\u0000\u0000\u0000L\u001b[32minfo\u001b[39m IPFS HTTP API httpApiUrl: \"http://ipfs.dappnode:5001/api/v0\"
+\u0001\u0000\u0000\u0000\u0000\u0000\u0000X\u001b[32minfo\u001b[39m IPFS Cluster HTTP API clusterApiUrl: \"http://ipfs-cluster.dappnode:9094\"
+\u0001\u0000\u0000\u0000\u0000\u0000\u0000N\u001b[32minfo\u001b[39m Web3 connected (ethers 4.0.39): http://fullnode.dappnode:8545
+\u0001\u0000\u0000\u0000\u0000\u0000\u00003\u001b[32minfo\u001b[39m Webserver on 80, /usr/src/app/dist`;
+
+    const logSampleCleanExpected = `
+\u001b[32minfo\u001b[39m Starting cache DB cacheDbPath: \"/usr/src/app/data/cachedb.json\"\n
+\u001b[32minfo\u001b[39m IPFS HTTP API httpApiUrl: \"http://ipfs.dappnode:5001/api/v0\"
+\u001b[32minfo\u001b[39m IPFS Cluster HTTP API clusterApiUrl: \"http://ipfs-cluster.dappnode:9094\"
+\u001b[32minfo\u001b[39m Web3 connected (ethers 4.0.39): http://fullnode.dappnode:8545
+\u001b[32minfo\u001b[39m Webserver on 80, /usr/src/app/dist`;
+
+    it("Should strip header from logs with header", () => {
+      const logSampleClean = stripDockerApiLogsHeader(logSample);
+      expect(logSampleClean).to.equal(logSampleCleanExpected);
+    });
+
+    it("Should not strip anything from clean logs", () => {
+      const logSampleClean = stripDockerApiLogsHeader(logSampleCleanExpected);
+      expect(logSampleClean).to.equal(logSampleCleanExpected);
+    });
+  });
+});


### PR DESCRIPTION
 When fetching logs from the API, each line is prefixed by a Header

 It is encoded on the first 8 bytes like this:

    header := [8]byte{STREAM_TYPE, 0, 0, 0, SIZE1, SIZE2, SIZE3, SIZE4}

 `STREAM_TYPE` can be:

 -   0: stdin (will be written on stdout)
 -   1: stdout
 -   2: stderr

 `SIZE1, SIZE2, SIZE3, SIZE4` are the 4 bytes of
 the uint32 size encoded as big endian.

 Example:
```
 \u0001\u0000\u0000\u0000\u0000\u0000\u0000O\u001b[32minfo\u001b[39m Starting cache DB cacheDbPath: \"/usr/src/app/data/cachedb.json\"\n\n
 \u0001\u0000\u0000\u0000\u0000\u0000\u0000L\u001b[32minfo\u001b[39m IPFS HTTP API httpApiUrl: \"http://ipfs.dappnode:5001/api/v0\"\n
 \u0001\u0000\u0000\u0000\u0000\u0000\u0000X\u001b[32minfo\u001b[39m IPFS Cluster HTTP API clusterApiUrl: \"http://ipfs-cluster.dappnode:9094\"\n
 \u0001\u0000\u0000\u0000\u0000\u0000\u0000N\u001b[32minfo\u001b[39m Web3 connected (ethers 4.0.39): http://fullnode.dappnode:8545 \n
 \u0001\u0000\u0000\u0000\u0000\u0000\u00003\u001b[32minfo\u001b[39m Webserver on 80, /usr/src/app/dist \n
```
 Where
```
 \u0001\u0000\u0000\u0000\u0000\u0000\u0000O
```
 is the header

----

This PR, removes the headers from all logs