### PR TITLE
Pablo/change report forum

### DIFF
--- a/packages/admin-ui/src/pages/support/components/Report.tsx
+++ b/packages/admin-ui/src/pages/support/components/Report.tsx
@@ -58,6 +58,11 @@ export default function Report() {
         <strong>Report without providing information</strong> button.
       </p>
 
+      <p>
+        Before report, please, make sure that the topic does not already exits
+        in our <a href="https://forum.dappnode.io">forum</a>
+      </p>
+
       <div className="discourse-topic-header">
         <span className="location">
           <span className="logo">

--- a/packages/admin-ui/src/pages/support/components/Report.tsx
+++ b/packages/admin-ui/src/pages/support/components/Report.tsx
@@ -4,11 +4,11 @@ import { useApi } from "api";
 import Card from "components/Card";
 // Styles
 import RenderMarkdown from "components/RenderMarkdown";
-import { formatIssueBody, formatIssueUrl } from "../formaters/githubIssue";
-import { issueBaseUrl } from "params";
+import { formatTopicBody, formatTopicUrl } from "../formaters/discourseTopic";
+import { topicBaseUrl } from "params";
 import { PackageVersionData } from "common/types";
 import Ok from "components/Ok";
-import { FaGithub } from "react-icons/fa";
+import { FaDiscourse } from "react-icons/fa";
 import { MdChevronRight } from "react-icons/md";
 
 export default function Report() {
@@ -42,9 +42,9 @@ export default function Report() {
     { name: "Disk usage", result: diskUsedPercentage }
   ];
 
-  const issueBody = formatIssueBody(coreDnpVersions, systemData);
-  const issueUrlWithData = formatIssueUrl(issueBody);
-  const issueUrlNoData = issueBaseUrl;
+  const topicBody = formatTopicBody(coreDnpVersions, systemData);
+  const topicUrlWithData = formatTopicUrl(topicBody);
+  const topicUrlNoData = topicBaseUrl;
   const reqs = [dnpsReq, systemInfoReq, diagnoseReq, hostStatsReq];
   const isLoading = reqs.some(req => req.isValidating);
   const isLoaded = reqs.every(req => req.data);
@@ -52,19 +52,19 @@ export default function Report() {
   return (
     <Card>
       <p>
-        To help the support team, the <strong>Report issue</strong> button will
-        prefill the Github issue with the information shown below. If you don't
+        To help the support team, the <strong>Report</strong> button will
+        prefill a new forum topic with the information shown below. If you don't
         want to share any information, use the{" "}
-        <strong>Report issue without providing information</strong> button.
+        <strong>Report without providing information</strong> button.
       </p>
 
-      <div className="github-issue-header">
+      <div className="discourse-topic-header">
         <span className="location">
           <span className="logo">
-            <FaGithub />
+            <FaDiscourse />
           </span>
           <MdChevronRight className="arrow" />
-          <span>New issue</span>
+          <span>New topic</span>
           <MdChevronRight className="arrow" />
           <span>Body</span>
         </span>
@@ -73,14 +73,14 @@ export default function Report() {
           <Ok msg="" loading={isLoading} ok={isLoaded} />
         </span>
       </div>
-      <div className="github-issue-body">
-        <RenderMarkdown source={issueBody} />
+      <div className="discourse-topic-body">
+        <RenderMarkdown source={topicBody} />
       </div>
-      <a className="btn btn-dappnode mt-3 mr-3" href={issueUrlWithData}>
-        Report issue
+      <a className="btn btn-dappnode mt-3 mr-3" href={topicUrlWithData}>
+        Report
       </a>
-      <a className="btn btn-outline-dappnode mt-3" href={issueUrlNoData}>
-        Report issue without providing information
+      <a className="btn btn-outline-dappnode mt-3" href={topicUrlNoData}>
+        Report without providing information
       </a>
     </Card>
   );

--- a/packages/admin-ui/src/pages/support/components/support.scss
+++ b/packages/admin-ui/src/pages/support/components/support.scss
@@ -1,4 +1,4 @@
-.github-issue-body {
+.discourse-topic-body {
   /* Box styling */
   border: solid 1px #d3d3d396;
   border-radius: 5px;
@@ -15,7 +15,7 @@
   max-height: 500px;
 }
 
-.github-issue-header {
+.discourse-topic-header {
   /* Box styling */
   border: solid 1px #d3d3d396;
   border-radius: 5px;

--- a/packages/admin-ui/src/pages/support/formaters/discourseTopic.ts
+++ b/packages/admin-ui/src/pages/support/formaters/discourseTopic.ts
@@ -76,7 +76,7 @@ export function formatTopicBody(
 
 export function formatTopicUrl(body: string) {
   // Construct topicUrl from the available info
-  const topicCategory = "4";
+  const topicCategory = "5"; // This category is technical support
   const title = "";
   const params = [
     "title=" + encodeURIComponent(title),

--- a/packages/admin-ui/src/pages/support/formaters/discourseTopic.ts
+++ b/packages/admin-ui/src/pages/support/formaters/discourseTopic.ts
@@ -1,5 +1,5 @@
 import { PackageVersionData } from "types";
-import { issueBaseUrl } from "params";
+import { topicBaseUrl } from "params";
 
 /**
  * Info selectors
@@ -13,17 +13,17 @@ import { issueBaseUrl } from "params";
  *   error: {string}
  * }
  */
-interface IssueDataItem {
+interface TopicDataItem {
   name: string;
   result?: string;
   error?: string;
 }
 
 /**
- * Construct github issue
+ * Construct discourse topic
  * ======================
  *
- * Before filing a new issue...
+ * Before filing a new topic...
  *
  * Core DNPs versions
  * - admin.dnp.dappnode.eth: 0.1.18
@@ -34,16 +34,16 @@ interface IssueDataItem {
  * ...
  */
 
-interface IssueBodySection {
+interface TopicBodySection {
   title: string;
   items: { name: string; data: string }[];
 }
 
-export function formatIssueBody(
+export function formatTopicBody(
   coreDnpVersions: { name: string; version: string | PackageVersionData }[],
-  systemData: IssueDataItem[]
+  systemData: TopicDataItem[]
 ): string {
-  const sections: IssueBodySection[] = [
+  const sections: TopicBodySection[] = [
     {
       title: "Core DAppNode Packages versions",
       items: coreDnpVersions.map(({ name, version }) => ({
@@ -63,7 +63,7 @@ export function formatIssueBody(
   ];
 
   return [
-    "*Before filing a new issue, please **provide the following information**.*",
+    "*Before filing a new topic, please **provide the following information**.*",
     ...sections
       .filter(({ items }) => items.length)
       .map(
@@ -74,14 +74,16 @@ export function formatIssueBody(
   ].join("\n\n");
 }
 
-export function formatIssueUrl(body: string) {
-  // Construct issueUrl from the available info
+export function formatTopicUrl(body: string) {
+  // Construct topicUrl from the available info
+  const topicCategory = "4";
   const title = "";
   const params = [
     "title=" + encodeURIComponent(title),
-    "body=" + encodeURIComponent(body)
+    "body=" + encodeURIComponent(body),
+    "category_id=" + encodeURIComponent(topicCategory)
   ];
-  return issueBaseUrl + "?" + params.join("&");
+  return topicBaseUrl + "?" + params.join("&");
 }
 
 /**

--- a/packages/admin-ui/src/params.ts
+++ b/packages/admin-ui/src/params.ts
@@ -75,5 +75,6 @@ export const autoUpdateIds = {
 export const MAIN_ADMIN_NAME = "dappnode_admin";
 
 // Support, where to send issues
-const githubRepoSlugToReport = "dappnode/DAppNode";
-export const issueBaseUrl = `https://github.com/${githubRepoSlugToReport}/issues/new`;
+//const githubRepoSlugToReport = "dappnode/DAppNode";
+//export const issueBaseUrl = `https://github.com/${githubRepoSlugToReport}/issues/new`;
+export const topicBaseUrl = `https://forum.dappnode.io/new-topic`;

--- a/packages/admin-ui/src/params.ts
+++ b/packages/admin-ui/src/params.ts
@@ -75,6 +75,4 @@ export const autoUpdateIds = {
 export const MAIN_ADMIN_NAME = "dappnode_admin";
 
 // Support, where to send issues
-//const githubRepoSlugToReport = "dappnode/DAppNode";
-//export const issueBaseUrl = `https://github.com/${githubRepoSlugToReport}/issues/new`;
 export const topicBaseUrl = `https://forum.dappnode.io/new-topic`;


### PR DESCRIPTION
**Main changes**
In the UI _admin-ui/src/pages/support_ section:
- Naming change
 **issue** to **topic** 
 **github** to **discourse**
- URL change: now it opens a new topic in the forum in category 5: "Technical support"
- Change github icon to discourse icon
- New paragraph to incentivate users to verify if their topic is already posted in the forum. This may  prevent topic duplications.

Result 

![Screenshot from 2020-12-23 13-39-53](https://user-images.githubusercontent.com/41727368/102997206-cfa88880-4524-11eb-863c-79b880d6a442.png)

![Screenshot from 2020-12-23 12-42-57](https://user-images.githubusercontent.com/41727368/102997221-d931f080-4524-11eb-9963-ac8e7eedafff.png)

![Screenshot from 2020-12-23 12-43-50](https://user-images.githubusercontent.com/41727368/102997249-e818a300-4524-11eb-9ba0-78f01282df53.png)
