### PR TITLE
Expose public packages endpoint

### DIFF
--- a/packages/dappmanager/src/api/index.ts
+++ b/packages/dappmanager/src/api/index.ts
@@ -21,6 +21,7 @@ import { upload } from "./routes/upload";
 import { containerLogs } from "./routes/containerLogs";
 import { downloadUserActionLogs } from "./routes/downloadUserActionLogs";
 import { globalEnvs } from "./routes/globalEnvs";
+import { publicPackagesData } from "./routes/publicPackagesData";
 
 const httpApiPort = params.HTTP_API_PORT;
 const uiFilesPath = params.UI_FILES_PATH;
@@ -86,6 +87,7 @@ export default function startHttpApi(
   app.post("/upload", isAdmin, wrapHandler(upload));
   // Open endpoints (no auth)
   app.get("/global-envs/:name?", wrapHandler(globalEnvs));
+  app.get("/public-packages/:id?", wrapHandler(publicPackagesData));
 
   // Rest of RPC methods
   app.post(

--- a/packages/dappmanager/src/api/routes/publicPackagesData.ts
+++ b/packages/dappmanager/src/api/routes/publicPackagesData.ts
@@ -1,0 +1,39 @@
+import express from "express";
+import {
+  listContainers,
+  listContainerNoThrow
+} from "../../modules/docker/listContainers";
+import { PackageContainer } from "../../types";
+
+/**
+ * Query publicly available packages data
+ */
+export const publicPackagesData: express.Handler = async (req, res) => {
+  const id = req.params.id as string | undefined;
+
+  if (id) {
+    const privateDnpData = await listContainerNoThrow(id);
+    if (privateDnpData) {
+      res.status(200).send(getPublicPackageData(privateDnpData));
+    } else {
+      res.status(404).send();
+    }
+  } else {
+    const privateDnpData = await listContainers();
+    res.status(200).send(privateDnpData.map(getPublicPackageData));
+  }
+};
+
+/**
+ * Return only non-sensitive data
+ */
+function getPublicPackageData(
+  container: PackageContainer
+): Pick<PackageContainer, "name" | "version" | "ip" | "state"> {
+  return {
+    name: container.name,
+    version: container.version,
+    ip: container.ip,
+    state: container.state
+  };
+}


### PR DESCRIPTION
`GET`, no credentials
```
/public-packages/:id?
```
Returns
```ts
{
    name: string;
    version: string;
    ip?: string;
    state: string;
}
```