### PR TITLE
Reduce log noise

### DIFF
--- a/build/src/src/registerHandler.ts
+++ b/build/src/src/registerHandler.ts
@@ -2,6 +2,7 @@ import logUserAction from "./logUserAction";
 import { Session } from "autobahn";
 import { RpcHandlerReturnGeneric } from "./types";
 import Logs from "./logs";
+import { EthProviderError } from "./modules/ethClient";
 const logs = Logs(module);
 
 /*
@@ -64,13 +65,16 @@ export const wrapErrors = <K>(
          * - Print a warning only
          */
         logs.warn(`Chain is still syncing, on ${event}: ${msg}`);
-      } else if (msg.includes("connection not open")) {
+      } else if (
+        msg.includes("connection not open") ||
+        e instanceof EthProviderError
+      ) {
         /**
          * 2. When attempting an JSON RPC but the connection with the node is closed
          * - Emit a userActionLog
          * - Print a warning only
          */
-        logs.warn(`Could not connect to ethchain node, on ${event}: ${msg}`);
+        logs.warn(`Eth provider error on ${event}: ${msg}`);
         logUserAction.log({ level: "error", event, ...error2obj(e), kwargs });
       } else {
         /**

--- a/build/src/src/watchers/autoUpdates/updateMyPackages.ts
+++ b/build/src/src/watchers/autoUpdates/updateMyPackages.ts
@@ -15,8 +15,9 @@ import installPackage from "../../calls/installPackage";
 import Logs from "../../logs";
 const logs = Logs(module);
 
-export default async function updateMyPackages(): Promise<void> {
-  const releaseFetcher = new ReleaseFetcher();
+export default async function updateMyPackages(
+  releaseFetcher: ReleaseFetcher
+): Promise<void> {
   const dnpList = await listContainers();
 
   for (const { name, isDnp, version: currentVersion } of dnpList) {

--- a/build/src/src/watchers/chains/index.ts
+++ b/build/src/src/watchers/chains/index.ts
@@ -100,7 +100,7 @@ async function getAndEmitChainData(): Promise<void> {
             ...chainDataResult
           };
         } catch (e) {
-          logs.warn(`Error on chain ${chain.dnpName} watcher: ${e.stack}`);
+          logs.debug(`Error on chain ${dnpName} watcher: ${e.stack}`);
           return {
             dnpName,
             syncing: false,


### PR DESCRIPTION
- Control chain watcher log noise
- Reduce auto-update log noise on expected errors
- Print only warning without stack in WAMP RPC calls on EthProviderError