### PR TITLE
Change devices tab name to VPN

### DIFF
--- a/packages/admin-ui/src/components/navbar/navbarItems.ts
+++ b/packages/admin-ui/src/components/navbar/navbarItems.ts
@@ -49,7 +49,7 @@ export const sidenavItems: {
     icon: MdDashboard
   },
   {
-    name: "Devices",
+    name: "VPN",
     href: "/devices",
     icon: MdDevices
   },

--- a/packages/admin-ui/src/pages/devices/components/DevicesHome.tsx
+++ b/packages/admin-ui/src/pages/devices/components/DevicesHome.tsx
@@ -13,7 +13,6 @@ import Card from "components/Card";
 import Switch from "components/Switch";
 import Button from "components/Button";
 import { renderResponse } from "components/SwrRender";
-import SubTitle from "components/SubTitle";
 // Icons
 import { MdDelete, MdRefresh } from "react-icons/md";
 import { MAIN_ADMIN_NAME } from "params";
@@ -78,11 +77,6 @@ export default function DevicesHome() {
   return (
     <>
       <Title title={title} />
-      <SubTitle>What can you do in this VPN section?</SubTitle>
-      <p>
-      On this page, you can set up your VPN for every device you have. You should set up every device you
-      will access the UI of your dappnode, you should generate VPN credential for everyone.
-      </p>
       <Input
         placeholder="Device's unique name"
         value={input}

--- a/packages/admin-ui/src/pages/devices/components/DevicesHome.tsx
+++ b/packages/admin-ui/src/pages/devices/components/DevicesHome.tsx
@@ -13,6 +13,7 @@ import Card from "components/Card";
 import Switch from "components/Switch";
 import Button from "components/Button";
 import { renderResponse } from "components/SwrRender";
+import SubTitle from "components/SubTitle";
 // Icons
 import { MdDelete, MdRefresh } from "react-icons/md";
 import { MAIN_ADMIN_NAME } from "params";
@@ -77,7 +78,11 @@ export default function DevicesHome() {
   return (
     <>
       <Title title={title} />
-
+      <SubTitle>What can you do in this VPN section?</SubTitle>
+      <p>
+      On this page, you can set up your VPN for every device you have. You should set up every device you
+      will access the UI of your dappnode, you should generate VPN credential for everyone.
+      </p>
       <Input
         placeholder="Device's unique name"
         value={input}

--- a/packages/admin-ui/src/pages/devices/data.ts
+++ b/packages/admin-ui/src/pages/devices/data.ts
@@ -1,6 +1,6 @@
 // This will be used later in our root reducer and selectors
 export const rootPath = "/devices";
-export const title = "Devices";
+export const title = "VPN";
 
 // Additional data
 export const maxIdLength = 80;

--- a/packages/admin-ui/src/pages/index.ts
+++ b/packages/admin-ui/src/pages/index.ts
@@ -1,5 +1,5 @@
 import * as dashboard from "./dashboard";
-import * as devices from "./devices";
+import * as VPN from "./devices";
 import * as installer from "./installer";
 import * as packages from "./packages";
 import * as sdk from "./sdk";
@@ -8,7 +8,7 @@ import * as system from "./system";
 
 export default {
   dashboard,
-  devices,
+  VPN,
   installer,
   packages,
   sdk,


### PR DESCRIPTION
Fixes #459

We have changed the name devices for "VPN", we have included a description text due to what you should set up on this section. 

I have not changed the folder name admin-ui/src/pages/devices for admin-ui/src/pages/vpn. Maybe it would be better to understand the structure of the project after this modification.

