### PR TITLE
Remove typo on a attribute

### DIFF
--- a/packages/admin-ui/src/api/mock/routes.ts
+++ b/packages/admin-ui/src/api/mock/routes.ts
@@ -1,6 +1,9 @@
 import { IApiRoutes } from "api/interface";
+import newTabProps from "utils/newTabProps";
 
 // For mock return: "data:text/csv;charset=utf-8;base64,dddddd"
+
+newTabProps.download = "test-dappnode-file";
 
 export const apiRoutes: IApiRoutes = {
   fileDownloadUrl({ containerName, path }) {

--- a/packages/admin-ui/src/api/routes/index.ts
+++ b/packages/admin-ui/src/api/routes/index.ts
@@ -1,9 +1,6 @@
 import { IApiRoutes } from "api/interface";
 import { apiUrls } from "params";
 import { urlJoin } from "utils/url";
-import newTabProps from "utils/newTabProps";
-
-newTabProps.download = "test-dappnode-file";
 
 export const apiRoutes: IApiRoutes = {
   fileDownloadUrl({ containerName, path }) {


### PR DESCRIPTION
Partially fixes https://github.com/dappnode/DAppNode/issues/261

This extra attribute is only meant for testing. In a production context it will turn a failed download attempt into a file that does not exist