### PR TITLE
Send notification on new package version available

### DIFF
--- a/packages/admin-ui/src/__mock-backend__/fetchPkgsData.ts
+++ b/packages/admin-ui/src/__mock-backend__/fetchPkgsData.ts
@@ -1,4 +1,4 @@
-import { CoreUpdateData, Routes } from "../common";
+import { CoreUpdateDataAvailable, Routes } from "../common";
 import { directory, dnpRequests } from "./data";
 
 export const fetchPkgsData: Pick<
@@ -14,7 +14,7 @@ export const fetchPkgsData: Pick<
   }
 };
 
-const sampleCoreUpdateData: CoreUpdateData = {
+const sampleCoreUpdateData: CoreUpdateDataAvailable = {
   available: true,
   type: "patch",
   packages: [
@@ -34,5 +34,6 @@ const sampleCoreUpdateData: CoreUpdateData = {
       message: "Conditional update alert: **Markdown**"
     }
   ],
-  versionId: ""
+  versionId: "admin@0.2.6",
+  coreVersion: "0.2.10"
 };

--- a/packages/admin-ui/src/common/types.ts
+++ b/packages/admin-ui/src/common/types.ts
@@ -756,14 +756,21 @@ export interface DependencyListItem {
   warningOnInstall?: string;
 }
 
-export interface CoreUpdateData {
-  available: boolean;
+export interface CoreUpdateDataNotAvailable {
+  available: false;
+}
+export interface CoreUpdateDataAvailable {
+  available: true;
   type?: string;
   packages: DependencyListItem[];
   changelog: string;
   updateAlerts: ManifestUpdateAlert[];
   versionId: string;
+  coreVersion: string;
 }
+export type CoreUpdateData =
+  | CoreUpdateDataNotAvailable
+  | CoreUpdateDataAvailable;
 
 /**
  * Releases types

--- a/packages/admin-ui/src/services/coreUpdate/actions.ts
+++ b/packages/admin-ui/src/services/coreUpdate/actions.ts
@@ -57,11 +57,16 @@ export const fetchCoreUpdateData = (): AppThunk => async dispatch => {
     dispatch(updateCoreRequestStatus({ success: true }));
     dispatch(updateCoreUpdateData(coreUpdateData));
 
-    /* eslint-disable-next-line no-console */
-    console.log(
-      `DAppNode ${coreDnpName} (${coreUpdateData.versionId})`,
-      coreUpdateData
-    );
+    if (coreUpdateData.available) {
+      /* eslint-disable-next-line no-console */
+      console.log(
+        `DAppNode ${coreDnpName} (${coreUpdateData.versionId})`,
+        coreUpdateData
+      );
+    } else {
+      /* eslint-disable-next-line no-console */
+      console.log(`DAppNode is updated`);
+    }
   } catch (e) {
     dispatch(updateCoreRequestStatus({ error: e.message }));
     console.error(`Error on checkCoreUpdate: ${e.stack}`);

--- a/packages/admin-ui/src/services/coreUpdate/selectors.ts
+++ b/packages/admin-ui/src/services/coreUpdate/selectors.ts
@@ -1,67 +1,23 @@
 import { RootState } from "rootReducer";
-// Selectors
-import { DependencyListItem, ManifestUpdateAlert } from "types";
 
 // Service > coreUpdate
 
-const getCoreUpdateData = (state: RootState) => state.coreUpdate.data;
+export const getCoreUpdateData = (state: RootState) => state.coreUpdate.data;
 export const getUpdatingCore = (state: RootState) =>
   state.coreUpdate.updatingCore;
 export const getCoreRequestStatus = (state: RootState) =>
   state.coreUpdate.requestStatus;
 
-/**
- * Returns core dependencies,
- * unless the core package is the only one, them returns it
- */
-export const getCoreDeps = (state: RootState): DependencyListItem[] => {
-  const coreUpdateData = getCoreUpdateData(state);
-  if (!coreUpdateData) return [];
-
-  const corePackages = coreUpdateData.packages || [];
-  const coreDeps = corePackages.filter(
-    dnp => !(dnp.name || "").includes("core")
-  );
-  if (coreDeps.length) return coreDeps;
-
-  const coreDnp = corePackages.find(dnp => (dnp.name || "").includes("core"));
-  if (coreDnp) {
-    // #### TODO: to prevent show the legacy OpenVPN 0.2.0 warning alert
-    // remove the warning on install for the core.dnp.dappnode.eth DNP
-    // Alerts can be added via the conditional update alerts
-    coreDnp.warningOnInstall = "";
-    return [coreDnp];
-  }
-
-  return [];
-};
-
-/**
- * Appends property `updateType` to the manifest
- * updateType = "major, minor, patch"
- */
-export const getCoreChangelog = (state: RootState): string | undefined => {
-  const coreUpdateData = getCoreUpdateData(state);
-  if (!coreUpdateData) return undefined;
-  return coreUpdateData.changelog;
-};
-
-/**
- * Gets the core update message, computing the current update jump
- */
-export const getCoreUpdateAlerts = (
-  state: RootState
-): ManifestUpdateAlert[] => {
-  const coreUpdateData = getCoreUpdateData(state);
-  return (coreUpdateData || {}).updateAlerts || [];
-};
-
 export const getCoreUpdateAvailable = (state: RootState): boolean => {
   const coreUpdateData = getCoreUpdateData(state);
-  return Boolean(coreUpdateData && coreUpdateData.available);
+  return coreUpdateData !== null && coreUpdateData.available;
 };
 
 export const getIsCoreUpdateTypePatch = (state: RootState): boolean => {
   const coreUpdateData = getCoreUpdateData(state);
-  return Boolean(coreUpdateData && coreUpdateData.type === "patch");
+  return (
+    coreUpdateData !== null &&
+    coreUpdateData.available &&
+    coreUpdateData.type === "patch"
+  );
 };

--- a/packages/dappmanager/src/calls/fetchCoreUpdateData.ts
+++ b/packages/dappmanager/src/calls/fetchCoreUpdateData.ts
@@ -10,14 +10,6 @@ import { logs } from "../logs";
 
 const coreName = params.coreDnpName;
 const defaultVersion = "*";
-const coreAlreadyUpdated: CoreUpdateData = {
-  available: false,
-  type: undefined,
-  packages: [],
-  changelog: "",
-  updateAlerts: [],
-  versionId: ""
-};
 
 /**
  * Fetches the core update data, if available
@@ -55,14 +47,14 @@ export async function getCoreUpdateData(
       logs.debug(
         `Core update to ${coreVersion} would cause a downgrade for ${e.dnpName} from ${e.dnpVersion}, assuming core is updated`
       );
-      return coreAlreadyUpdated;
+      return { available: false };
     } else {
       throw e;
     }
   }
 
   if (releases.length === 0) {
-    return coreAlreadyUpdated;
+    return { available: false };
   }
 
   const dnpList = await listPackages();
@@ -137,6 +129,7 @@ export async function getCoreUpdateData(
     packages,
     changelog: coreManifest.changelog || "",
     updateAlerts,
-    versionId
+    versionId,
+    coreVersion: coreManifest.version
   };
 }

--- a/packages/dappmanager/src/daemons/autoUpdates/formatNotificationBody.ts
+++ b/packages/dappmanager/src/daemons/autoUpdates/formatNotificationBody.ts
@@ -1,0 +1,55 @@
+import { CoreUpdateDataAvailable } from "../../common";
+import { shortNameCapitalized } from "../../utils/format";
+import { enableAutoUpdatesCmd } from "../telegramBot/commands";
+
+export function formatPackageUpdateNotification({
+  dnpName,
+  currentVersion,
+  newVersion,
+  upstreamVersion,
+  autoUpdatesEnabled
+}: {
+  dnpName: string;
+  currentVersion: string;
+  newVersion: string;
+  upstreamVersion?: string;
+  autoUpdatesEnabled: boolean;
+}): string {
+  const prettyName = shortNameCapitalized(dnpName);
+
+  return [
+    `New version ready to install for ${prettyName} (current version ${currentVersion})`,
+    upstreamVersion
+      ? ` - package version: ${newVersion}\n` +
+        ` - upstream version: ${upstreamVersion}`
+      : ` - version: ${newVersion}`,
+
+    `Connect to your DAppNode to install this new version [install / ${prettyName}](url).`,
+    autoUpdatesEnabled
+      ? `You may also wait for auto-updates to automatically install this version for you`
+      : `You can also enable auto-updates so packages are updated automatically by responding with the command: \n\n  ${enableAutoUpdatesCmd}`
+  ].join("\n\n");
+}
+
+export function formatSystemUpdateNotification({
+  packages,
+  autoUpdatesEnabled
+}: {
+  packages: CoreUpdateDataAvailable["packages"];
+  autoUpdatesEnabled: boolean;
+}): string {
+  return [
+    "New system version ready to install",
+    packages.map(
+      p =>
+        ` - ${shortNameCapitalized(p.name)}: ${p.to} ${
+          p.from ? `(current: ${p.from})` : ""
+        }`
+    ),
+
+    `Connect to your DAppNode to install this [system / update](url).`,
+    autoUpdatesEnabled
+      ? `You may also wait for auto-updates to automatically install this version for you`
+      : `You can also enable auto-updates so packages are updated automatically by responding with the command: \n\n  ${enableAutoUpdatesCmd}`
+  ].join("\n\n");
+}

--- a/packages/dappmanager/src/daemons/autoUpdates/sendUpdateNotification.ts
+++ b/packages/dappmanager/src/daemons/autoUpdates/sendUpdateNotification.ts
@@ -1,0 +1,89 @@
+import semver from "semver";
+import params from "../../params";
+import * as db from "../../db";
+import { eventBus } from "../../eventBus";
+import { ReleaseFetcher } from "../../modules/release";
+import { shortNameCapitalized } from "../../utils/format";
+import { CoreUpdateDataAvailable } from "../../types";
+import {
+  isCoreUpdateEnabled,
+  isDnpUpdateEnabled
+} from "../../utils/autoUpdateHelper";
+import {
+  formatPackageUpdateNotification,
+  formatSystemUpdateNotification
+} from "./formatNotificationBody";
+
+export async function sendUpdatePackageNotificationMaybe(
+  releaseFetcher: ReleaseFetcher,
+  {
+    dnpName,
+    currentVersion,
+    newVersion
+  }: {
+    dnpName: string;
+    currentVersion: string;
+    newVersion: string;
+  }
+): Promise<void> {
+  // If version has already been emitted, skip
+  const lastEmittedVersion = db.notificationLastEmitVersion.get(dnpName);
+  if (
+    lastEmittedVersion &&
+    semver.valid(lastEmittedVersion) &&
+    semver.lte(newVersion, lastEmittedVersion)
+  )
+    return; // Already emitted update available for this version
+
+  // Ensure the release resolves on IPFS
+  const release = await releaseFetcher.getRelease(dnpName, newVersion);
+
+  eventBus.notification // Emit notification about new version available
+    .emit({
+      id: `update-available-${dnpName}-${newVersion}`,
+      type: "success",
+      title: `Update available for ${shortNameCapitalized(dnpName)}`,
+      body: formatPackageUpdateNotification({
+        dnpName: dnpName,
+        newVersion,
+        upstreamVersion: release.metadata.upstreamVersion,
+        currentVersion,
+        autoUpdatesEnabled: isDnpUpdateEnabled(dnpName)
+      })
+    });
+
+  // Register version to prevent sending notification again
+  db.notificationLastEmitVersion.set(dnpName, newVersion);
+}
+
+export async function sendUpdateSystemNotificationMaybe(
+  data: CoreUpdateDataAvailable
+): Promise<void> {
+  const newVersion = data.coreVersion;
+  const dnpName = params.coreDnpName;
+
+  // If version has already been emitted, skip
+  const lastEmittedVersion = db.notificationLastEmitVersion.get(dnpName);
+  if (
+    lastEmittedVersion &&
+    semver.valid(lastEmittedVersion) &&
+    semver.lte(newVersion, lastEmittedVersion)
+  )
+    return; // Already emitted update available for this version
+
+  eventBus.notification // Emit notification about new version available
+    .emit({
+      id: `update-available-${dnpName}-${newVersion}`,
+      type: "success",
+      title: "System update available",
+      body: formatSystemUpdateNotification({
+        packages: data.packages,
+        autoUpdatesEnabled: isCoreUpdateEnabled()
+      })
+    });
+
+  data.packages;
+
+  // Register version to prevent sending notification again
+  db.notificationLastEmitVersion.set(dnpName, newVersion);
+}

--- a/packages/dappmanager/src/daemons/autoUpdates/updateMyPackages.ts
+++ b/packages/dappmanager/src/daemons/autoUpdates/updateMyPackages.ts
@@ -2,7 +2,9 @@ import semver from "semver";
 import { listPackages } from "../../modules/docker/list";
 import { eventBus } from "../../eventBus";
 import { ReleaseFetcher } from "../../modules/release";
-// Utils
+import { packageInstall } from "../../calls";
+import { logs } from "../../logs";
+import { sendUpdatePackageNotificationMaybe } from "./sendUpdateNotification";
 import computeSemverUpdateType from "../../utils/computeSemverUpdateType";
 import {
   isDnpUpdateEnabled,
@@ -10,66 +12,80 @@ import {
   flagCompletedUpdate,
   flagErrorUpdate
 } from "../../utils/autoUpdateHelper";
-// External calls
-import { packageInstall } from "../../calls";
-import { logs } from "../../logs";
 
-export default async function updateMyPackages(
+/**
+ * For all installed non-core DAppNode packages, check their latest version
+ * If there is an update available (of any kind)
+ * - Send notification once per package and version
+ * - Auto-update the package if allowed
+ */
+export async function checkNewPackagesVersion(
   releaseFetcher: ReleaseFetcher
 ): Promise<void> {
-  const dnpList = await listPackages();
+  const dnps = await listPackages();
 
-  for (const { dnpName, isDnp, version: currentVersion } of dnpList) {
-    if (
-      dnpName &&
-      // Ignore core DNPs
-      isDnp &&
-      // Ignore wierd versions
-      semver.valid(currentVersion)
-    ) {
-      try {
-        await updateMyPackage(releaseFetcher, dnpName, currentVersion);
-      } catch (e) {
-        logs.error(`Error auto-updating ${dnpName}`, e);
-      }
+  for (const { dnpName, isDnp, version: currentVersion } of dnps) {
+    // Ignore core DNPs, and non-valid versions (semver.lte will throw)
+    if (!dnpName || !isDnp || !semver.valid(currentVersion)) continue;
+
+    try {
+      // MUST exist an APM repo with the package dnpName
+      // Check here instead of the if statement to be inside the try / catch
+      const repoExists = await releaseFetcher.repoExists(dnpName);
+      if (!repoExists) return;
+
+      const { version: newVersion } = await releaseFetcher.fetchVersion(
+        dnpName
+      );
+
+      // This version is not an update
+      if (semver.lte(newVersion, currentVersion)) return;
+
+      const updateData = { dnpName, currentVersion, newVersion };
+
+      // Will try to resolve the IPFS release content, so await it to ensure it resolves
+      await sendUpdatePackageNotificationMaybe(releaseFetcher, updateData);
+
+      await autoUpdatePackageMaybe(updateData);
+    } catch (e) {
+      logs.error(`Error checking ${dnpName} version`, e);
     }
   }
 }
 
 /**
- * Only `minor` and `patch` updates are allowed
+ * Auto-update only if:
+ * - Updates are enabled for this specific package or all my-packages
+ * - Update type is minor or patch
+ * - The update delay is completed
  */
-
-async function updateMyPackage(
-  releaseFetcher: ReleaseFetcher,
-  dnpName: string,
-  currentVersion: string
-): Promise<void> {
+async function autoUpdatePackageMaybe({
+  dnpName,
+  currentVersion,
+  newVersion
+}: {
+  dnpName: string;
+  currentVersion: string;
+  newVersion: string;
+}): Promise<void> {
   // Check if this specific dnp has auto-updates enabled
   if (!isDnpUpdateEnabled(dnpName)) return;
 
-  // MUST exist an APM repo with the package name
-  // Check here instead of the if statement to be inside the try / catch
-  const repoExists = await releaseFetcher.repoExists(dnpName);
-  if (!repoExists) return;
-
-  const { version: latestVersion } = await releaseFetcher.fetchVersion(dnpName);
-
   // Compute if the update type is "patch"/"minor" = is allowed
   // If release is not allowed, abort
-  const updateType = computeSemverUpdateType(currentVersion, latestVersion);
+  const updateType = computeSemverUpdateType(currentVersion, newVersion);
   if (updateType !== "minor" && updateType !== "patch") return;
 
   // Enforce a 24h delay before performing an auto-update
   // Also records the remaining time in the db for the UI
-  if (!isUpdateDelayCompleted(dnpName, latestVersion)) return;
+  if (!isUpdateDelayCompleted(dnpName, newVersion)) return;
 
-  logs.info(`Auto-updating ${dnpName} to ${latestVersion}...`);
+  logs.info(`Auto-updating ${dnpName} to ${newVersion}...`);
 
   try {
-    await packageInstall({ name: dnpName, version: latestVersion });
+    await packageInstall({ name: dnpName, version: newVersion });
 
-    flagCompletedUpdate(dnpName, latestVersion);
+    flagCompletedUpdate(dnpName, newVersion);
     logs.info(`Successfully auto-updated system packages`);
     eventBus.requestPackages.emit();
   } catch (e) {

--- a/packages/dappmanager/src/daemons/autoUpdates/updateSystemPackages.ts
+++ b/packages/dappmanager/src/daemons/autoUpdates/updateSystemPackages.ts
@@ -3,19 +3,40 @@ import params from "../../params";
 import {
   isUpdateDelayCompleted,
   flagCompletedUpdate,
-  flagErrorUpdate
+  flagErrorUpdate,
+  isCoreUpdateEnabled
 } from "../../utils/autoUpdateHelper";
 import { packageInstall } from "../../calls";
 import { logs } from "../../logs";
 import { getCoreUpdateData } from "../../calls/fetchCoreUpdateData";
+import { CoreUpdateDataAvailable } from "../../types";
+import { sendUpdateSystemNotificationMaybe } from "./sendUpdateNotification";
 
 const coreDnpName = params.coreDnpName;
 
-export default async function updateSystemPackages(): Promise<void> {
-  const { available, type, versionId } = await getCoreUpdateData();
+/**
+ * Fetch core update data, check its version and if there is an update available
+ * - Send notification if this specific DNP_CORE version has not been seen
+ * - Auto-update system according if DNP_CORE or any dependency is not updated
+ */
+export async function checkSystemPackagesVersion(): Promise<void> {
+  const coreUpdateData = await getCoreUpdateData();
+
+  if (!coreUpdateData.available) return;
+
+  sendUpdateSystemNotificationMaybe(coreUpdateData);
+
+  await autoUpdateSystemPackages(coreUpdateData);
+}
+
+export async function autoUpdateSystemPackages({
+  type,
+  versionId
+}: CoreUpdateDataAvailable): Promise<void> {
+  if (!isCoreUpdateEnabled()) return;
 
   // If there is not update available or the type is not patch, return early
-  if (!available || type !== "patch") return;
+  if (type !== "patch") return;
 
   // Enforce a 24h delay before performing an auto-update
   // Also records the remaining time in the db for the UI

--- a/packages/dappmanager/src/daemons/telegramBot/commands.ts
+++ b/packages/dappmanager/src/daemons/telegramBot/commands.ts
@@ -4,6 +4,11 @@ import * as db from "../../db";
 import { logs } from "../../logs";
 import { formatTelegramCommandHeader } from "./buildTelegramCommandMessage";
 import { bold, url } from "./markdown";
+import { editCoreSetting, editDnpSetting } from "../../utils/autoUpdateHelper";
+
+export const enableAutoUpdatesCmd = "/enable-auto-updates";
+export const unsubscribeCmd = "/unsubscribe";
+export const helpCmd = "/help";
 
 /**
  * Polls for commands and responds.
@@ -30,9 +35,11 @@ export class DappnodeTelegramBot {
       try {
         if (!msg.text) return;
 
-        if (/\/unsubscribe/.test(msg.text)) {
+        if (msg.text.startsWith(enableAutoUpdatesCmd)) {
+          this.enableAutoUpdatesCmd(msg);
+        } else if (msg.text.startsWith(unsubscribeCmd)) {
           this.unsubscribeCmd(msg);
-        } else if (/\/help/.test(msg.text)) {
+        } else if (msg.text.startsWith(helpCmd)) {
           this.helpCmd(msg);
         } else {
           // If channel is not subscribed yet, subscribe
@@ -61,12 +68,26 @@ export class DappnodeTelegramBot {
   }
 
   /**
+   * Enable auto-updates for system and regular packages
+   */
+  private async enableAutoUpdatesCmd(msg: TelegramBot.Message): Promise<void> {
+    editDnpSetting(true);
+    editCoreSetting(true);
+
+    const message = [
+      "Successfully enabled auto-updates",
+      "You can manage or disable auto-update in the Admin UI"
+    ].join("\n\n");
+    await this.sendMessage(msg.chat.id.toString(), message);
+  }
+
+  /**
    * Add channel ID
    */
   private async subscribeCmd(msg: TelegramBot.Message): Promise<void> {
     const chatId = msg.chat.id.toString();
     const message =
-      formatTelegramCommandHeader("Success") + "Succesfully saved channel ID";
+      formatTelegramCommandHeader("Success") + "Successfully saved channel ID";
 
     this.addChannelId(chatId);
 

--- a/packages/dappmanager/src/db/notification.ts
+++ b/packages/dappmanager/src/db/notification.ts
@@ -4,6 +4,7 @@ import { joinWithDot } from "./dbUtils";
 import { PackageNotification } from "../types";
 
 const NOTIFICATION = "notification";
+const NOTIFICATION_LAST_EMITTED_VERSION = "notification-last-emitted-version";
 
 const notificationKeyGetter = (id: string): string =>
   joinWithDot(NOTIFICATION, id);
@@ -16,11 +17,20 @@ export const notification = dynamicKeyValidate<PackageNotificationDb, string>(
   notificationKeyGetter,
   notificationValidate
 );
-export function notificationPush(id: string, n: PackageNotification) {
+export function notificationPush(id: string, n: PackageNotification): void {
   notification.set(id, { ...n, timestamp: Date.now(), viewed: false });
 }
 
 export const notifications = staticKey<{ [id: string]: PackageNotificationDb }>(
   NOTIFICATION,
   {}
+);
+
+/**
+ * Register the last emitted version for a dnpName
+ * Only emit notifications for versions above this one
+ */
+export const notificationLastEmitVersion = dynamicKeyValidate<string, string>(
+  dnpName => joinWithDot(NOTIFICATION_LAST_EMITTED_VERSION, dnpName),
+  (dnpName, lastEmittedVersion) => typeof lastEmittedVersion === "string"
 );

--- a/packages/dappmanager/test/integration/fetchExternalData.test.int.ts
+++ b/packages/dappmanager/test/integration/fetchExternalData.test.int.ts
@@ -17,7 +17,9 @@ describe("Fetch external data", () => {
   describe("fetchCoreUpdateData", () => {
     it("Should fetch core update data", async () => {
       const result = await calls.fetchCoreUpdateData({});
-      expect(result.available, "Core update should be available").to.be.true;
+      if (!result.available) {
+        throw Error("Core update should be available");
+      }
       const dnpBind = result.packages.find(({ name }) => name === bindId);
       expect(dnpBind, "Bind DNP must be in packages array").to.be.ok;
     });


### PR DESCRIPTION
Fixes https://github.com/dappnode/DNP_DAPPMANAGER/issues/550

Extends the auto-updates daemon to also send new version available notifications

1. Check if new version available
2. Send notification if hasn't sent notification yet
3. Auto-update package if auto-updates are enabled for that package 