### PR TITLE
Fix logs UI bug with multi-services packages

### DIFF
--- a/packages/admin-ui/src/pages/packages/components/Logs.tsx
+++ b/packages/admin-ui/src/pages/packages/components/Logs.tsx
@@ -24,7 +24,6 @@ const validateLines = (lines: number) => !isNaN(lines) && lines > 0;
 export function Logs({ containers }: { containers: PackageContainer[] }) {
   const serviceNames = containers.map(c => c.serviceName).sort();
   const [serviceName, setServiceName] = useState(serviceNames[0]);
-  const [serviceNameHasChanged, setServiceNameHasChanged] = useState(false);
 
   // User options
   const [autoRefresh, setAutoRefresh] = useState(true);
@@ -62,7 +61,6 @@ export function Logs({ containers }: { containers: PackageContainer[] }) {
         // Prevent updating the state of an unmounted component
         if (unmounted) return;
 
-        setServiceNameHasChanged(false);
         setLogs(logs);
         // Auto scroll to bottom (deffered after the paint)
         setTimeout(scrollToBottom, 10);
@@ -71,23 +69,19 @@ export function Logs({ containers }: { containers: PackageContainer[] }) {
         setAutoRefresh(false);
       }
     }
-    if (
-      (autoRefresh && validateLines(lines)) ||
-      serviceNameHasChanged === true
-    ) {
-      setLogs("fetching...");
+    if (autoRefresh) {
       const interval = setInterval(logDnp, refreshInterval);
       return () => {
         clearInterval(interval);
         unmounted = true;
       };
+    } else {
+      logDnp();
+      return () => {
+        unmounted = true;
+      };
     }
-  }, [autoRefresh, timestamps, lines, containerName, serviceNameHasChanged]);
-
-  function handleSetServiceName(serviceName: string) {
-    setServiceName(serviceName);
-    setServiceNameHasChanged(true);
-  }
+  }, [autoRefresh, timestamps, lines, containerName]);
 
   /**
    * Filter the logs text by lines that contain the query
@@ -109,7 +103,7 @@ export function Logs({ containers }: { containers: PackageContainer[] }) {
     <Card spacing>
       <ServiceSelector
         serviceName={serviceName}
-        setServiceName={handleSetServiceName}
+        setServiceName={setServiceName}
         containers={containers}
       />
 

--- a/packages/admin-ui/src/pages/packages/components/Logs.tsx
+++ b/packages/admin-ui/src/pages/packages/components/Logs.tsx
@@ -35,7 +35,6 @@ export function Logs({ containers }: { containers: PackageContainer[] }) {
 
   const container = containers.find(c => c.serviceName === serviceName);
   const containerName = container?.containerName;
-  console.log(containerName);
 
   /**
    * This use effect fetches the logs again everytime any of this variables changes:
@@ -60,8 +59,9 @@ export function Logs({ containers }: { containers: PackageContainer[] }) {
         if (typeof logs !== "string") throw Error("Logs must be a string");
 
         // Prevent updating the state of an unmounted component
+        console.log("ContainerName: ", containerName);
         if (unmounted) return;
-
+        console.log("ContainerName: ", containerName);
         setLogs(logs);
         // Auto scroll to bottom (deffered after the paint)
         setTimeout(scrollToBottom, 10);
@@ -78,7 +78,7 @@ export function Logs({ containers }: { containers: PackageContainer[] }) {
         unmounted = true;
       };
     }
-  }, [autoRefresh, timestamps, lines, containerName, serviceName]);
+  }, [autoRefresh, timestamps, lines, containerName]);
 
   /**
    * Filter the logs text by lines that contain the query

--- a/packages/admin-ui/src/pages/packages/components/Logs.tsx
+++ b/packages/admin-ui/src/pages/packages/components/Logs.tsx
@@ -69,6 +69,7 @@ export function Logs({ containers }: { containers: PackageContainer[] }) {
         setAutoRefresh(false);
       }
     }
+    setLogs("fetching...");
     if (autoRefresh) {
       const interval = setInterval(logDnp, refreshInterval);
       return () => {

--- a/packages/admin-ui/src/pages/packages/components/Logs.tsx
+++ b/packages/admin-ui/src/pages/packages/components/Logs.tsx
@@ -35,6 +35,7 @@ export function Logs({ containers }: { containers: PackageContainer[] }) {
 
   const container = containers.find(c => c.serviceName === serviceName);
   const containerName = container?.containerName;
+  console.log(containerName);
 
   /**
    * This use effect fetches the logs again everytime any of this variables changes:
@@ -77,7 +78,7 @@ export function Logs({ containers }: { containers: PackageContainer[] }) {
         unmounted = true;
       };
     }
-  }, [autoRefresh, timestamps, lines, containerName]);
+  }, [autoRefresh, timestamps, lines, containerName, serviceName]);
 
   /**
    * Filter the logs text by lines that contain the query

--- a/packages/admin-ui/src/pages/packages/components/Logs.tsx
+++ b/packages/admin-ui/src/pages/packages/components/Logs.tsx
@@ -84,7 +84,7 @@ export function Logs({ containers }: { containers: PackageContainer[] }) {
     }
   }, [autoRefresh, timestamps, lines, containerName, serviceNameHasChanged]);
 
-  function handleSetServiceName() {
+  function handleSetServiceName(serviceName: string) {
     setServiceName(serviceName);
     setServiceNameHasChanged(true);
   }


### PR DESCRIPTION
**Main changes**

- New useState in _/admin-ui/src/pages/packages/components/Logs.tsx_: the new useState has been created to track whenever the serviceName selected has changed.

**Result**

Now the logs changed to display the new serviceName selected, even with the option "Auto refresh logs" disabled

![Screenshot from 2020-12-23 09-12-42](https://user-images.githubusercontent.com/41727368/102974620-2307e000-44ff-11eb-9ae7-41c0ae4e3833.png)
![Screenshot from 2020-12-23 09-12-27](https://user-images.githubusercontent.com/41727368/102974625-2602d080-44ff-11eb-9c5f-306715758d98.png)
