### PR TITLE
Fix post auto-update system packages logic

### DIFF
--- a/packages/dappmanager/src/calls/autoUpdateDataGet.ts
+++ b/packages/dappmanager/src/calls/autoUpdateDataGet.ts
@@ -27,11 +27,9 @@ export async function autoUpdateDataGet(): Promise<AutoUpdateDataView> {
       id: SYSTEM_PACKAGES,
       displayName: "System packages",
       enabled: autoUpdateHelper.isCoreUpdateEnabled(),
-      feedback: autoUpdateHelper.getCoreFeedbackMessage({
-        currentVersionId: getCoreVersionId(
-          dnpList.filter(({ isCore }) => isCore)
-        )
-      })
+      feedback: autoUpdateHelper.getCoreFeedbackMessage(
+        dnpList.filter(({ isCore }) => isCore)
+      )
     },
     {
       id: MY_PACKAGES,

--- a/packages/dappmanager/src/daemons/autoUpdates/index.ts
+++ b/packages/dappmanager/src/daemons/autoUpdates/index.ts
@@ -1,9 +1,9 @@
 import { AbortSignal } from "abort-controller";
 import params from "../../params";
 import { eventBus } from "../../eventBus";
-import { fetchCoreUpdateData } from "../../calls/fetchCoreUpdateData";
 import { ReleaseFetcher } from "../../modules/release";
 import { EthProviderError } from "../../modules/ethClient";
+import { listPackages } from "../../modules/docker/list";
 import {
   clearPendingUpdates,
   clearRegistry,
@@ -53,9 +53,9 @@ async function checkAutoUpdates(): Promise<void> {
  * update happen before restarting
  */
 async function checkForCompletedCoreUpdates(): Promise<void> {
-  const coreUpdateData = await fetchCoreUpdateData({});
-  if (coreUpdateData.available)
-    clearCompletedCoreUpdatesIfAny(coreUpdateData.versionId);
+  const dnps = await listPackages();
+  const currentCorePackages = dnps.filter(d => d.isCore);
+  clearCompletedCoreUpdatesIfAny(currentCorePackages);
 }
 
 /**

--- a/packages/dappmanager/src/utils/autoUpdateHelper.ts
+++ b/packages/dappmanager/src/utils/autoUpdateHelper.ts
@@ -2,7 +2,7 @@ import * as db from "../db";
 import params from "../params";
 import { eventBus } from "../eventBus";
 import { pick, omit } from "lodash";
-import { areCoreVersionIdsIncluded } from "./coreVersionId";
+import { areCoreVersionIdsIncluded, getCoreVersionId } from "./coreVersionId";
 import {
   AutoUpdateSettings,
   AutoUpdateRegistryEntry,
@@ -252,14 +252,17 @@ export function clearRegistry(dnpName: string): void {
  * "completed". So on every DAPPMANAGER start it must checked if a successful
  * update happen before restarting
  *
- * @param currentVersionId "admin@0.2.6,core@0.2.8"
+ * @param currentCorePackages To get the current version of installed packages
+ * If stored pending coreVersionId contains versions higher than this, it will
+ * be marked as done
  * @param timestamp Use ONLY to make tests deterministic
  */
 export function clearCompletedCoreUpdatesIfAny(
-  currentVersionId: string,
+  currentCorePackages: { dnpName: string; version: string }[],
   timestamp?: number
 ): void {
   const pending = getPending();
+  const currentVersionId = getCoreVersionId(currentCorePackages);
 
   const { version: pendingVersionId } =
     pending[coreDnpName] || ({} as AutoUpdatePendingEntry);

--- a/packages/dappmanager/src/utils/autoUpdateHelper.ts
+++ b/packages/dappmanager/src/utils/autoUpdateHelper.ts
@@ -2,7 +2,7 @@ import * as db from "../db";
 import params from "../params";
 import { eventBus } from "../eventBus";
 import { pick, omit } from "lodash";
-import { areCoreVersionIdsIncluded, getCoreVersionId } from "./coreVersionId";
+import { areCoreVersionIdsIncluded, isVersionIdUpdated } from "./coreVersionId";
 import {
   AutoUpdateSettings,
   AutoUpdateRegistryEntry,
@@ -262,13 +262,12 @@ export function clearCompletedCoreUpdatesIfAny(
   timestamp?: number
 ): void {
   const pending = getPending();
-  const currentVersionId = getCoreVersionId(currentCorePackages);
 
   const { version: pendingVersionId } =
     pending[coreDnpName] || ({} as AutoUpdatePendingEntry);
   const pendingVersionsAreInstalled =
     pendingVersionId &&
-    areCoreVersionIdsIncluded(pendingVersionId, currentVersionId);
+    isVersionIdUpdated(pendingVersionId, currentCorePackages);
 
   if (pendingVersionsAreInstalled && pendingVersionId) {
     flagCompletedUpdate(coreDnpName, pendingVersionId, timestamp);

--- a/packages/dappmanager/src/utils/autoUpdateHelper.ts
+++ b/packages/dappmanager/src/utils/autoUpdateHelper.ts
@@ -2,7 +2,7 @@ import * as db from "../db";
 import params from "../params";
 import { eventBus } from "../eventBus";
 import { pick, omit } from "lodash";
-import { areCoreVersionIdsIncluded, isVersionIdUpdated } from "./coreVersionId";
+import { isVersionIdUpdated } from "./coreVersionId";
 import {
   AutoUpdateSettings,
   AutoUpdateRegistryEntry,
@@ -433,17 +433,12 @@ export function getDnpFeedbackMessage({
  *   scheduled: 15363818244
  * }
  */
-export function getCoreFeedbackMessage({
-  currentVersionId,
-  registry,
-  pending
-}: {
-  currentVersionId: string;
-  registry?: AutoUpdateRegistry;
-  pending?: AutoUpdatePending;
-}): AutoUpdateFeedback {
-  if (!registry) registry = getRegistry();
-  if (!pending) pending = getPending();
+export function getCoreFeedbackMessage(
+  currentCorePackages: { dnpName: string; version: string }[],
+  data?: { registry?: AutoUpdateRegistry; pending?: AutoUpdatePending }
+): AutoUpdateFeedback {
+  const registry = data?.registry || getRegistry();
+  const pending = data?.pending || getPending();
 
   /**
    * Let's figure out the version of the core
@@ -454,10 +449,9 @@ export function getCoreFeedbackMessage({
   const lastUpdatedVersion = getLastRegistryEntry(registry[coreDnpName] || {});
   const lastUpdatedVersionsAreInstalled =
     lastUpdatedVersion.version &&
-    areCoreVersionIdsIncluded(lastUpdatedVersion.version, currentVersionId);
+    isVersionIdUpdated(lastUpdatedVersion.version, currentCorePackages);
   const pendingVersionsAreInstalled =
-    pendingVersion &&
-    areCoreVersionIdsIncluded(pendingVersion, currentVersionId);
+    pendingVersion && isVersionIdUpdated(pendingVersion, currentCorePackages);
 
   if (scheduledUpdate) {
     // If the pending version is the current BUT it is NOT in the registry,

--- a/packages/dappmanager/src/utils/coreVersionId.ts
+++ b/packages/dappmanager/src/utils/coreVersionId.ts
@@ -1,4 +1,5 @@
 import { difference } from "lodash";
+import semver from "semver";
 
 /**
  * Compute version id:
@@ -51,4 +52,23 @@ export function areCoreVersionIdsIncluded(
     parseCoreVersionIdToStrings(coreVersionIdSubset),
     parseCoreVersionIdToStrings(coreVersionIdSuperset)
   );
+}
+
+/**
+ * Returns true if the package versions of `coreVersionId` are greater than or equal
+ * to their version in `coreDnps`
+ * @param coreVersionId "admin@0.2.4,vpn@0.2.2,core@0.2.6"
+ */
+export function isVersionIdUpdated(
+  coreVersionId: string,
+  currentCorePackages: { dnpName: string; version: string }[]
+): boolean {
+  const currentVersions = new Map<string, string>(
+    currentCorePackages.map(p => [p.dnpName, p.version])
+  );
+  const versionIdDnps = parseCoreVersionId(coreVersionId);
+  return versionIdDnps.every(versionIdDnp => {
+    const currentVersion = currentVersions.get(versionIdDnp.dnpName);
+    return currentVersion && semver.gte(currentVersion, versionIdDnp.version);
+  });
 }

--- a/packages/dappmanager/test/utils/autoUpdateHelper.test.ts
+++ b/packages/dappmanager/test/utils/autoUpdateHelper.test.ts
@@ -562,11 +562,12 @@ describe("Util: autoUpdateHelper", () => {
   describe("DAPPMANAGER update patch measures", () => {
     it("Should clear complete core updates if update was completed", () => {
       const timestamp = Date.now();
-      const versionId = getCoreVersionId([
+      const currentCorePackages = [
         { dnpName: "admin", version: "0.2.1" },
         { dnpName: "vpn", version: "0.2.1" },
         { dnpName: "core", version: "0.2.1" }
-      ]);
+      ];
+      const versionId = getCoreVersionId(currentCorePackages);
       const nextVersionId = getCoreVersionId([
         { dnpName: "admin", version: "0.2.1" },
         { dnpName: "core", version: "0.2.1" }
@@ -586,7 +587,7 @@ describe("Util: autoUpdateHelper", () => {
         "Core update should be pending"
       );
 
-      clearCompletedCoreUpdatesIfAny(versionId, timestamp);
+      clearCompletedCoreUpdatesIfAny(currentCorePackages, timestamp);
 
       expect(getPending()).to.deep.equal(
         {},
@@ -605,11 +606,11 @@ describe("Util: autoUpdateHelper", () => {
 
     it("Should NOT clear complete core updates if update was NOT completed", () => {
       const timestamp = Date.now();
-      const versionId = getCoreVersionId([
+      const currentCorePackages = [
         { dnpName: "admin", version: "0.2.0" },
         { dnpName: "vpn", version: "0.2.1" },
         { dnpName: "core", version: "0.2.1" }
-      ]);
+      ];
       const nextVersionId = getCoreVersionId([
         { dnpName: "admin", version: "0.2.1" },
         { dnpName: "core", version: "0.2.1" }
@@ -629,7 +630,7 @@ describe("Util: autoUpdateHelper", () => {
         "Core update should be pending"
       );
 
-      clearCompletedCoreUpdatesIfAny(versionId, timestamp);
+      clearCompletedCoreUpdatesIfAny(currentCorePackages, timestamp);
 
       expect(getPending()).to.deep.equal(
         {

--- a/packages/dappmanager/test/utils/autoUpdateHelper.test.ts
+++ b/packages/dappmanager/test/utils/autoUpdateHelper.test.ts
@@ -368,9 +368,9 @@ describe("Util: autoUpdateHelper", () => {
 
   describe("Feedback text for COREs", () => {
     const currentVersionId = getCoreVersionId([
-      { dnpName: "admin", version: "0.2.0" },
-      { dnpName: "vpn", version: "0.2.1" },
-      { dnpName: "core", version: "0.2.0" }
+      { dnpName: "admin.dnp.dappnode.eth", version: "0.2.0" },
+      { dnpName: "vpn.dnp.dappnode.eth", version: "0.2.1" },
+      { dnpName: "core.dnp.dappnode.eth", version: "0.2.0" }
     ]);
 
     it("1. Nothing happened yet", () => {
@@ -390,8 +390,8 @@ describe("Util: autoUpdateHelper", () => {
         pending: {
           [coreDnpName]: {
             version: getCoreVersionId([
-              { dnpName: "admin", version: "0.2.1" },
-              { dnpName: "core", version: "0.2.1" }
+              { dnpName: "admin.dnp.dappnode.eth", version: "0.2.1" },
+              { dnpName: "core.dnp.dappnode.eth", version: "0.2.1" }
             ]),
             firstSeen: Date.now(),
             scheduledUpdate: timestamp,
@@ -405,16 +405,16 @@ describe("Util: autoUpdateHelper", () => {
     it("3A. Core is manually updated", () => {
       const feedback = getCoreFeedbackMessage({
         currentVersionId: getCoreVersionId([
-          { dnpName: "admin", version: "0.2.1" },
-          { dnpName: "vpn", version: "0.2.1" },
-          { dnpName: "core", version: "0.2.1" }
+          { dnpName: "admin.dnp.dappnode.eth", version: "0.2.1" },
+          { dnpName: "vpn.dnp.dappnode.eth", version: "0.2.1" },
+          { dnpName: "core.dnp.dappnode.eth", version: "0.2.1" }
         ]),
         registry: {},
         pending: {
           [coreDnpName]: {
             version: getCoreVersionId([
-              { dnpName: "admin", version: "0.2.1" },
-              { dnpName: "core", version: "0.2.1" }
+              { dnpName: "admin.dnp.dappnode.eth", version: "0.2.1" },
+              { dnpName: "core.dnp.dappnode.eth", version: "0.2.1" }
             ]),
             firstSeen: Date.now(),
             scheduledUpdate: Date.now() + 12.3 * 60 * 60 * 1000,
@@ -428,13 +428,13 @@ describe("Util: autoUpdateHelper", () => {
     it("3B. Core is successfully updated", () => {
       const timestamp = Date.now();
       const nextVersion = getCoreVersionId([
-        { dnpName: "admin", version: "0.2.1" },
-        { dnpName: "core", version: "0.2.1" }
+        { dnpName: "admin.dnp.dappnode.eth", version: "0.2.1" },
+        { dnpName: "core.dnp.dappnode.eth", version: "0.2.1" }
       ]);
       const currentVersionId = getCoreVersionId([
-        { dnpName: "admin", version: "0.2.1" },
-        { dnpName: "vpn", version: "0.2.1" },
-        { dnpName: "core", version: "0.2.1" }
+        { dnpName: "admin.dnp.dappnode.eth", version: "0.2.1" },
+        { dnpName: "vpn.dnp.dappnode.eth", version: "0.2.1" },
+        { dnpName: "core.dnp.dappnode.eth", version: "0.2.1" }
       ]);
       const feedback = getCoreFeedbackMessage({
         currentVersionId,
@@ -456,8 +456,8 @@ describe("Util: autoUpdateHelper", () => {
         pending: {
           [coreDnpName]: {
             version: getCoreVersionId([
-              { dnpName: "admin", version: "0.2.1" },
-              { dnpName: "core", version: "0.2.1" }
+              { dnpName: "admin.dnp.dappnode.eth", version: "0.2.1" },
+              { dnpName: "core.dnp.dappnode.eth", version: "0.2.1" }
             ]),
             firstSeen: Date.now() - 24.3 * 60 * 60 * 1000,
             scheduledUpdate: Date.now() - 0.3 * 60 * 60 * 1000,
@@ -471,22 +471,22 @@ describe("Util: autoUpdateHelper", () => {
 
     it("1 -> 4. Core full lifecycle", async () => {
       const currentVersionIdBefore = getCoreVersionId([
-        { dnpName: "admin", version: "0.2.0" },
-        { dnpName: "vpn", version: "0.2.0" },
-        { dnpName: "core", version: "0.2.0" }
+        { dnpName: "admin.dnp.dappnode.eth", version: "0.2.0" },
+        { dnpName: "vpn.dnp.dappnode.eth", version: "0.2.0" },
+        { dnpName: "core.dnp.dappnode.eth", version: "0.2.0" }
       ]);
       const nextVersionId = getCoreVersionId([
-        { dnpName: "admin", version: "0.2.1" },
-        { dnpName: "core", version: "0.2.1" }
+        { dnpName: "admin.dnp.dappnode.eth", version: "0.2.1" },
+        { dnpName: "core.dnp.dappnode.eth", version: "0.2.1" }
       ]);
       const currentVersionIdAfter = getCoreVersionId([
-        { dnpName: "admin", version: "0.2.1" },
-        { dnpName: "vpn", version: "0.2.0" },
-        { dnpName: "core", version: "0.2.1" }
+        { dnpName: "admin.dnp.dappnode.eth", version: "0.2.1" },
+        { dnpName: "vpn.dnp.dappnode.eth", version: "0.2.0" },
+        { dnpName: "core.dnp.dappnode.eth", version: "0.2.1" }
       ]);
       const nextVersion2Id = getCoreVersionId([
-        { dnpName: "admin", version: "0.2.2" },
-        { dnpName: "core", version: "0.2.2" }
+        { dnpName: "admin.dnp.dappnode.eth", version: "0.2.2" },
+        { dnpName: "core.dnp.dappnode.eth", version: "0.2.2" }
       ]);
       const microDelay = 20;
 
@@ -563,14 +563,13 @@ describe("Util: autoUpdateHelper", () => {
     it("Should clear complete core updates if update was completed", () => {
       const timestamp = Date.now();
       const currentCorePackages = [
-        { dnpName: "admin", version: "0.2.1" },
-        { dnpName: "vpn", version: "0.2.1" },
-        { dnpName: "core", version: "0.2.1" }
+        { dnpName: "admin.dnp.dappnode.eth", version: "0.2.1" },
+        { dnpName: "vpn.dnp.dappnode.eth", version: "0.2.1" },
+        { dnpName: "core.dnp.dappnode.eth", version: "0.2.1" }
       ];
-      const versionId = getCoreVersionId(currentCorePackages);
       const nextVersionId = getCoreVersionId([
-        { dnpName: "admin", version: "0.2.1" },
-        { dnpName: "core", version: "0.2.1" }
+        { dnpName: "admin.dnp.dappnode.eth", version: "0.2.1" },
+        { dnpName: "core.dnp.dappnode.eth", version: "0.2.1" }
       ]);
 
       isUpdateDelayCompleted(coreDnpName, nextVersionId, timestamp);
@@ -607,13 +606,13 @@ describe("Util: autoUpdateHelper", () => {
     it("Should NOT clear complete core updates if update was NOT completed", () => {
       const timestamp = Date.now();
       const currentCorePackages = [
-        { dnpName: "admin", version: "0.2.0" },
-        { dnpName: "vpn", version: "0.2.1" },
-        { dnpName: "core", version: "0.2.1" }
+        { dnpName: "admin.dnp.dappnode.eth", version: "0.2.0" },
+        { dnpName: "vpn.dnp.dappnode.eth", version: "0.2.1" },
+        { dnpName: "core.dnp.dappnode.eth", version: "0.2.1" }
       ];
       const nextVersionId = getCoreVersionId([
-        { dnpName: "admin", version: "0.2.1" },
-        { dnpName: "core", version: "0.2.1" }
+        { dnpName: "admin.dnp.dappnode.eth", version: "0.2.1" },
+        { dnpName: "core.dnp.dappnode.eth", version: "0.2.1" }
       ]);
 
       isUpdateDelayCompleted(coreDnpName, nextVersionId, timestamp);

--- a/packages/dappmanager/test/utils/coreVersionId.test.ts
+++ b/packages/dappmanager/test/utils/coreVersionId.test.ts
@@ -5,7 +5,7 @@ import {
   getCoreVersionId,
   parseCoreVersionId,
   includesArray,
-  areCoreVersionIdsIncluded
+  isVersionIdUpdated
 } from "../../src/utils/coreVersionId";
 
 describe("Util: coreVersionId", () => {
@@ -53,28 +53,52 @@ describe("Util: coreVersionId", () => {
     });
   });
 
-  describe("areCoreVersionIdsIncluded", () => {
-    const coreVersionSubset: { dnpName: string; version: string }[] = [
-      { dnpName: "admin.dnp.dappnode.eth", version: "0.2.6" },
-      { dnpName: "core.dnp.dappnode.eth", version: "0.2.8" }
-    ];
-    const coreVersionSuperset: { dnpName: string; version: string }[] = [
-      ...coreVersionSubset,
-      { dnpName: "vpn.dnp.dappnode.eth", version: "0.2.2" }
-    ];
-    const coreVersionIdSubset = getCoreVersionId(coreVersionSubset);
-    const coreVersionIdSuperset = getCoreVersionId(coreVersionSuperset);
+  describe("isVersionIdUpdated", () => {
+    describe("Compare versions encoded", () => {
+      const corePkgsPrev = [
+        { dnpName: "admin.dnp.dappnode.eth", version: "0.2.0" }
+      ];
+      const corePkgsNext = [
+        { dnpName: "admin.dnp.dappnode.eth", version: "0.2.1" }
+      ];
 
-    it("Should return true for including core version ids", () => {
-      expect(
-        areCoreVersionIdsIncluded(coreVersionIdSubset, coreVersionIdSuperset)
-      ).to.be.true;
+      const versionIdPrev = getCoreVersionId(corePkgsPrev);
+      const versionIdNext = getCoreVersionId(corePkgsNext);
+
+      it("prev should NOT be gte next", () => {
+        expect(isVersionIdUpdated(versionIdPrev, corePkgsNext)).to.be.false;
+      });
+
+      it("next should be gte prev", () => {
+        expect(isVersionIdUpdated(versionIdNext, corePkgsPrev)).to.be.true;
+      });
+
+      it("next should be gte next", () => {
+        expect(isVersionIdUpdated(versionIdNext, corePkgsNext)).to.be.true;
+      });
     });
 
-    it("Should return false for NOT including core version ids", () => {
-      expect(
-        areCoreVersionIdsIncluded(coreVersionIdSuperset, coreVersionIdSubset)
-      ).to.be.false;
+    describe("Compare a subset with a superset", () => {
+      const corePkgsSubset = [
+        { dnpName: "admin.dnp.dappnode.eth", version: "0.2.0" },
+        { dnpName: "core.dnp.dappnode.eth", version: "0.2.0" }
+      ];
+      const corePkgsSuperset = [
+        ...corePkgsSubset,
+        { dnpName: "vpn.dnp.dappnode.eth", version: "0.2.0" }
+      ];
+      const versionIdSubset = getCoreVersionId(corePkgsSubset);
+      const versionIdSuperset = getCoreVersionId(corePkgsSuperset);
+
+      it("Should return true for including core version ids", () => {
+        expect(isVersionIdUpdated(versionIdSubset, corePkgsSuperset)).to.be
+          .true;
+      });
+
+      it("Should return false for NOT including core version ids", () => {
+        expect(isVersionIdUpdated(versionIdSuperset, corePkgsSubset)).to.be
+          .false;
+      });
     });
   });
 });


### PR DESCRIPTION
To uniquely identify core updates a `coreVersionId` is used. The logic to clear existing updates was faulty since it was compared against the latest versions in blockchain instead of the local current version. This PR also simplifies unnecessary complexity converting from and to this `coreVersionId` string.