### PR TITLE
Allow safe compose keys

### DIFF
--- a/packages/admin-ui/src/common/types.ts
+++ b/packages/admin-ui/src/common/types.ts
@@ -508,32 +508,36 @@ export interface ComposeVolumes {
 }
 
 export interface ComposeService {
-  container_name: string; // "DAppNodeCore-dappmanager.dnp.dappnode.eth";
-  image: string; // "dappmanager.dnp.dappnode.eth:0.2.6";
-  volumes?: string[]; // ["dappmanagerdnpdappnodeeth_data:/usr/src/app/dnp_repo/"];
-  ports?: string[];
-  environment?: PackageEnvs | string[];
-  labels?: { [labelName: string]: string };
-  env_file?: string[];
-  // ipv4_address: "172.33.1.7";
-  networks?: string[] | { [networkName: string]: { ipv4_address: string } };
-  dns?: string; // "172.33.1.2";
-  restart?: string; // "unless-stopped";
-  privileged?: boolean;
   cap_add?: string[];
   cap_drop?: string[];
-  extra_hosts?: string[];
-  devices?: string[];
-  network_mode?: string;
   command?: string;
+  container_name: string; // "DAppNodeCore-dappmanager.dnp.dappnode.eth";
+  devices?: string[];
+  dns?: string; // "172.33.1.2";
   entrypoint?: string;
-  // Logging
+  env_file?: string[];
+  environment?: PackageEnvs | string[];
+  expose?: string[];
+  extra_hosts?: string[];
+  image: string; // "dappmanager.dnp.dappnode.eth:0.2.6";
+  // ipv4_address: "172.33.1.7";
+  labels?: { [labelName: string]: string };
   logging?: {
     driver?: string;
     options?: {
       [optName: string]: string | number | null;
     };
   };
+  network_mode?: string;
+  networks?: string[] | { [networkName: string]: { ipv4_address: string } };
+  ports?: string[];
+  privileged?: boolean;
+  restart?: string; // "unless-stopped";
+  stop_grace_period?: string;
+  stop_signal?: string;
+  user?: string;
+  volumes?: string[]; // ["dappmanagerdnpdappnodeeth_data:/usr/src/app/dnp_repo/"];
+  working_dir?: string;
 }
 
 export interface Compose {

--- a/packages/dappmanager/src/modules/compose/unsafeCompose.ts
+++ b/packages/dappmanager/src/modules/compose/unsafeCompose.ts
@@ -12,20 +12,26 @@ interface ValidationAlert {
 }
 
 const serviceSafeKeys: (keyof ComposeService)[] = [
-  "volumes",
-  "ports",
-  "environment",
-  "restart",
-  "privileged",
   "cap_add",
   "cap_drop",
-  "extra_hosts",
+  "command",
   "devices",
+  "entrypoint",
+  "environment",
+  "expose",
+  "extra_hosts",
+  "labels",
+  "logging",
   "network_mode",
   "networks",
-  "command",
-  "labels",
-  "logging"
+  "ports",
+  "privileged",
+  "restart",
+  "stop_grace_period",
+  "stop_signal",
+  "user",
+  "volumes",
+  "working_dir"
 ];
 
 // Disallow external volumes to prevent packages accessing sensitive data of others


### PR DESCRIPTION
Allows docker-compose service keys that may be useful but don't pose any obvious thread.

Fixes https://github.com/dappnode/DNP_DAPPMANAGER/issues/551