### PR TITLE
Fix multiple ETHFORWARD issues

### DIFF
--- a/build/src/src/ethForward/index.ts
+++ b/build/src/src/ethForward/index.ts
@@ -56,7 +56,7 @@ export default function startEthForward(): void {
             // Usually happens when the node is not running
             if (e.message.includes("EHOSTUNREACH"))
               reject(new NodeNotAvailable(e.message, content.location));
-            else reject(new ProxyError(e.stack || e.message, target));
+            else reject(new ProxyError(e.message, target));
           });
         });
       }

--- a/build/src/src/ethForward/views/base.ts
+++ b/build/src/src/ethForward/views/base.ts
@@ -35,7 +35,7 @@ export function base(title: string, body: string, e?: Error): string {
   h1 { color: #555; font-size: 2em; font-weight: 400; }
   p { max-width: 400px; }
   a { color: #4db6a7; text-decoration: none; }
-  details { opacity: 0.75; }
+  details { opacity: 0.75; white-space: pre; text-align: left; }
 </style>
 </head>
 
@@ -48,7 +48,7 @@ export function base(title: string, body: string, e?: Error): string {
     e
       ? `
   <details>
-    <summary>${e.message}</summary>
+    <summary>${(e.message || "").split("\n")[0]}</summary>
     ${e.stack}
   </details>
   `

--- a/build/src/src/utils/url.ts
+++ b/build/src/src/utils/url.ts
@@ -1,0 +1,10 @@
+/**
+ * Joins multiple url parts safely
+ * - Does not break the protocol double slash //
+ * - Cleans double slashes at any point
+ * @param args ("http://ipfs.io", "ipfs", "Qm")
+ * @return "http://ipfs.io/ipfs/Qm"
+ */
+export function urlJoin(...args: string[]): string {
+  return args.join("/").replace(/([^:]\/)\/+/g, "$1");
+}


### PR DESCRIPTION
- Fix `http-proxy` binding issue that prevents resolving webs. The source code would fail since an internal use of `this` which was not binded failed
- Report ethForward ProxyErrors with more detail. Make sure the full original stack trace can be fetched by the user easily.
- Make sure only one HTML is written in the ethForward response. Fixed a typo that wrote data to the response stream after closing it