### PR TITLE
Add sign endpoint

### DIFF
--- a/packages/admin-ui/server-mock/index.ts
+++ b/packages/admin-ui/server-mock/index.ts
@@ -42,6 +42,7 @@ const server = startHttpApi({
     globalEnvs: () => {},
     packageManifest: () => {},
     publicPackagesData: () => {},
+    sign: () => {},
     upload: () => {}
   },
   ethForwardMiddleware: (req, res, next) => {

--- a/packages/dappmanager/src/api/routes/index.ts
+++ b/packages/dappmanager/src/api/routes/index.ts
@@ -4,5 +4,5 @@ export * from "./downloadUserActionLogs";
 export * from "./globalEnvs";
 export * from "./packageManifest";
 export * from "./publicPackagesData";
-export * from "./signFromPackage";
+export * from "./sign";
 export * from "./upload";

--- a/packages/dappmanager/src/api/routes/index.ts
+++ b/packages/dappmanager/src/api/routes/index.ts
@@ -4,4 +4,5 @@ export * from "./downloadUserActionLogs";
 export * from "./globalEnvs";
 export * from "./packageManifest";
 export * from "./publicPackagesData";
+export * from "./signFromPackage";
 export * from "./upload";

--- a/packages/dappmanager/src/api/routes/sign.ts
+++ b/packages/dappmanager/src/api/routes/sign.ts
@@ -6,15 +6,13 @@ import {
 } from "../../utils/sign";
 import { wrapHandler } from "../utils";
 
-interface Params {
-  data: string;
-}
+type Params = {};
 
 /**
  * Sign arbitrary requests by packages
  */
-export const signFromPackage = wrapHandler<Params>(async (req, res) => {
-  const data = req.params.data as string | undefined;
+export const sign = wrapHandler<Params>(async (req, res) => {
+  const data = req.body as string | undefined;
 
   try {
     if (typeof data === undefined) throw Error("missing");

--- a/packages/dappmanager/src/api/routes/signFromPackage.ts
+++ b/packages/dappmanager/src/api/routes/signFromPackage.ts
@@ -1,0 +1,47 @@
+import * as db from "../../db";
+import { listContainers } from "../../modules/docker/listContainers";
+import {
+  signDataFromPackage,
+  getAddressFromPrivateKey
+} from "../../utils/sign";
+import { wrapHandler } from "../utils";
+
+interface Params {
+  data: string;
+}
+
+/**
+ * Sign arbitrary requests by packages
+ */
+export const signFromPackage = wrapHandler<Params>(async (req, res) => {
+  const data = req.params.data as string | undefined;
+
+  try {
+    if (typeof data === undefined) throw Error("missing");
+    if (typeof data !== "string") throw Error("must be a string");
+    if (!data) throw Error("must not be empty");
+  } catch (e) {
+    return res.status(400).send(`Arg data ${e.message}`);
+  }
+
+  // Find IPv4 adresses only, this is a IPv6 to IPv4 prefix
+  const ipv4 = req.ip.replace("::ffff:", "");
+  const dnps = await listContainers();
+  const dnp = dnps.find(_dnp => _dnp.ip === ipv4);
+  if (!dnp) return res.status(405).send(`No DNP found for ip ${ipv4}`);
+
+  const privateKey = db.dyndnsIdentity.get()?.privateKey;
+  if (!privateKey) throw Error("Private key not initialized");
+
+  const address = getAddressFromPrivateKey(privateKey);
+  const signature = signDataFromPackage({
+    privateKey,
+    packageEnsName: dnp.dnpName,
+    data
+  });
+
+  return res.status(200).send({
+    signature,
+    address
+  });
+});

--- a/packages/dappmanager/src/api/startHttpApi.ts
+++ b/packages/dappmanager/src/api/startHttpApi.ts
@@ -36,6 +36,7 @@ interface HttpRoutes {
   globalEnvs: RequestHandler<{ name: string }>;
   packageManifest: RequestHandler<{ dnpName: string }>;
   publicPackagesData: RequestHandler<{ containerName: string }>;
+  signFromPackage: RequestHandler<{ data: string }>;
   upload: RequestHandler<{}>;
 }
 
@@ -140,6 +141,7 @@ export function startHttpApi({
   app.get("/global-envs/:name?", routes.globalEnvs);
   app.get("/public-packages/:containerName?", routes.publicPackagesData);
   app.get("/package-manifest/:dnpName", routes.packageManifest);
+  app.post("/sign", routes.signFromPackage);
 
   // Rest of RPC methods
   app.post(

--- a/packages/dappmanager/src/api/startHttpApi.ts
+++ b/packages/dappmanager/src/api/startHttpApi.ts
@@ -36,7 +36,7 @@ interface HttpRoutes {
   globalEnvs: RequestHandler<{ name: string }>;
   packageManifest: RequestHandler<{ dnpName: string }>;
   publicPackagesData: RequestHandler<{ containerName: string }>;
-  signFromPackage: RequestHandler<{ data: string }>;
+  sign: RequestHandler<{}>;
   upload: RequestHandler<{}>;
 }
 
@@ -86,6 +86,7 @@ export function startHttpApi({
   app.use(cors({ credentials: true, origin: params.HTTP_CORS_WHITELIST }));
   app.use(compression());
   app.use(bodyParser.json());
+  app.use(bodyParser.text());
   app.use(bodyParser.urlencoded({ extended: true }));
   // Express uses "ETags" (hashes of the files requested) to know when the file changed
   app.use(express.static(path.resolve(params.UI_FILES_PATH), { maxAge: "1d" }));
@@ -141,7 +142,7 @@ export function startHttpApi({
   app.get("/global-envs/:name?", routes.globalEnvs);
   app.get("/public-packages/:containerName?", routes.publicPackagesData);
   app.get("/package-manifest/:dnpName", routes.packageManifest);
-  app.post("/sign", routes.signFromPackage);
+  app.post("/sign", routes.sign);
 
   // Rest of RPC methods
   app.post(

--- a/packages/dappmanager/src/params.ts
+++ b/packages/dappmanager/src/params.ts
@@ -55,6 +55,9 @@ const params = {
   // UI static files
   UI_FILES_PATH: process.env.UI_FILES_PATH || "dist",
 
+  // Signature API
+  SIGNATURE_PREFIX: "\x1dDappnode Signed Message:",
+
   // HTTP API parameters
   IPFS_GATEWAY: "http://ipfs.dappnode:8080/ipfs/",
   HTTP_API_PORT: process.env.HTTP_API_PORT || 80,

--- a/packages/dappmanager/src/utils/sign.ts
+++ b/packages/dappmanager/src/utils/sign.ts
@@ -1,0 +1,49 @@
+import { ethers } from "ethers";
+import params from "../params";
+
+export function prepareMessageFromPackage({
+  packageEnsName,
+  data
+}: {
+  packageEnsName: string;
+  data: string;
+}): string {
+  // Adding a custom prefix to signature to prevent signing arbitrary data.
+  // See https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_sign
+  return (
+    params.SIGNATURE_PREFIX +
+    "\n" +
+    packageEnsName +
+    "\n" +
+    data.length +
+    "\n" +
+    data
+  );
+}
+
+export function hashMessage(message: string): string {
+  return ethers.utils.solidityKeccak256(["string"], [message]);
+}
+
+export function signDataFromPackage({
+  privateKey,
+  packageEnsName,
+  data
+}: {
+  privateKey: string;
+  packageEnsName: string;
+  data: string;
+}): string {
+  const message = prepareMessageFromPackage({ packageEnsName, data });
+  const hash = hashMessage(message);
+
+  // Using ethers as a raw signer (without '\x19Ethereum Signed Message:\n' prefix)
+  // to mimic previous EthCrypto signature
+  const signingKey = new ethers.utils.SigningKey(privateKey);
+  return ethers.utils.joinSignature(signingKey.signDigest(hash));
+}
+
+export function getAddressFromPrivateKey(privateKey: string): string {
+  const wallet = new ethers.Wallet(privateKey);
+  return wallet.address;
+}

--- a/packages/dappmanager/test/utils/sign.test.ts
+++ b/packages/dappmanager/test/utils/sign.test.ts
@@ -1,0 +1,57 @@
+import "mocha";
+import { expect } from "chai";
+import { ethers } from "ethers";
+import {
+  prepareMessageFromPackage,
+  signDataFromPackage,
+  hashMessage
+} from "../../src/utils/sign";
+
+describe("Util / sign", () => {
+  describe("prepareMessageFromPackage", () => {
+    it("Should concat message to sign", () => {
+      const packageEnsName = "test.dnp.dappnode.eth";
+      const data = "1607077255674";
+
+      const message = prepareMessageFromPackage({ packageEnsName, data });
+
+      expect(message).to.equal(
+        `
+\x1dDappnode Signed Message:
+test.dnp.dappnode.eth
+13
+1607077255674
+      `.trim()
+      );
+    });
+  });
+
+  describe("signDataFromPackage", () => {
+    it("Should sign data from package", () => {
+      const wallet = ethers.Wallet.createRandom();
+
+      const packageEnsName = "test.dnp.dappnode.eth";
+      const data = "1607077255674";
+
+      const signature = signDataFromPackage({
+        privateKey: wallet.privateKey,
+        packageEnsName,
+        data
+      });
+
+      expect(signature, "Signature not OK").to.be.ok;
+
+      // Simulate sending payload over the wire
+      // This code should run on the signature consumer
+
+      const message = prepareMessageFromPackage({ packageEnsName, data });
+      const digest = hashMessage(message);
+      const address = ethers.utils.recoverAddress(digest, signature);
+
+      expect(address).to.deep.equal(
+        wallet.address,
+        "Recovered address does not match"
+      );
+    });
+  });
+});


### PR DESCRIPTION
Exposes endpoint to sign arbitrary data from other DAppNode packages.
```
POST /sign?data=some-payload
```

Unless the request comes from a container of a DAppNode package, it will be rejected

Fixes https://github.com/dappnode/DNP_DAPPMANAGER/issues/473