### PR TITLE
Move volume data fetching data to volumeGet method

### DIFF
--- a/packages/admin-ui/server-mock/data/dnps/lightningNetwork.ts
+++ b/packages/admin-ui/server-mock/data/dnps/lightningNetwork.ts
@@ -162,7 +162,14 @@ Content in the first column | Content in the second column
         protocol: "UDP"
       }
     ],
-    volumes: [],
+    volumes: [
+      {
+        name: "lightning-networkpublicdappnodeeth_data",
+        owner: "lightning-network.public.dappnode.eth",
+        host: "data",
+        container: "./data/ethereum"
+      }
+    ],
     userSettings: {
       environment: {
         ENV_NAME: "ENV_VALUE"

--- a/packages/admin-ui/server-mock/data/dnps/openEthereum.ts
+++ b/packages/admin-ui/server-mock/data/dnps/openEthereum.ts
@@ -43,8 +43,7 @@ export const openEthereum: MockDnp = {
         name: "paritydnpdappnodeeth_data",
         users: ["parity.dnp.dappnode.eth"],
         owner: "parity.dnp.dappnode.eth",
-        isOwner: true,
-        size: 71570000000
+        isOwner: true
       },
       {
         host: "/var/lib/docker/volumes/paritydnpdappnodeeth_geth/_data",
@@ -52,8 +51,7 @@ export const openEthereum: MockDnp = {
         name: "paritydnpdappnodeeth_geth",
         users: ["parity.dnp.dappnode.eth"],
         owner: "parity.dnp.dappnode.eth",
-        isOwner: true,
-        size: 94620000000
+        isOwner: true
       }
     ],
     canBeFullnode: true

--- a/packages/admin-ui/server-mock/methods/index.ts
+++ b/packages/admin-ui/server-mock/methods/index.ts
@@ -3,3 +3,4 @@ export * from "./devices";
 export * from "./packages";
 export * from "./pending";
 export * from "./userActionLogs";
+export * from "./volumes";

--- a/packages/admin-ui/server-mock/methods/pending.ts
+++ b/packages/admin-ui/server-mock/methods/pending.ts
@@ -9,10 +9,9 @@ import {
   NewFeatureStatus,
   PackageNotificationDb,
   PackageNotification,
-  SystemInfo,
-  VolumeData
+  SystemInfo
 } from "../../src/common";
-import { pause } from "../utils";
+import { mountpoints } from "../mockData";
 
 /**
  * Generates a backup of a package and sends it to the client for download.
@@ -155,7 +154,7 @@ export async function getStats(): Promise<HostStats> {
  * by running a pre-written script in the host
  */
 export async function mountpointsGet(): Promise<MountpointData[]> {
-  return [];
+  return mountpoints;
 }
 
 /**
@@ -317,62 +316,4 @@ export async function systemInfoGet(): Promise<SystemInfo> {
       // "change-host-password"
     ]
   };
-}
-
-/**
- * Removes a docker volume by name
- * @param name Full volume name: "bitcoindnpdappnodeeth_bitcoin_data"
- */
-export async function volumeRemove(kwargs: { name: string }): Promise<void> {
-  await pause(1000);
-}
-
-/**
- * Returns volume data
- */
-export async function volumesGet(): Promise<VolumeData[]> {
-  return [
-    {
-      name: "gethdnpdappnodeeth_data",
-      owner: undefined,
-      nameDisplay: "data",
-      ownerDisplay: "gethdnpdappnodeeth",
-      createdAt: 1569346006000,
-      mountpoint: "",
-      size: 161254123,
-      refCount: 0,
-      isOrphan: true
-    },
-    {
-      name: "lightning-networkpublicdappnodeeth_data",
-      owner: "lightning-network.public.dappnode.eth",
-      nameDisplay: "data",
-      ownerDisplay: "lightning-networkpublicdappnodeeth",
-      createdAt: 1569146006000,
-      mountpoint: "/media/usb0",
-      size: 0,
-      fileSystem: {
-        mountpoint: "/media/usb0",
-        use: "89%",
-        used: 198642520,
-        total: 235782040,
-        free: 25092776,
-        vendor: "SanDisk",
-        model: "Ultra_USB_3.0"
-      },
-      refCount: 2,
-      isOrphan: false
-    },
-    {
-      name: "d19f0771fe2e5b813cf0d138a77eddc33ae3fd6afc1cc6daf0fba42ed73e36ae",
-      owner: undefined,
-      nameDisplay: "",
-      ownerDisplay: "",
-      createdAt: 1569306006000,
-      mountpoint: "",
-      size: 24,
-      refCount: 0,
-      isOrphan: true
-    }
-  ];
 }

--- a/packages/admin-ui/server-mock/methods/volumes.ts
+++ b/packages/admin-ui/server-mock/methods/volumes.ts
@@ -1,0 +1,81 @@
+import { VolumeData } from "../../src/types";
+import { pause } from "../utils";
+import * as eventBus from "../eventBus";
+
+let volumes = [
+  {
+    name: "gethdnpdappnodeeth_data",
+    owner: undefined,
+    nameDisplay: "data",
+    ownerDisplay: "gethdnpdappnodeeth",
+    createdAt: 1569346006000,
+    mountpoint: "",
+    size: 161254123,
+    refCount: 0,
+    isOrphan: true
+  },
+  {
+    name: "lightning-networkpublicdappnodeeth_data",
+    owner: "lightning-network.public.dappnode.eth",
+    nameDisplay: "data",
+    ownerDisplay: "lightning-networkpublicdappnodeeth",
+    createdAt: 1569146006000,
+    mountpoint: "/media/usb0",
+    size: 0,
+    fileSystem: {
+      mountpoint: "/media/usb0",
+      use: "89%",
+      used: 198642520,
+      total: 235782040,
+      free: 25092776,
+      vendor: "SanDisk",
+      model: "Ultra_USB_3.0"
+    },
+    refCount: 2,
+    isOrphan: false
+  },
+  {
+    name: "d19f0771fe2e5b813cf0d138a77eddc33ae3fd6afc1cc6daf0fba42ed73e36ae",
+    owner: undefined,
+    nameDisplay: "",
+    ownerDisplay: "",
+    createdAt: 1569306006000,
+    mountpoint: "",
+    size: 24,
+    refCount: 0,
+    isOrphan: true
+  },
+  {
+    name: "paritydnpdappnodeeth_data",
+    owner: "parity.dnp.dappnode.eth",
+    size: 71570000000,
+    createdAt: 1569146006000,
+    mountpoint: "",
+    isOrphan: false
+  },
+  {
+    name: "paritydnpdappnodeeth_geth",
+    owner: "parity.dnp.dappnode.eth",
+    size: 94620000000,
+    createdAt: 1569146006000,
+    mountpoint: "",
+    isOrphan: false
+  }
+];
+
+/**
+ * Removes a docker volume by name
+ * @param name Full volume name: "bitcoindnpdappnodeeth_bitcoin_data"
+ */
+export async function volumeRemove({ name }: { name: string }): Promise<void> {
+  await pause(1000);
+  volumes = volumes.filter(v => v.name !== name);
+  eventBus.requestPackages.emit();
+}
+
+/**
+ * Returns volume data
+ */
+export async function volumesGet(): Promise<VolumeData[]> {
+  return volumes;
+}

--- a/packages/admin-ui/src/common/types.ts
+++ b/packages/admin-ui/src/common/types.ts
@@ -314,15 +314,6 @@ export interface PackageContainer {
 export interface InstalledPackageData extends PackageContainer {}
 
 export interface InstalledPackageDetailData extends InstalledPackageData {
-  // ### Have this in a separate endpoint?
-  volumesSize?: {
-    // volumeName = bitcoin_data
-    [volumeName: string]: {
-      size?: string; // "823203"
-      devicePath: string; // "/dev1/data/dappnode-volumes/bitcoin.dnp.dappnode.eth/data"
-      mountpoint?: string; // "/dev1/data"
-    };
-  };
   setupWizard?: SetupWizard;
   userSettings?: UserSettings;
   gettingStarted?: string;
@@ -838,7 +829,7 @@ export interface VolumeData {
   nameDisplay?: string; // "data", Guessed short name for display
   ownerDisplay?: string; // "gethdnpdappnodeeth", Guessed owner name for display
   createdAt: number; // 1569346006000,
-  mountpoint: string; // "",
+  mountpoint: string; // "/dev1/data",
   fileSystem?: MountpointData;
   size?: number; // 161254123,
   refCount?: number; // 2

--- a/packages/admin-ui/src/pages/packages/components/Info/Vols.tsx
+++ b/packages/admin-ui/src/pages/packages/components/Info/Vols.tsx
@@ -1,17 +1,19 @@
 import React from "react";
+import { useSelector } from "react-redux";
+import { getVolumes } from "services/dappnodeStatus/selectors";
 import DataList from "./DataList";
 import { prettyVolumeName, prettyBytes } from "utils/format";
-import { VolumeMapping, InstalledPackageDetailData } from "types";
+import { VolumeMapping } from "types";
 
 export default function Vols({
   dnpName,
-  volumes,
-  volumesDetail
+  volumes
 }: {
   dnpName: string;
   volumes: VolumeMapping[];
-  volumesDetail: InstalledPackageDetailData["volumesSize"];
 }) {
+  const volumesData = useSelector(getVolumes);
+
   return (
     <DataList
       title={"Volumes"}
@@ -24,9 +26,9 @@ export default function Vols({
         // - dncore_vpndnpdappnodeeth_data: 866B
         // - /etc/hostname: - (bind)
         .map(({ name, container, size, host }) => {
-          const volumeDetail = (volumesDetail || {})[name || ""];
-          const mountpointSize = volumeDetail ? volumeDetail.size : undefined;
-          const mountpoint = volumeDetail ? volumeDetail.mountpoint : undefined;
+          const volumeDetail = volumesData.find(v => v.name === name);
+          const mountpointSize = volumeDetail?.size;
+          const mountpoint = volumeDetail?.mountpoint;
           const prettyVol = prettyVolumeName(name || "", dnpName);
           const prettyVolString = [prettyVol.owner, prettyVol.name]
             .filter(s => s)
@@ -34,7 +36,7 @@ export default function Vols({
           return {
             name: name ? prettyVolString : container || "Unknown",
             size: mountpointSize
-              ? prettyBytes(parseInt(mountpointSize))
+              ? prettyBytes(mountpointSize)
               : typeof size === "number" && !isNaN(size)
               ? prettyBytes(size)
               : !name

--- a/packages/admin-ui/src/pages/packages/components/Info/index.tsx
+++ b/packages/admin-ui/src/pages/packages/components/Info/index.tsx
@@ -11,7 +11,7 @@ import Links from "./Links";
 import Vols from "./Vols";
 import StateBadge from "../StateBadge";
 import newTabProps from "utils/newTabProps";
-import { PackageContainer, Manifest, InstalledPackageDetailData } from "types";
+import { PackageContainer, Manifest } from "types";
 import "./info.scss";
 
 const ipfsGateway = "http://ipfs.dappnode:8080";
@@ -20,14 +20,12 @@ function Info({
   dnp,
   manifest,
   gettingStarted,
-  gettingStartedShow,
-  volumesDetail
+  gettingStartedShow
 }: {
   dnp: PackageContainer;
   manifest?: Manifest;
   gettingStarted?: string;
   gettingStartedShow?: boolean;
-  volumesDetail: InstalledPackageDetailData["volumesSize"];
 }) {
   const [gettingStartedShowLocal, setGettingStartedIsShown] = useState(false);
   const [allowUndo, setAllowUndo] = useState(false);
@@ -122,11 +120,7 @@ function Info({
         )}
 
         <div>
-          <Vols
-            dnpName={dnp.name}
-            volumes={dnp.volumes}
-            volumesDetail={volumesDetail}
-          />
+          <Vols dnpName={dnp.name} volumes={dnp.volumes} />
         </div>
 
         <div>

--- a/packages/admin-ui/src/pages/packages/pages/ById.tsx
+++ b/packages/admin-ui/src/pages/packages/pages/ById.tsx
@@ -59,8 +59,7 @@ export const PackageById: React.FC<RouteComponentProps<{
     setupWizard,
     manifest,
     gettingStarted,
-    gettingStartedShow,
-    volumesSize: volumesDetail
+    gettingStartedShow
   } = dnp;
   const { backup = [] } = manifest || {};
 
@@ -74,10 +73,7 @@ export const PackageById: React.FC<RouteComponentProps<{
       name: "Info",
       subPath: "info",
       render: () => (
-        <Info
-          dnp={dnp}
-          {...{ manifest, gettingStarted, gettingStartedShow, volumesDetail }}
-        />
+        <Info dnp={dnp} {...{ manifest, gettingStarted, gettingStartedShow }} />
       ),
       available: true
     },

--- a/packages/dappmanager/src/calls/volumesGet.ts
+++ b/packages/dappmanager/src/calls/volumesGet.ts
@@ -13,8 +13,8 @@ export async function volumesGet(): Promise<VolumeData[]> {
   const dnpList = await listContainers();
 
   // This expensive function won't be called on empty volDevicePaths
-  const callDetectMountpoints = volumes.some(vol => (vol.Options || {}).device);
-  const mountpoints = callDetectMountpoints ? await detectMountpoints() : [];
+  const shouldDetectMountpoints = volumes.some(vol => vol.Options?.device);
+  const mountpoints = shouldDetectMountpoints ? await detectMountpoints() : [];
 
   // TODO: Calling getHostVolumeSizes() is deactivated until UX is sorted out
   //       calling du on massive dirs can take +30min (i.e. Storj data));


### PR DESCRIPTION
Fetching volume data is very expensive as it uses `docker system df` underneath. UI should consume data from the package and volume endpoint and merge it in the info display.