### PR TITLE
Pablo docker timeout

### DIFF
--- a/packages/admin-ui/src/common/types.ts
+++ b/packages/admin-ui/src/common/types.ts
@@ -386,6 +386,7 @@ export interface PackageContainer {
   domainAlias?: string[];
   canBeFullnode?: boolean;
   isMain?: boolean;
+  dockerTimeout?: string;
   // Note: environment is only accessible doing a container inspect or reading the compose
   // envs?: PackageEnvs;
 }

--- a/packages/admin-ui/src/common/types.ts
+++ b/packages/admin-ui/src/common/types.ts
@@ -806,6 +806,7 @@ export type InstallPackageDataPaths = Pick<
   | "manifestBackupPath"
   | "imagePath"
   | "isUpdate"
+  | "timeout"
 >;
 
 export interface InstallPackageData extends PackageRelease {
@@ -820,6 +821,7 @@ export interface InstallPackageData extends PackageRelease {
   compose: Compose;
   // User settings to be applied after running
   fileUploads?: { [serviceName: string]: { [containerPath: string]: string } };
+  timeout: number | undefined;
 }
 
 // Must be in-sync with SDK types

--- a/packages/dappmanager/src/calls/packageRemove.ts
+++ b/packages/dappmanager/src/calls/packageRemove.ts
@@ -9,6 +9,7 @@ import shell from "../utils/shell";
 import { listPackage } from "../modules/docker/listContainers";
 import { restartPackageVolumes } from "../modules/docker/restartPackageVolumes";
 import { logs } from "../logs";
+import { getDockerTimeoutMax } from "../modules/docker/utils";
 
 /**
  * Remove package data: docker down + disk files
@@ -18,16 +19,15 @@ import { logs } from "../logs";
  */
 export async function packageRemove({
   dnpName,
-  deleteVolumes = false,
-  timeout = 10
+  deleteVolumes = false
 }: {
   dnpName: string;
   deleteVolumes?: boolean;
-  timeout?: number;
 }): Promise<void> {
   if (!dnpName) throw Error("kwarg dnpName must be defined");
 
   const dnp = await listPackage({ dnpName });
+  const timeout = getDockerTimeoutMax(dnp.containers);
 
   if (dnp.isCore || dnp.dnpName === params.dappmanagerDnpName) {
     throw Error("Core packages cannot be cannot be removed");

--- a/packages/dappmanager/src/calls/packageRestart.ts
+++ b/packages/dappmanager/src/calls/packageRestart.ts
@@ -1,4 +1,6 @@
+import { PackageContainer } from "../common";
 import * as eventBus from "../eventBus";
+import { listPackage } from "../modules/docker/listContainers";
 import { restartPackage } from "../modules/docker/restartPackage";
 
 /**
@@ -13,9 +15,30 @@ export async function packageRestart({
 }): Promise<void> {
   if (!dnpName) throw Error("kwarg dnpName must be defined");
 
-  await restartPackage({ dnpName, serviceNames, forceRecreate: true });
+  const dnp = await listPackage({ dnpName });
+  const timeout = getDockerTimeout(dnp.containers);
+  await restartPackage({
+    dnpName,
+    serviceNames,
+    forceRecreate: true,
+    timeout
+  });
 
   // Emit packages update
   eventBus.requestPackages.emit();
   eventBus.packagesModified.emit({ dnpNames: [dnpName] });
+}
+
+function getDockerTimeout(containers: PackageContainer[]): number | undefined {
+  let timeout: number | undefined = undefined;
+
+  for (const container of containers) {
+    if (container.dockerTimeout) {
+      const timeoutNumber = parseInt(container.dockerTimeout);
+      if (!timeout || timeoutNumber > timeout) {
+        timeout = timeoutNumber;
+      }
+    }
+  }
+  return timeout;
 }

--- a/packages/dappmanager/src/calls/packageRestart.ts
+++ b/packages/dappmanager/src/calls/packageRestart.ts
@@ -1,7 +1,7 @@
-import { PackageContainer } from "../common";
 import * as eventBus from "../eventBus";
 import { listPackage } from "../modules/docker/listContainers";
 import { restartPackage } from "../modules/docker/restartPackage";
+import { getDockerTimeoutMax } from "../modules/docker/utils";
 
 /**
  * Recreates a package containers
@@ -16,7 +16,7 @@ export async function packageRestart({
   if (!dnpName) throw Error("kwarg dnpName must be defined");
 
   const dnp = await listPackage({ dnpName });
-  const timeout = getDockerTimeout(dnp.containers);
+  const timeout = getDockerTimeoutMax(dnp.containers);
   await restartPackage({
     dnpName,
     serviceNames,
@@ -27,18 +27,4 @@ export async function packageRestart({
   // Emit packages update
   eventBus.requestPackages.emit();
   eventBus.packagesModified.emit({ dnpNames: [dnpName] });
-}
-
-function getDockerTimeout(containers: PackageContainer[]): number | undefined {
-  let timeout: number | undefined = undefined;
-
-  for (const container of containers) {
-    if (container.dockerTimeout) {
-      const timeoutNumber = parseInt(container.dockerTimeout);
-      if (!timeout || timeoutNumber > timeout) {
-        timeout = timeoutNumber;
-      }
-    }
-  }
-  return timeout;
 }

--- a/packages/dappmanager/src/calls/packageStartStop.ts
+++ b/packages/dappmanager/src/calls/packageStartStop.ts
@@ -1,6 +1,7 @@
 import { listPackage } from "../modules/docker/listContainers";
 import { dockerStart, dockerStop } from "../modules/docker/dockerCommands";
 import * as eventBus from "../eventBus";
+import { getDockerTimeoutMax } from "../modules/docker/utils";
 
 /**
  * Stops or starts a package containers
@@ -8,16 +9,15 @@ import * as eventBus from "../eventBus";
  */
 export async function packageStartStop({
   dnpName,
-  serviceNames,
-  timeout = 10
+  serviceNames
 }: {
   dnpName: string;
   serviceNames?: string[];
-  timeout?: number;
 }): Promise<void> {
   if (!dnpName) throw Error("kwarg containerName must be defined");
 
   const dnp = await listPackage({ dnpName });
+  const timeout = getDockerTimeoutMax(dnp.containers);
 
   const targetContainers = dnp.containers.filter(
     c => !serviceNames || serviceNames.includes(c.serviceName)

--- a/packages/dappmanager/src/db/coreUpdate.ts
+++ b/packages/dappmanager/src/db/coreUpdate.ts
@@ -31,7 +31,8 @@ export const coreUpdatePackagesData = {
                 "manifestPath",
                 "manifestBackupPath",
                 "imagePath",
-                "isUpdate"
+                "isUpdate",
+                "timeout"
               ])
           )
         : packagesData

--- a/packages/dappmanager/src/modules/compose/labelsDb.ts
+++ b/packages/dappmanager/src/modules/compose/labelsDb.ts
@@ -131,6 +131,7 @@ export function readContainerLabels(
   defaultEnvironment: string[];
   defaultPorts: string[];
   defaultVolumes: string[];
+  dockerTimeout: string;
 }> {
   const labelValues = parseContainerLabels(labelsRaw);
   return {
@@ -147,6 +148,7 @@ export function readContainerLabels(
     defaultEnvironment: labelValues["dappnode.dnp.default.environment"],
     defaultPorts: labelValues["dappnode.dnp.default.ports"],
     defaultVolumes: labelValues["dappnode.dnp.default.volumes"]
+    //dockerTimeout: labelValues["dappnode.dnp.default.timeOut"]
   };
 }
 

--- a/packages/dappmanager/src/modules/docker/listContainers.ts
+++ b/packages/dappmanager/src/modules/docker/listContainers.ts
@@ -130,6 +130,7 @@ function parseContainerInfo(container: ContainerInfo): PackageContainer {
     labels.defaultPorts && parsePortMappings(labels.defaultPorts);
   const defaultVolumes =
     labels.defaultVolumes && parseVolumeMappings(labels.defaultVolumes);
+  const dockerTimeout = labels.dockerTimeout;
 
   return {
     // Identification
@@ -190,7 +191,8 @@ function parseContainerInfo(container: ContainerInfo): PackageContainer {
     // Default settings on the original package version's docker-compose
     defaultEnvironment,
     defaultPorts,
-    defaultVolumes
+    defaultVolumes,
+    dockerTimeout
   };
 }
 

--- a/packages/dappmanager/src/modules/docker/restartPackage.ts
+++ b/packages/dappmanager/src/modules/docker/restartPackage.ts
@@ -12,11 +12,13 @@ import { dockerComposeUp } from "./dockerCommands";
 export async function restartPackage({
   dnpName,
   serviceNames,
-  forceRecreate
+  forceRecreate,
+  timeout
 }: {
   dnpName: string;
   serviceNames?: string[];
   forceRecreate: boolean;
+  timeout?: number;
 }): Promise<void> {
   const composePath = getPath.dockerComposeSmart(dnpName);
   if (!fs.existsSync(composePath)) {
@@ -27,6 +29,10 @@ export async function restartPackage({
     await restartDappmanagerPatch({ composePath });
   } else {
     // Note: About restartPatch, combining rm && up doesn't prevent the installer from crashing
-    await dockerComposeUp(composePath, { forceRecreate, serviceNames });
+    await dockerComposeUp(composePath, {
+      forceRecreate,
+      serviceNames,
+      timeout
+    });
   }
 }

--- a/packages/dappmanager/src/modules/docker/restartPackageVolumes.ts
+++ b/packages/dappmanager/src/modules/docker/restartPackageVolumes.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import { uniq } from "lodash";
 import { dockerRm, dockerComposeUp } from "./dockerCommands";
-import { listPackage, listPackages } from "./listContainers";
+import { listPackages } from "./listContainers";
 import { removeNamedVolume } from "./removeNamedVolume";
 import params from "../../params";
 // Utils

--- a/packages/dappmanager/src/modules/docker/restartPackageVolumes.ts
+++ b/packages/dappmanager/src/modules/docker/restartPackageVolumes.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import { uniq } from "lodash";
 import { dockerRm, dockerComposeUp } from "./dockerCommands";
-import { listPackages } from "./listContainers";
+import { listPackage, listPackages } from "./listContainers";
 import { removeNamedVolume } from "./removeNamedVolume";
 import params from "../../params";
 // Utils
@@ -10,6 +10,7 @@ import { logs } from "../../logs";
 import { VolumeOwnershipData } from "../../types";
 import { getVolumesOwnershipData } from "./volumesData";
 import { InstalledPackageData } from "../../common";
+import { getDockerTimeoutMax } from "./utils";
 
 /**
  * ```
@@ -38,11 +39,13 @@ type VolumesToRemove = string[];
 export async function restartPackageVolumes({
   dnpName,
   doNotRestart,
-  volumeId
+  volumeId,
+  timeout
 }: {
   dnpName: string;
   doNotRestart?: boolean;
   volumeId?: string;
+  timeout?: number;
 }): Promise<{ removedDnps: string[] }> {
   if (!dnpName) throw Error("kwarg dnpName must be defined");
 
@@ -66,6 +69,7 @@ export async function restartPackageVolumes({
   // Verify results
   const composePaths: { [dnpName: string]: string } = {};
   const containerNames: { [dnpName: string]: string[] } = {};
+  const timeoutByDnpName: { [dnpName: string]: number | undefined } = {};
 
   /**
    * Load docker-compose paths and verify results
@@ -87,6 +91,9 @@ export async function restartPackageVolumes({
           `No compose found for ${dnpToRemove.dnpName}: ${composePath}`
         );
 
+      timeoutByDnpName[dnpToRemove.dnpName] = getDockerTimeoutMax(
+        dnpToRemove.containers
+      );
       composePaths[dnpToRemove.dnpName] = composePath;
 
       for (const container of dnpToRemove.containers) {
@@ -127,7 +134,10 @@ export async function restartPackageVolumes({
     // It is critical up packages in the correct order,
     // so that the named volumes are created before the users are started
     for (const dnpName of dnpsToRemoveSorted)
-      if (composePaths[dnpName]) await dockerComposeUp(composePaths[dnpName]);
+      if (composePaths[dnpName])
+        await dockerComposeUp(composePaths[dnpName], {
+          timeout: timeoutByDnpName[dnpName]
+        });
   }
 
   // In case of error: FIRST up the dnp, THEN throw the error

--- a/packages/dappmanager/src/modules/docker/utils.ts
+++ b/packages/dappmanager/src/modules/docker/utils.ts
@@ -1,3 +1,5 @@
+import { PackageContainer } from "../../common";
+
 /**
  * When fetching logs from the API, each line is prefixed by a Header
  *
@@ -42,4 +44,24 @@ function stripDockerApiLogHeader(line: string): string {
   } else {
     return line;
   }
+}
+
+/**
+ * Returns the maximum dockerTimeout param from the container or undefined if none
+ * @param containers
+ */
+export function getDockerTimeoutMax(
+  containers: PackageContainer[]
+): number | undefined {
+  let timeout: number | undefined = undefined;
+
+  for (const container of containers) {
+    if (container.dockerTimeout) {
+      const timeoutNumber = parseInt(container.dockerTimeout);
+      if (!timeout || timeoutNumber > timeout) {
+        timeout = timeoutNumber;
+      }
+    }
+  }
+  return timeout;
 }

--- a/packages/dappmanager/src/modules/docker/utils.ts
+++ b/packages/dappmanager/src/modules/docker/utils.ts
@@ -1,4 +1,4 @@
-import { PackageContainer } from "../../common";
+import { PackageContainer } from "../../types";
 
 /**
  * When fetching logs from the API, each line is prefixed by a Header

--- a/packages/dappmanager/src/modules/installer/getInstallerPackageData.ts
+++ b/packages/dappmanager/src/modules/installer/getInstallerPackageData.ts
@@ -58,6 +58,8 @@ function getInstallerPackageData(
   const compose = new ComposeEditor(release.compose);
   compose.applyUserSettings(nextUserSet, { dnpName });
 
+  const timeout;
+
   return {
     ...release,
     isUpdate: Boolean(currentVersion),
@@ -70,6 +72,7 @@ function getInstallerPackageData(
     // Data to write
     compose: compose.output(),
     // User settings to be applied by the installer
-    fileUploads: userSettings?.fileUploads
+    fileUploads: userSettings?.fileUploads,
+    timeout
   };
 }

--- a/packages/dappmanager/src/modules/installer/getInstallerPackageData.ts
+++ b/packages/dappmanager/src/modules/installer/getInstallerPackageData.ts
@@ -58,7 +58,7 @@ function getInstallerPackageData(
   const compose = new ComposeEditor(release.compose);
   compose.applyUserSettings(nextUserSet, { dnpName });
 
-  const timeout;
+  const timeout = undefined;
 
   return {
     ...release,

--- a/packages/dappmanager/src/modules/installer/rollbackPackages.ts
+++ b/packages/dappmanager/src/modules/installer/rollbackPackages.ts
@@ -48,7 +48,7 @@ export async function rollbackPackages(
     }
 
   // Restore backup versions
-  for (const { dnpName, composePath, isUpdate } of packagesData)
+  for (const { dnpName, composePath, isUpdate, timeout } of packagesData)
     try {
       log(dnpName, "Aborting and rolling back...");
 
@@ -58,7 +58,7 @@ export async function rollbackPackages(
         // restartPatch failed before stopping the original container there's no need
         // to roll back, since the current container has the original version.
       } else if (isUpdate) {
-        await dockerComposeUp(composePath);
+        await dockerComposeUp(composePath, { timeout });
       } else {
         // Remove new containers that were NOT installed before this install call
         await dockerComposeRm(composePath);

--- a/packages/dappmanager/src/modules/installer/runPackages.ts
+++ b/packages/dappmanager/src/modules/installer/runPackages.ts
@@ -34,7 +34,10 @@ export async function runPackages(
         log(pkg.dnpName, "Copying file uploads...");
         logs.debug(`${pkg.dnpName} fileUploads`, pkg.fileUploads);
 
-        await dockerComposeUp(pkg.composePath, { noStart: true });
+        await dockerComposeUp(pkg.composePath, {
+          noStart: true,
+          timeout: pkg.timeout
+        });
         for (const [serviceName, serviceFileUploads] of Object.entries(
           pkg.fileUploads
         ))

--- a/packages/dappmanager/src/modules/installer/runPackages.ts
+++ b/packages/dappmanager/src/modules/installer/runPackages.ts
@@ -50,7 +50,7 @@ export async function runPackages(
       }
 
       log(pkg.dnpName, "Starting package... ");
-      await dockerComposeUp(pkg.composePath);
+      await dockerComposeUp(pkg.composePath, { timeout: pkg.timeout });
     }
 
     log(pkg.dnpName, "Package started");

--- a/packages/dappmanager/test/calls/packageRemove.test.ts
+++ b/packages/dappmanager/test/calls/packageRemove.test.ts
@@ -73,8 +73,8 @@ describe("Call function: packageRemove", function() {
 
   it("should have called docker-compose down", async () => {
     sinon.assert.callCount(dockerComposeDown, 1);
-    expect(dockerComposeDown.firstCall.args).to.deep.equal(
-      [dockerComposePath, { volumes: false, timeout: 10 }],
+    expect(dockerComposeDown.firstCall.args[0]).to.deep.equal(
+      dockerComposePath,
       `should call docker.compose.down for the package ${dnpName}`
     );
   });

--- a/packages/dappmanager/test/integration/dnpLifecycle.test.int.ts
+++ b/packages/dappmanager/test/integration/dnpLifecycle.test.int.ts
@@ -511,7 +511,7 @@ describe("DNP lifecycle", function() {
     });
 
     it("Should stop the DNP", async () => {
-      await calls.packageStartStop({ dnpName: dnpNameMain, timeout: 0 });
+      await calls.packageStartStop({ dnpName: dnpNameMain });
     });
 
     it(`DNP should be running`, async () => {
@@ -520,7 +520,7 @@ describe("DNP lifecycle", function() {
     });
 
     it("Should start the DNP", async () => {
-      await calls.packageStartStop({ dnpName: dnpNameMain, timeout: 0 });
+      await calls.packageStartStop({ dnpName: dnpNameMain });
     });
 
     it(`DNP should be running`, async () => {

--- a/packages/dappmanager/test/integration/resilienceFeatures.test.int.ts
+++ b/packages/dappmanager/test/integration/resilienceFeatures.test.int.ts
@@ -54,7 +54,7 @@ describe("Resilience features, when things go wrong", function() {
     it("Remove the compose and then remove the package", async () => {
       const composePath = getPath.dockerCompose(dnpName, false);
       fs.unlinkSync(composePath);
-      await calls.packageRemove({ dnpName, deleteVolumes: true, timeout: 0 });
+      await calls.packageRemove({ dnpName, deleteVolumes: true });
     });
   });
 
@@ -70,7 +70,7 @@ describe("Resilience features, when things go wrong", function() {
       const composePath = getPath.dockerCompose(dnpName, false);
       const composeString = fs.readFileSync(composePath, "utf8");
       fs.writeFileSync(composePath, composeString + "BROKEN");
-      await calls.packageRemove({ dnpName, deleteVolumes: true, timeout: 0 });
+      await calls.packageRemove({ dnpName, deleteVolumes: true });
     });
   });
 

--- a/packages/dappmanager/test/testUtils.ts
+++ b/packages/dappmanager/test/testUtils.ts
@@ -258,7 +258,8 @@ export const mockPackageData: InstallPackageData = {
   composePath: "mock/path/compose",
   composeBackupPath: "mock/path/compose.backup.yml",
   manifestPath: "mock/path/manifest.json",
-  manifestBackupPath: "mock/path/manifest.backup.json"
+  manifestBackupPath: "mock/path/manifest.backup.json",
+  timeout: undefined
 };
 
 // For copyFileTo and copyFileFrom


### PR DESCRIPTION
**Added timeout parameter to:**
- `dockerComposeUp():` called in restartPackage, restartPackageVolumes, rollbackPackages, runPackages, and tests.
- `dockerComposeDown():` called in packageRemove and tests.
- `dockerComposeStop():` no needed to change anything in the background since it is not called anywhere.
- `dockerStop():` called in packageStartStop and tests.

**Added new funtion:**
- `getDockerTimeoutMax():` this function returns the maximum timeout value from all the docker packages, in order to be used in the corersponding place.

**Other changes**
These changes were implemented after running yarn build
- Due to the delete of the timeout parameter in some functions in the previous commit, there have appeared some errors due to functions calls with this parameter. There have been deleted the timeout parameter in these function calls.
- Added timeout parameter to coreUpdatePackageData()
- Give undefined value to timeout parameter in getInstallerPackageData()

