### PR TITLE
Run functions only in the index

### DIFF
--- a/build/src/src/db/index.ts
+++ b/build/src/src/db/index.ts
@@ -23,7 +23,7 @@ import { isEmpty } from "lodash";
 /**
  * Migrate keys to the new DB
  */
-function migrateToNewMainDb(): void {
+export function migrateToNewMainDb(): void {
   // AUTO_UPDATE_SETTINGS
   // Migrate ONLY if there are settings in the old DB
   const autoUpdateSettingsValue = lowLevelCacheDb.get(AUTO_UPDATE_SETTINGS);
@@ -34,15 +34,9 @@ function migrateToNewMainDb(): void {
 }
 
 /**
- * Alias
+ * Alias, General methods
  */
-const clearCache = lowLevelCacheDb.clearDb;
+export const clearCache = lowLevelCacheDb.clearDb;
 
-export {
-  // Aditional low levels methods
-  lowLevelMainDb,
-  lowLevelCacheDb,
-  // General methods
-  clearCache,
-  migrateToNewMainDb
-};
+// Aditional low levels methods
+export { lowLevelMainDb, lowLevelCacheDb };

--- a/build/src/src/watchers/diskUsage/index.ts
+++ b/build/src/src/watchers/diskUsage/index.ts
@@ -134,8 +134,12 @@ async function monitorDiskUsage(): Promise<void> {
   }
 }
 
-setInterval(() => {
-  monitorDiskUsage();
-}, monitoringInterval);
-
-export default monitorDiskUsage;
+/**
+ * Disk usage watcher.
+ * Prevents disk usage from getting full by stopping non-essential packages
+ */
+export default function runWatcher(): void {
+  setInterval(() => {
+    monitorDiskUsage();
+  }, monitoringInterval);
+}

--- a/build/src/src/watchers/dyndns/index.ts
+++ b/build/src/src/watchers/dyndns/index.ts
@@ -89,10 +89,13 @@ async function checkIpAndUpdateIfNecessary(): Promise<void> {
   }
 }
 
-setInterval(() => {
-  checkIpAndUpdateIfNecessary();
-}, dyndnsInterval);
+/**
+ * Dyndns watcher.
+ */
+export default function runWatcher(): void {
+  setInterval(() => {
+    checkIpAndUpdateIfNecessary();
+  }, dyndnsInterval);
 
-eventBus.initializedDb.on(checkIpAndUpdateIfNecessary);
-
-export default checkIpAndUpdateIfNecessary;
+  eventBus.initializedDb.on(checkIpAndUpdateIfNecessary);
+}

--- a/build/src/src/watchers/index.ts
+++ b/build/src/src/watchers/index.ts
@@ -1,13 +1,19 @@
-import "./autoUpdates";
-import "./chains";
-import "./diskUsage";
-import "./dyndns";
-import runEthMultiClient from "./ethMultiClient";
-import "./natRenewal";
-import "./nsupdate";
-import runVpnBridge from "./vpnBridge";
+import runAutoUpdates from "./autoUpdates";
+import runChainWatcher from "./chains";
+import runDiskUsageWatcher from "./diskUsage";
+import runDyndnsWatcher from "./dyndns";
+import runEthMultiClientWatcher from "./ethMultiClient";
+import runNatrenewal from "./natRenewal";
+import runNsupdateWatcher from "./nsupdate";
+import runVpnBridgeWatcher from "./vpnBridge";
 
 export default function runWatchers(): void {
-  runEthMultiClient();
-  runVpnBridge();
+  runAutoUpdates();
+  runChainWatcher();
+  runDiskUsageWatcher();
+  runDyndnsWatcher();
+  runEthMultiClientWatcher();
+  runNatrenewal();
+  runNsupdateWatcher();
+  runVpnBridgeWatcher();
 }

--- a/build/src/src/watchers/natRenewal/index.ts
+++ b/build/src/src/watchers/natRenewal/index.ts
@@ -115,13 +115,17 @@ async function natRenewal(): Promise<void> {
 
 const throttledNatRenewal = runOnlyOneSequentially(natRenewal);
 
-throttledNatRenewal();
-setInterval(() => {
+/**
+ * NAT renewal watcher.
+ * Makes sure all necessary ports are mapped using UPNP
+ */
+export default function runWatcher(): void {
   throttledNatRenewal();
-}, natRenewalInterval);
+  setInterval(() => {
+    throttledNatRenewal();
+  }, natRenewalInterval);
 
-eventBus.runNatRenewal.on(() => {
-  throttledNatRenewal();
-});
-
-export default throttledNatRenewal;
+  eventBus.runNatRenewal.on(() => {
+    throttledNatRenewal();
+  });
+}

--- a/build/src/src/watchers/nsupdate/index.ts
+++ b/build/src/src/watchers/nsupdate/index.ts
@@ -51,32 +51,37 @@ async function runNsupdate({
   }
 }
 
-// First call
-runNsupdate({});
-
-// Every interval
-setIntervalDynamic(() => {
+/**
+ * nsupdate watcher.
+ * Makes sure all package domains are mapped to their current IP
+ */
+export default function runWatcher(): void {
+  // First call
   runNsupdate({});
-}, [
-  // There may be a race condition between the DAPPMANAGER and the BIND
-  // On an update, if the DAPPMANAGER restarts first and then the BIND,
-  // there might be a potential window of `nsupdateInterval` hasn't applied
-  // the dynamic nsupdates provided by the DAPPMANAGER
-  // Since doing an nsupdate is cheap this increase in refresh frequency
-  // after a restart wants to prevents a potential issue by the race condition
-  1 * 60 * 1000, //        1  min
-  5 * 60 * 1000, //        5  min
-  nsupdateInterval / 4, // 15 min
-  nsupdateInterval / 2, // 30 min
-  nsupdateInterval //      60 min
-]);
 
-eventBus.packagesModified.on(({ ids, removed }) => {
-  // When the BIND is re-created, run nsupdate on all domains. Wait 5s to be active
-  if (ids.includes(params.bindDnpName)) setTimeout(() => runNsupdate({}), 5000);
-  // React immediatelly to new installs
-  else if (removed) runNsupdate({ ids, removeOnly: true });
-  else runNsupdate({ ids });
-});
+  // Every interval
+  setIntervalDynamic(() => {
+    runNsupdate({});
+  }, [
+    // There may be a race condition between the DAPPMANAGER and the BIND
+    // On an update, if the DAPPMANAGER restarts first and then the BIND,
+    // there might be a potential window of `nsupdateInterval` hasn't applied
+    // the dynamic nsupdates provided by the DAPPMANAGER
+    // Since doing an nsupdate is cheap this increase in refresh frequency
+    // after a restart wants to prevents a potential issue by the race condition
+    1 * 60 * 1000, //        1  min
+    5 * 60 * 1000, //        5  min
+    nsupdateInterval / 4, // 15 min
+    nsupdateInterval / 2, // 30 min
+    nsupdateInterval //      60 min
+  ]);
 
-export {};
+  eventBus.packagesModified.on(({ ids, removed }) => {
+    // When the BIND is re-created, run nsupdate on all domains. Wait 5s to be active
+    if (ids.includes(params.bindDnpName))
+      setTimeout(() => runNsupdate({}), 5000);
+    // React immediatelly to new installs
+    else if (removed) runNsupdate({ ids, removeOnly: true });
+    else runNsupdate({ ids });
+  });
+}


### PR DESCRIPTION
Prevent running unexpected code when just importing a module.
- Do not run watchers code in the body of the module