### PR TITLE
Add alert banners to dangerous actions

### DIFF
--- a/packages/admin-ui/src/pages/packages/actions.ts
+++ b/packages/admin-ui/src/pages/packages/actions.ts
@@ -41,7 +41,7 @@ export async function packageRestart(
 
   // If the DNP is not gracefully stopped, ask for confirmation to reset
   if (dnp && dnp.containers.some(container => container.running))
-    await new Promise(resolve => {
+    await new Promise<void>(resolve => {
       confirm({
         title: `Restarting ${name}`,
         text: `This action cannot be undone. If this DAppNode Package holds state, it may be lost.`,

--- a/packages/admin-ui/src/pages/packages/components/DnpSpecific/DappmanagerDnpDappnodeEth.tsx
+++ b/packages/admin-ui/src/pages/packages/components/DnpSpecific/DappmanagerDnpDappnodeEth.tsx
@@ -9,7 +9,7 @@ import { withToast } from "components/toast/Toast";
 export function DappmanagerDnpDappnodeEth() {
   async function cleanCache() {
     try {
-      await new Promise(resolve =>
+      await new Promise<void>(resolve =>
         confirm({
           title: `Deleting cache`,
           text: `This action cannot be undone. You should only clean the cache in response to a problem.`,

--- a/packages/admin-ui/src/pages/packages/components/Info/ContainerList.tsx
+++ b/packages/admin-ui/src/pages/packages/components/Info/ContainerList.tsx
@@ -87,7 +87,7 @@ export const ContainerList = ({ dnp }: { dnp: InstalledPackageData }) => {
                     onClick={() =>
                       dnp.dnpName === "wifi.dnp.dappnode.eth"
                         ? confirm({
-                            title: `Disabling wifi service`,
+                            title: `Disabling wifi service `,
                             text: "You may loose access",
                             label: "Disable",
                             onClick: () =>

--- a/packages/admin-ui/src/pages/packages/components/Info/ContainerList.tsx
+++ b/packages/admin-ui/src/pages/packages/components/Info/ContainerList.tsx
@@ -27,45 +27,26 @@ export const ContainerList = ({ dnp }: { dnp: InstalledPackageData }) => {
 
   async function onStartStop(container?: PackageContainer) {
     const dnpName = dnp.dnpName;
-    const isWifi = isWifiPackage();
-    const serviceNames = container && [container.serviceName];
-    const name = container
-      ? [sn(dnpName), sn(container.serviceName)].join(" ")
-      : sn(dnpName);
-    if (isWifi) {
+    if (dnpName === "wifi.dnp.dappnode.eth")
       await new Promise<void>(resolve => {
         confirm({
-          title: `Disabling wifi service`,
+          title: `Disabling Wifi package`,
           text:
-            "You may loose wifi access to your DAppNode. Are you sure you want to disable it?",
+            "You may loose Wifi access to your DAppNode. Are you sure you want to disable it?",
           label: "Disable",
           onClick: resolve
         });
       });
-      packageStartStop({ dnpName, serviceNames, name });
-    } else {
-      packageStartStop({ dnpName, serviceNames, name });
-    }
-  }
 
-  function packageStartStop({
-    dnpName,
-    serviceNames,
-    name
-  }: {
-    dnpName: string;
-    serviceNames: string[] | undefined;
-    name: string;
-  }) {
+    const serviceNames = container && [container.serviceName];
+    const name = container
+      ? [sn(dnpName), sn(container.serviceName)].join(" ")
+      : sn(dnpName);
+
     withToastNoThrow(() => api.packageStartStop({ dnpName, serviceNames }), {
       message: `Toggling ${name}...`,
       onSuccess: `Toggled ${name}`
     });
-  }
-
-  function isWifiPackage(): boolean {
-    if (dnp.dnpName === "wifi.dnp.dappnode.eth") return true;
-    return false;
   }
 
   const allContainersRunning = dnp.containers.every(c => c.running);

--- a/packages/admin-ui/src/pages/packages/components/Info/ContainerList.tsx
+++ b/packages/admin-ui/src/pages/packages/components/Info/ContainerList.tsx
@@ -37,6 +37,25 @@ export const ContainerList = ({ dnp }: { dnp: InstalledPackageData }) => {
     });
   }
 
+  function onStartStopConfirm() {
+    confirm({
+      title: `Disabling wifi service`,
+      text:
+        "You may loose wifi access to your DAppNode. Are you sure you want to disable it?",
+      label: "Disable",
+      onClick: () =>
+        withToastNoThrow(async () => onStartStop(), {
+          message: `Disabling wifi...`,
+          onSuccess: `Disabled wifi`
+        })
+    });
+  }
+
+  function isWifiPackage() {
+    if (dnp.dnpName === "wifi.dnp.dappnode.eth") return true;
+    return false;
+  }
+
   const allContainersRunning = dnp.containers.every(c => c.running);
 
   return (
@@ -68,18 +87,7 @@ export const ContainerList = ({ dnp }: { dnp: InstalledPackageData }) => {
           {allContainersRunning ? (
             <MdPauseCircleOutline
               onClick={() =>
-                dnp.dnpName === "wifi.dnp.dappnode.eth"
-                  ? confirm({
-                      title: `Disabling wifi service `,
-                      text: "You may loose access",
-                      label: "Disable",
-                      onClick: () =>
-                        withToastNoThrow(async () => onStartStop(), {
-                          message: `Disabling wifi...`,
-                          onSuccess: `Disabled wifi`
-                        })
-                    })
-                  : onStartStop()
+                isWifiPackage() ? onStartStopConfirm() : onStartStop()
               }
             />
           ) : (

--- a/packages/admin-ui/src/pages/packages/components/Info/ContainerList.tsx
+++ b/packages/admin-ui/src/pages/packages/components/Info/ContainerList.tsx
@@ -66,7 +66,22 @@ export const ContainerList = ({ dnp }: { dnp: InstalledPackageData }) => {
           </span>
 
           {allContainersRunning ? (
-            <MdPauseCircleOutline onClick={() => onStartStop()} />
+            <MdPauseCircleOutline
+              onClick={() =>
+                dnp.dnpName === "wifi.dnp.dappnode.eth"
+                  ? confirm({
+                      title: `Disabling wifi service `,
+                      text: "You may loose access",
+                      label: "Disable",
+                      onClick: () =>
+                        withToastNoThrow(async () => onStartStop(), {
+                          message: `Disabling wifi...`,
+                          onSuccess: `Disabled wifi`
+                        })
+                    })
+                  : onStartStop()
+              }
+            />
           ) : (
             <MdPlayCircleOutline onClick={() => onStartStop()} />
           )}
@@ -84,23 +99,7 @@ export const ContainerList = ({ dnp }: { dnp: InstalledPackageData }) => {
                 <span className="name">{sn(container.serviceName)}</span>
                 {container.running ? (
                   <MdPauseCircleOutline
-                    onClick={() =>
-                      dnp.dnpName === "wifi.dnp.dappnode.eth"
-                        ? confirm({
-                            title: `Disabling wifi service `,
-                            text: "You may loose access",
-                            label: "Disable",
-                            onClick: () =>
-                              withToastNoThrow(
-                                async () => onStartStop(container),
-                                {
-                                  message: `Disabling wifi...`,
-                                  onSuccess: `Disabled wifi`
-                                }
-                              )
-                          })
-                        : onStartStop(container)
-                    }
+                    onClick={() => onStartStop(container)}
                   />
                 ) : (
                   <MdPlayCircleOutline onClick={() => onStartStop(container)} />

--- a/packages/admin-ui/src/pages/packages/components/Info/ContainerList.tsx
+++ b/packages/admin-ui/src/pages/packages/components/Info/ContainerList.tsx
@@ -15,6 +15,7 @@ import { InstalledPackageData, PackageContainer } from "types";
 import { withToastNoThrow } from "components/toast/Toast";
 import { api } from "api";
 import { shortNameCapitalized as sn } from "utils/format";
+import { confirm } from "components/ConfirmDialog";
 import "./containerList.scss";
 
 export const ContainerList = ({ dnp }: { dnp: InstalledPackageData }) => {
@@ -83,7 +84,23 @@ export const ContainerList = ({ dnp }: { dnp: InstalledPackageData }) => {
                 <span className="name">{sn(container.serviceName)}</span>
                 {container.running ? (
                   <MdPauseCircleOutline
-                    onClick={() => onStartStop(container)}
+                    onClick={() =>
+                      dnp.dnpName === "wifi.dnp.dappnode.eth"
+                        ? confirm({
+                            title: `Disabling wifi service`,
+                            text: "You may loose access",
+                            label: "Disable",
+                            onClick: () =>
+                              withToastNoThrow(
+                                async () => onStartStop(container),
+                                {
+                                  message: `Disabling wifi...`,
+                                  onSuccess: `Disabled wifi`
+                                }
+                              )
+                          })
+                        : onStartStop(container)
+                    }
                   />
                 ) : (
                   <MdPlayCircleOutline onClick={() => onStartStop(container)} />

--- a/packages/admin-ui/src/pages/packages/components/Info/ContainerList.tsx
+++ b/packages/admin-ui/src/pages/packages/components/Info/ContainerList.tsx
@@ -25,7 +25,7 @@ export const ContainerList = ({ dnp }: { dnp: InstalledPackageData }) => {
     packageRestart(dnp, container).catch(console.error);
   }
 
-  function onStartStop(container?: PackageContainer) {
+  async function onStartStop(container?: PackageContainer) {
     const dnpName = dnp.dnpName;
     const isWifi = isWifiPackage();
     const serviceNames = container && [container.serviceName];
@@ -33,13 +33,16 @@ export const ContainerList = ({ dnp }: { dnp: InstalledPackageData }) => {
       ? [sn(dnpName), sn(container.serviceName)].join(" ")
       : sn(dnpName);
     if (isWifi) {
-      confirm({
-        title: `Disabling wifi service`,
-        text:
-          "You may loose wifi access to your DAppNode. Are you sure you want to disable it?",
-        label: "Disable",
-        onClick: () => packageStartStop({ dnpName, serviceNames, name })
+      await new Promise<void>(resolve => {
+        confirm({
+          title: `Disabling wifi service`,
+          text:
+            "You may loose wifi access to your DAppNode. Are you sure you want to disable it?",
+          label: "Disable",
+          onClick: resolve
+        });
       });
+      packageStartStop({ dnpName, serviceNames, name });
     } else {
       packageStartStop({ dnpName, serviceNames, name });
     }

--- a/packages/admin-ui/src/pages/packages/components/Info/ContainerList.tsx
+++ b/packages/admin-ui/src/pages/packages/components/Info/ContainerList.tsx
@@ -32,7 +32,7 @@ export const ContainerList = ({ dnp }: { dnp: InstalledPackageData }) => {
         confirm({
           title: `Disabling Wifi package`,
           text:
-            "You may loose Wifi access to your DAppNode. Are you sure you want to disable it?",
+            "Warning, if you are connected via WIFI you will lose access to your DAppNode. Make sure to have another way to connect to it before disabling WIFI",
           label: "Disable",
           onClick: resolve
         });

--- a/packages/admin-ui/src/pages/packages/components/Info/ContainerList.tsx
+++ b/packages/admin-ui/src/pages/packages/components/Info/ContainerList.tsx
@@ -27,31 +27,40 @@ export const ContainerList = ({ dnp }: { dnp: InstalledPackageData }) => {
 
   function onStartStop(container?: PackageContainer) {
     const dnpName = dnp.dnpName;
+    const isWifi = isWifiPackage();
     const serviceNames = container && [container.serviceName];
     const name = container
       ? [sn(dnpName), sn(container.serviceName)].join(" ")
       : sn(dnpName);
+    if (isWifi) {
+      confirm({
+        title: `Disabling wifi service`,
+        text:
+          "You may loose wifi access to your DAppNode. Are you sure you want to disable it?",
+        label: "Disable",
+        onClick: () => packageStartStop({ dnpName, serviceNames, name })
+      });
+    } else {
+      packageStartStop({ dnpName, serviceNames, name });
+    }
+  }
+
+  function packageStartStop({
+    dnpName,
+    serviceNames,
+    name
+  }: {
+    dnpName: string;
+    serviceNames: string[] | undefined;
+    name: string;
+  }) {
     withToastNoThrow(() => api.packageStartStop({ dnpName, serviceNames }), {
       message: `Toggling ${name}...`,
       onSuccess: `Toggled ${name}`
     });
   }
 
-  function onStartStopConfirm() {
-    confirm({
-      title: `Disabling wifi service`,
-      text:
-        "You may loose wifi access to your DAppNode. Are you sure you want to disable it?",
-      label: "Disable",
-      onClick: () =>
-        withToastNoThrow(async () => onStartStop(), {
-          message: `Disabling wifi...`,
-          onSuccess: `Disabled wifi`
-        })
-    });
-  }
-
-  function isWifiPackage() {
+  function isWifiPackage(): boolean {
     if (dnp.dnpName === "wifi.dnp.dappnode.eth") return true;
     return false;
   }
@@ -85,11 +94,7 @@ export const ContainerList = ({ dnp }: { dnp: InstalledPackageData }) => {
           </span>
 
           {allContainersRunning ? (
-            <MdPauseCircleOutline
-              onClick={() =>
-                isWifiPackage() ? onStartStopConfirm() : onStartStop()
-              }
-            />
+            <MdPauseCircleOutline onClick={() => onStartStop()} />
           ) : (
             <MdPlayCircleOutline onClick={() => onStartStop()} />
           )}

--- a/packages/admin-ui/src/pages/packages/components/Info/RemovePackage.tsx
+++ b/packages/admin-ui/src/pages/packages/components/Info/RemovePackage.tsx
@@ -55,7 +55,7 @@ export function RemovePackage({ dnp }: { dnp: InstalledPackageDetailData }) {
     }
 
     if (dnpsToRemoveWarningsList.length > 0)
-      await new Promise(resolve =>
+      await new Promise<void>(resolve =>
         confirm({
           title: `Removing ${sn(dnpName)}`,
           text: `This action cannot be undone.`,

--- a/packages/admin-ui/src/pages/packages/components/Info/VolumesList.tsx
+++ b/packages/admin-ui/src/pages/packages/components/Info/VolumesList.tsx
@@ -30,7 +30,7 @@ export const VolumesList = ({ dnp }: { dnp: InstalledPackageDetailData }) => {
 
     // If there are NOT conflicting volumes,
     // Display a dialog to confirm volumes reset
-    await new Promise(resolve =>
+    await new Promise<void>(resolve =>
       confirm({
         title: `Removing ${sn(dnpName)} data`,
         text: `This action cannot be undone. If this DAppNode Package is a blockchain node, it will lose all the chain data and start syncing from scratch.`,

--- a/packages/admin-ui/src/pages/system/actions.ts
+++ b/packages/admin-ui/src/pages/system/actions.ts
@@ -64,7 +64,7 @@ export const passwordChange = (
   newPassword: string
 ): AppThunk => async dispatch => {
   // Display a dialog to confirm the password change
-  await new Promise(resolve =>
+  await new Promise<void>(resolve =>
     confirm({
       title: `Changing host user password`,
       text: `Make sure to safely store this password and keep a back up. \n\nYou will never be able to see this password again. If you lose it, you will not be able to recover it in any way.`,
@@ -84,7 +84,7 @@ export const passwordChange = (
 
 export const volumeRemove = (name: string): AppThunk => async dispatch => {
   // Display a dialog to confirm the password change
-  await new Promise(resolve =>
+  await new Promise<void>(resolve =>
     confirm({
       title: `Removing volume`,
       text: `Are you sure you want to permanently remove volume ${name}?`,
@@ -113,7 +113,7 @@ export const packageVolumeRemove = (
 
   // If there are NOT conflicting volumes,
   // Display a dialog to confirm volumes reset
-  await new Promise(resolve =>
+  await new Promise<void>(resolve =>
     confirm({
       title: `Removing ${prettyVolRef}`,
       text: `Are you sure you want to permanently remove this volume? This action cannot be undone. If this DAppNode Package is a blockchain node, it will lose all the chain data and start syncing from scratch.`,

--- a/packages/admin-ui/src/pages/system/components/Advanced/SshManager/ChangeStatus.tsx
+++ b/packages/admin-ui/src/pages/system/components/Advanced/SshManager/ChangeStatus.tsx
@@ -41,7 +41,7 @@ export function SshManagerChangeStatus() {
     confirm({
       title: `Disabling SSH service`,
       text:
-        "You may loose SSH access to your DAppNode. Are you sure you want to disable it?",
+        "You will loose SSH access to your DAppNode. Make sure to have an alternative way to access your DAppNode, such as physically with a screen and keyboard before disabling SSH access",
       label: "Disable",
       onClick: () =>
         withToastNoThrow(() => changeSshStatus("disabled"), {

--- a/packages/admin-ui/src/pages/system/components/Advanced/SshManager/ChangeStatus.tsx
+++ b/packages/admin-ui/src/pages/system/components/Advanced/SshManager/ChangeStatus.tsx
@@ -37,6 +37,20 @@ export function SshManagerChangeStatus() {
     }
   }
 
+  function confirmChangeSsh() {
+    confirm({
+      title: `Disabling SSH service`,
+      text:
+        "You may loose SSH access to your DAppNode. Are you sure you want to disable it?",
+      label: "Disable",
+      onClick: () =>
+        withToastNoThrow(() => changeSshStatus("disabled"), {
+          message: `Disabling SSH...`,
+          onSuccess: `Disabled SSH`
+        })
+    });
+  }
+
   return (
     <>
       <Input
@@ -64,18 +78,7 @@ export function SshManagerChangeStatus() {
         </Button>
         <Button
           disabled={reqSetStatus.loading}
-          onClick={() =>
-            confirm({
-              title: `Disabling SSH service`,
-              text: "You may loose access",
-              label: "Disable",
-              onClick: () =>
-                withToastNoThrow(() => changeSshStatus("disabled"), {
-                  message: `Disabling SSH...`,
-                  onSuccess: `Disabled SSH`
-                })
-            })
-          }
+          onClick={() => confirmChangeSsh()}
         >
           Disable
         </Button>

--- a/packages/admin-ui/src/pages/system/components/Advanced/SshManager/ChangeStatus.tsx
+++ b/packages/admin-ui/src/pages/system/components/Advanced/SshManager/ChangeStatus.tsx
@@ -4,8 +4,10 @@ import Button from "components/Button";
 import ErrorView from "components/ErrorView";
 import Input from "components/Input";
 import Ok from "components/Ok";
+import { confirm } from "components/ConfirmDialog";
 import { ReqStatus, ShhStatus } from "types";
 import "./sshManager.scss";
+import { withToastNoThrow } from "components/toast/Toast";
 
 export function SshManagerChangeStatus() {
   const [reqGetStatus, setReqGetStatus] = useState<ReqStatus<ShhStatus>>({});
@@ -62,7 +64,18 @@ export function SshManagerChangeStatus() {
         </Button>
         <Button
           disabled={reqSetStatus.loading}
-          onClick={() => changeSshStatus("disabled")}
+          onClick={() =>
+            confirm({
+              title: `Disabling SSH service`,
+              text: "You may loose access",
+              label: "Disable",
+              onClick: () =>
+                withToastNoThrow(() => changeSshStatus("disabled"), {
+                  message: `Disabling SSH...`,
+                  onSuccess: `Disabled SSH`
+                })
+            })
+          }
         >
           Disable
         </Button>

--- a/packages/admin-ui/src/pages/system/components/Identity.tsx
+++ b/packages/admin-ui/src/pages/system/components/Identity.tsx
@@ -35,7 +35,7 @@ export default function Identity() {
     try {
       setIsOnProgress(true);
       if (identityAddress)
-        await new Promise(resolve =>
+        await new Promise<void>(resolve =>
           confirm({
             title: `Changing DAppNode Identity`,
             text: `Are you sure you want to change the current DAppNode's identity?`,

--- a/packages/admin-ui/src/pages/system/components/PowerManagment.tsx
+++ b/packages/admin-ui/src/pages/system/components/PowerManagment.tsx
@@ -10,7 +10,7 @@ import { withToast } from "components/toast/Toast";
 function PowerManagment() {
   async function reboot() {
     try {
-      await new Promise(resolve =>
+      await new Promise<void>(resolve =>
         confirm({
           title: `Rebooting host`,
           text: `Are you sure you want to reboot the host machine? Only do this if it’s strictly necessary.`,
@@ -32,7 +32,7 @@ function PowerManagment() {
   async function powerOff() {
     try {
       // Since there are two consecutive modals, the async form must be used
-      await new Promise(resolve =>
+      await new Promise<void>(resolve =>
         confirm({
           title: `Powering off host`,
           text: `WARNING! Your machine will power off and you will not be able to turn it back on without physical access or a remote way to switch on the power.`,
@@ -42,7 +42,7 @@ function PowerManagment() {
         })
       );
 
-      await new Promise(resolve =>
+      await new Promise<void>(resolve =>
         confirm({
           title: `Are you sure?`,
           text: `Please make sure you have a way of turning the host machine’s power back on.`,


### PR DESCRIPTION
Fixes https://github.com/dappnode/DNP_DAPPMANAGER/issues/548

**Changes**

- Added confirmation dialog to: 
    - SSH service when user attemps to disable it
    - Wifi package when user attemps to stop it.
 
**On both cases there will be shown a warming message advicinf user that he/she may loose access**

**Results**

**SSH**

![Screenshot from 2021-01-07 12-15-07](https://user-images.githubusercontent.com/41727368/103892569-17fea380-50ec-11eb-93b9-b57be110e6eb.png)
![Screenshot from 2021-01-07 12-15-19](https://user-images.githubusercontent.com/41727368/103892605-25b42900-50ec-11eb-83c5-4f7818adbcde.png)

**WIFI**

![Screenshot from 2021-01-07 13-24-08](https://user-images.githubusercontent.com/41727368/103892552-11702c00-50ec-11eb-892c-2b8c41a43afd.png)
![Screenshot from 2021-01-07 13-24-33](https://user-images.githubusercontent.com/41727368/103892558-13d28600-50ec-11eb-9cbb-a5fab1157ed8.png)

