### PR TITLE
Share variables with multiples services

### DIFF
--- a/packages/admin-ui/src/__tests__/pages/installer/parsers/setupWizardParser.test.ts
+++ b/packages/admin-ui/src/__tests__/pages/installer/parsers/setupWizardParser.test.ts
@@ -132,6 +132,43 @@ const testCases: {
         envService2: "value2"
       }
     }
+  },
+
+  {
+    testName: "Multi-service case2",
+    setupTarget: {
+      [dnpName]: {
+        envService1: {
+          type: "environment",
+          name: "ENV_SERVICE_1",
+          service: [service1, service2]
+        },
+        envService2: {
+          type: "environment",
+          name: "ENV_SERVICE_2",
+          service: service2
+        }
+      }
+    },
+    userSettings: {
+      [dnpName]: {
+        environment: {
+          [service1]: {
+            ENV_SERVICE_1: "value1"
+          },
+          [service2]: {
+            ENV_SERVICE_1: "value1",
+            ENV_SERVICE_2: "value2"
+          }
+        }
+      }
+    },
+    formData: {
+      [dnpName]: {
+        envService1: "value1",
+        envService2: "value2"
+      }
+    }
   }
 ];
 

--- a/packages/admin-ui/src/common/types.ts
+++ b/packages/admin-ui/src/common/types.ts
@@ -99,7 +99,7 @@ export interface SetupWizardField {
 }
 
 export type UserSettingTarget =
-  | { type: "environment"; name: string; service?: string }
+  | { type: "environment"; name: string; service?: string[] | string }
   | { type: "portMapping"; containerPort: string; service?: string }
   | { type: "namedVolumeMountpoint"; volumeName: string }
   | { type: "allNamedVolumesMountpoint" }


### PR DESCRIPTION
Add this feature:  this Setup wizard: Share variables with multiple services #633 

I created this package to test it where we have a package using both ways to define variables:
You can install it: 
Release hash : /ipfs/QmYH3vbqN4bt3eDpbBp4Gcn72CM61LVR9Q2drTviZuLTcX
http://my.dappnode/#/installer/%2Fipfs%2FQmYH3vbqN4bt3eDpbBp4Gcn72CM61LVR9Q2drTviZuLTcX

The format is the following:
```yaml
fields:
  - id: ethereum_url
    target:
      type: environment
      name: ETHEREUM_URL
      services: [service1, service2]
```
