### PR TITLE
Change the position of the QR box on devices page

### DIFF
--- a/packages/admin-ui/src/pages/devices/components/DeviceDetails.tsx
+++ b/packages/admin-ui/src/pages/devices/components/DeviceDetails.tsx
@@ -121,8 +121,6 @@ function DeviceDetailsLoaded({ device }: { device: VpnDeviceCredentials }) {
         )
       ) : null}
 
-
-
       {showQr && url && <QrCode url={url} width={"400px"} />}
 
       <div className="alert alert-secondary" role="alert">

--- a/packages/admin-ui/src/pages/devices/components/DeviceDetails.tsx
+++ b/packages/admin-ui/src/pages/devices/components/DeviceDetails.tsx
@@ -67,6 +67,10 @@ function DeviceDetailsLoaded({ device }: { device: VpnDeviceCredentials }) {
         />
       </Form.Group>
 
+      <Button onClick={() => setShowQr(!showQr)}>
+        {showQr ? "Hide" : "Show"} VPN credentials URL QR code
+      </Button>
+
       {device.admin ? (
         device.hasChangedPassword ? (
           <Alert variant="info">
@@ -117,9 +121,7 @@ function DeviceDetailsLoaded({ device }: { device: VpnDeviceCredentials }) {
         )
       ) : null}
 
-      <Button onClick={() => setShowQr(!showQr)}>
-        {showQr ? "Hide" : "Show"} VPN credentials URL QR code
-      </Button>
+
 
       {showQr && url && <QrCode url={url} width={"400px"} />}
 

--- a/packages/admin-ui/src/pages/devices/components/DeviceDetails.tsx
+++ b/packages/admin-ui/src/pages/devices/components/DeviceDetails.tsx
@@ -67,12 +67,6 @@ function DeviceDetailsLoaded({ device }: { device: VpnDeviceCredentials }) {
         />
       </Form.Group>
 
-      <Button onClick={() => setShowQr(!showQr)}>
-        {showQr ? "Hide" : "Show"} VPN credentials URL QR code
-      </Button>
-
-      {showQr && url && <QrCode url={url} width={"400px"} />}
-
       {device.admin ? (
         device.hasChangedPassword ? (
           <Alert variant="info">
@@ -122,6 +116,12 @@ function DeviceDetailsLoaded({ device }: { device: VpnDeviceCredentials }) {
           </>
         )
       ) : null}
+
+      <Button onClick={() => setShowQr(!showQr)}>
+        {showQr ? "Hide" : "Show"} VPN credentials URL QR code
+      </Button>
+
+      {showQr && url && <QrCode url={url} width={"400px"} />}
 
       <div className="alert alert-secondary" role="alert">
         Beware of shoulder surfing attacks (unsolicited observers), This data


### PR DESCRIPTION
We are changing the position of the QR code. The button is under the inputs : username and admin password now. Furthermore, when the qr image is showed is under the admin username and password too.