### PR TITLE
Improve usability of ETH_MAINNET_RPC_URL variables

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,9 +21,9 @@ services:
       - "/etc/hostname:/etc/dappnodename:ro"
     environment:
       - LOG_LEVEL=info
-      - WEB3_HOST=
+      - ETH_MAINNET_RPC_URL_OVERRIDE=
+      - ETH_MAINNET_RPC_URL_REMOTE=
       - IPFS_HOST=
-      - REMOTE_MAINNET_RPC_URL=
       - DISABLE_UPNP=
     dns: 172.33.1.2
     networks:

--- a/packages/dappmanager/.env
+++ b/packages/dappmanager/.env
@@ -1,7 +1,7 @@
 NODE_ENV=development
 LOG_LEVEL=debug
 
-WEB3_HOST=https://mainnet.infura.io/v3/bb15bacfcdbe45819caede241dcf8b0d
+ETH_MAINNET_RPC_URL_OVERRIDE=https://mainnet.infura.io/v3/bb15bacfcdbe45819caede241dcf8b0d
 IPFS_HOST=http://ipfs.dappnode.io:5001
 
 TEST=true

--- a/packages/dappmanager/src/calls/systemInfoGet.ts
+++ b/packages/dappmanager/src/calls/systemInfoGet.ts
@@ -30,7 +30,7 @@ export async function systemInfoGet(): Promise<SystemInfo> {
     dappmanagerNaclPublicKey: db.naclPublicKey.get(),
     // From seedPhrase: If it's not stored yet, it's an empty string
     identityAddress: db.identityAddress.get(),
-    // Eth provider configured URL, if empty will default to WEB3_HOST
+    // Eth provider configured URL
     ethClientTarget,
     ethClientStatus: ethClientTarget
       ? db.ethClientStatus.get(ethClientTarget)

--- a/packages/dappmanager/src/modules/ethClient/ethersProvider.ts
+++ b/packages/dappmanager/src/modules/ethClient/ethersProvider.ts
@@ -27,6 +27,9 @@ export async function getEthersProvider(): Promise<
  * @returns ethProvier http://geth.dappnode:8545
  */
 export async function getEthProviderUrl(): Promise<string> {
+  if (params.ETH_MAINNET_RPC_URL_OVERRIDE)
+    return params.ETH_MAINNET_RPC_URL_OVERRIDE;
+
   const target = db.ethClientTarget.get();
   const fallback = db.ethClientFallback.get();
 
@@ -34,7 +37,7 @@ export async function getEthProviderUrl(): Promise<string> {
   if (!target) throw new EthProviderError(`No ethereum client selected yet`);
 
   // Remote is selected, just return remote
-  if (target === "remote") return params.REMOTE_MAINNET_RPC_URL;
+  if (target === "remote") return params.ETH_MAINNET_RPC_URL_REMOTE;
 
   const status = await getClientStatus(target);
   db.ethClientStatus.set(target, status);
@@ -46,7 +49,7 @@ export async function getEthProviderUrl(): Promise<string> {
   } else {
     if (fallback === "on") {
       // Fallback on, ignore error and return remote
-      return params.REMOTE_MAINNET_RPC_URL;
+      return params.ETH_MAINNET_RPC_URL_REMOTE;
     } else {
       // Fallback off, throw nice error
       const message = parseClientStatusError(status);

--- a/packages/dappmanager/src/params.ts
+++ b/packages/dappmanager/src/params.ts
@@ -129,7 +129,9 @@ const params = {
   IPFS_TIMEOUT: 0.5 * MINUTE,
 
   // Web3 parameters
-  WEB3_HOST: process.env.WEB3_HOST || "http://fullnode.dappnode:8545",
+  ETH_MAINNET_RPC_URL_OVERRIDE: process.env.ETH_MAINNET_RPC_OVERRIDE,
+  ETH_MAINNET_RPC_URL_REMOTE:
+    process.env.ETH_MAINNET_RPC_URL_REMOTE || "https://web3.dappnode.net",
 
   // DAppNode specific names
   bindDnpName: "bind.dnp.dappnode.eth",
@@ -155,10 +157,6 @@ const params = {
   DYNDNS_HOST: "https://ns.dappnode.io",
   DYNDNS_DOMAIN: "dyndns.dappnode.io",
   DYNDNS_INTERVAL: 30 * 60 * 1000, // 30 minutes
-
-  // DAppNode remote fullnode service
-  REMOTE_MAINNET_RPC_URL:
-    process.env.REMOTE_MAINNET_RPC_URL || "https://web3.dappnode.net",
 
   // System file paths
   HOSTNAME_PATH: "/etc/dappnodename",

--- a/test/test_integration.sh
+++ b/test/test_integration.sh
@@ -17,7 +17,6 @@ docker-compose down --timeout 0 --volumes
 # cp dappnode_package.json $DAPPNODE_DIR
 
 # docker-compose -f ${DAPPNODE_DIR}/docker-compose-dappmanager.yml build
-# WEB3_HOST_WS
 # # Run test
 # ##########
 # docker-compose -f ${DAPPNODE_DIR}/docker-compose-dappmanager.yml up -d


### PR DESCRIPTION
Adds two ENV variables
- `ETH_MAINNET_RPC_URL_OVERRIDE`: If defined the DAPPMANAGER will always use this rpc URL to fetch package data
- `ETH_MAINNET_RPC_URL_REMOTE`: Defines the remote node, only used under certain conditions

Fixes https://github.com/dappnode/DNP_DAPPMANAGER/issues/619