### PR TITLE
Fix bug in migration: check if aliases is defined in compose

### DIFF
--- a/packages/dappmanager/src/modules/dockerUpdate/utils.ts
+++ b/packages/dappmanager/src/modules/dockerUpdate/utils.ts
@@ -30,8 +30,6 @@ export function parseDockerEngineRequirements(
 
   const dockerServerVersionCleaned = sanitizeVersion(dockerServerVersion);
   const dockerCliVersionCleaned = sanitizeVersion(dockerCliVersion);
-  if (!dockerServerVersionCleaned || !dockerCliVersionCleaned)
-    throw Error("Docker version cannot be used by semver");
 
   const isOsSupported = supportedOs === os;
   const isArchSupported = supportedArchs.some(arch => arch === architecture);

--- a/packages/dappmanager/src/modules/dockerUpdate/utils.ts
+++ b/packages/dappmanager/src/modules/dockerUpdate/utils.ts
@@ -5,6 +5,7 @@ import {
   UpdateRequirement,
   DockerUpdateStatus
 } from "../../types";
+import { sanitizeVersion } from "../../utils/sanitizeVersion";
 import {
   supportedOs,
   supportedArchs,
@@ -27,12 +28,8 @@ export function parseDockerEngineRequirements(
     dockerComposeVersion
   } = info;
 
-  const dockerServerVersionCleaned = semver.clean(dockerServerVersion, {
-    loose: true
-  });
-  const dockerCliVersionCleaned = semver.clean(dockerCliVersion, {
-    loose: true
-  });
+  const dockerServerVersionCleaned = sanitizeVersion(dockerServerVersion);
+  const dockerCliVersionCleaned = sanitizeVersion(dockerCliVersion);
   if (!dockerServerVersionCleaned || !dockerCliVersionCleaned)
     throw Error("Docker version cannot be used by semver");
 

--- a/packages/dappmanager/src/modules/https-portal/migration.ts
+++ b/packages/dappmanager/src/modules/https-portal/migration.ts
@@ -116,10 +116,10 @@ export function migrateCoreNetworkAndAliasInCompose(
     params.DNP_PRIVATE_NETWORK_NAME
   );
   if (
-    composeNetwork?.name === params.DNP_PRIVATE_NETWORK_NAME &&
-    composeNetwork?.external &&
-    serviceNetwork.aliases &&
-    serviceNetwork.aliases.includes(alias)
+    !serviceNetwork || // serviceNetwork will not exist in composes already migrated
+    (composeNetwork?.name === params.DNP_PRIVATE_NETWORK_NAME &&
+      composeNetwork?.external &&
+      serviceNetwork.aliases?.includes(alias))
   )
     return;
 

--- a/packages/dappmanager/src/modules/https-portal/migration.ts
+++ b/packages/dappmanager/src/modules/https-portal/migration.ts
@@ -16,7 +16,7 @@ import { PackageContainer } from "../../types";
 import { parseServiceNetworks } from "../compose/networks";
 import { ComposeNetwork, ComposeServiceNetwork } from "../../common";
 import semver from "semver";
-import { sanitizeVersion } from "../../utils/sanitizeVersion";
+import { parseComposeSemver } from "../../utils/sanitizeVersion";
 
 /** Alias for code succinctness */
 const dncoreNetworkName = params.DNP_PRIVATE_NETWORK_NAME;
@@ -159,8 +159,8 @@ function isComposeNetworkAndAliasMigrated(
     composeNetwork?.name === params.DNP_PRIVATE_NETWORK_NAME && // Check property name is defined
     composeNetwork?.external && // Check is external network
     semver.gte(
-      sanitizeVersion(composeVersion + ".0"),
-      sanitizeVersion(params.MINIMUM_COMPOSE_VERSION + ".0")
+      parseComposeSemver(composeVersion),
+      parseComposeSemver(params.MINIMUM_COMPOSE_VERSION)
     ) && // Check version is at least 3.5
     serviceNetwork.aliases?.includes(alias) // Check alias has been added
   )

--- a/packages/dappmanager/src/modules/https-portal/migration.ts
+++ b/packages/dappmanager/src/modules/https-portal/migration.ts
@@ -14,6 +14,8 @@ import * as getPath from "../../utils/getPath";
 import { ComposeFileEditor } from "../compose/editor";
 import { PackageContainer } from "../../types";
 import { parseServiceNetworks } from "../compose/networks";
+import { ComposeNetwork, ComposeServiceNetwork } from "../../common";
+import semver from "semver";
 
 /** Alias for code succinctness */
 const dncoreNetworkName = params.DNP_PRIVATE_NETWORK_NAME;
@@ -96,10 +98,10 @@ export function migrateCoreNetworkAndAliasInCompose(
 ): void {
   const compose = new ComposeFileEditor(container.dnpName, container.isCore);
 
-  // 0. Check if network migration has been done
-
-  // 1. Get compose network settings: not needed since will be declared as external
-  // const networkConfig = compose.getComposeNetwork(dncoreNetworkNameFromCore);
+  // 1. Get compose network settings
+  const composeNetwork = compose.getComposeNetwork(
+    params.DNP_PRIVATE_NETWORK_NAME
+  );
 
   // 2. Get compose service network settings
   const composeService = compose.services()[container.serviceName];
@@ -109,17 +111,16 @@ export function migrateCoreNetworkAndAliasInCompose(
   );
 
   const serviceNetwork =
-    serviceNetworks?.[params.DNP_PRIVATE_NETWORK_NAME_FROM_CORE];
+    serviceNetworks[params.DNP_PRIVATE_NETWORK_NAME_FROM_CORE] ?? null;
 
   // 3. Check if migration was done
-  const composeNetwork = compose.getComposeNetwork(
-    params.DNP_PRIVATE_NETWORK_NAME
-  );
   if (
-    !serviceNetwork || // serviceNetwork will not exist in composes already migrated
-    (composeNetwork?.name === params.DNP_PRIVATE_NETWORK_NAME &&
-      composeNetwork?.external &&
-      serviceNetwork.aliases?.includes(alias))
+    isComposeNetworkAndAliasMigrated(
+      composeNetwork,
+      serviceNetwork,
+      compose.compose.version,
+      alias
+    )
   )
     return;
 
@@ -129,8 +130,12 @@ export function migrateCoreNetworkAndAliasInCompose(
     version: params.MINIMUM_COMPOSE_VERSION
   };
 
-  // 5. core network migration: network => dncore_network
-  composeService.removeNetwork(params.DNP_PRIVATE_NETWORK_NAME_FROM_CORE);
+  // 5. Add network and alias
+  if (composeNetwork || serviceNetwork)
+    // composeNetwork and serviceNetwork might be null and have different values (eitherway it should be the same)
+    // Only remove network if exists
+    composeService.removeNetwork(params.DNP_PRIVATE_NETWORK_NAME_FROM_CORE);
+
   composeService.addNetwork(
     params.DNP_PRIVATE_NETWORK_NAME,
     { ...serviceNetwork, aliases: [alias] },
@@ -138,4 +143,37 @@ export function migrateCoreNetworkAndAliasInCompose(
   );
 
   compose.write();
+}
+
+function isComposeNetworkAndAliasMigrated(
+  composeNetwork: ComposeNetwork | null,
+  serviceNetwork: ComposeServiceNetwork | null,
+  composeVersion: string,
+  alias: string
+): boolean {
+  // semver can only work with version of 3 numbers. e.g: 3.5.0
+  const composeVersionCleaned = semver.clean(composeVersion + ".0", {
+    loose: true
+  });
+  const minimumComposeVersionCleaned = semver.clean(
+    params.MINIMUM_COMPOSE_VERSION + ".0",
+    {
+      loose: true
+    }
+  );
+
+  if (!composeVersionCleaned || !minimumComposeVersionCleaned)
+    throw Error("Docker compose file version cannot be used by semver");
+
+  // 1. Migration undone for aliases or networks or both => return false
+  if (!composeNetwork || !serviceNetwork) return false; // Consider as not migrated if either composeNetwork or serviceNetwork are not present
+  // 2. Migration done for aliases and networks => return true
+  if (
+    composeNetwork?.name === params.DNP_PRIVATE_NETWORK_NAME && // Check property name is defined
+    composeNetwork?.external && // Check is external network
+    semver.gte(composeVersionCleaned, minimumComposeVersionCleaned) && // Check version is at least 3.5
+    serviceNetwork.aliases?.includes(alias) // Check alias has been added
+  )
+    return true;
+  return false; // In other cases return false
 }

--- a/packages/dappmanager/src/modules/https-portal/migration.ts
+++ b/packages/dappmanager/src/modules/https-portal/migration.ts
@@ -118,7 +118,8 @@ export function migrateCoreNetworkAndAliasInCompose(
   if (
     composeNetwork?.name === params.DNP_PRIVATE_NETWORK_NAME &&
     composeNetwork?.external &&
-    serviceNetwork.aliases?.includes(alias)
+    serviceNetwork.aliases &&
+    serviceNetwork.aliases.includes(alias)
   )
     return;
 

--- a/packages/dappmanager/src/utils/sanitizeVersion.ts
+++ b/packages/dappmanager/src/utils/sanitizeVersion.ts
@@ -1,10 +1,23 @@
 import semver from "semver";
 
-export function sanitizeVersion(version: string) {
+/**
+ * Return a version with low level of constraints that can be used by semver
+ * Or throw an error if cannot be cleaned
+ */
+export function sanitizeVersion(version: string): string {
   const sanitizedVersion = semver.clean(version, {
     loose: true
   });
   if (!sanitizedVersion)
     throw Error(`Error: ${version} cannot be used by semver`);
   return sanitizedVersion;
+}
+
+/**
+ * A compose version has format `major.minor` (i.e. `3.5`) which is not valid semver.
+ * This function returns a valid semver by setting `patch = 0`, allowing to compare with semver fns,
+ * i.e. `semver.gt()`
+ */
+export function parseComposeSemver(composeVersion: string): string {
+  return sanitizeVersion(composeVersion + ".0");
 }

--- a/packages/dappmanager/src/utils/sanitizeVersion.ts
+++ b/packages/dappmanager/src/utils/sanitizeVersion.ts
@@ -1,0 +1,10 @@
+import semver from "semver";
+
+export function sanitizeVersion(version: string) {
+  const sanitizedVersion = semver.clean(version, {
+    loose: true
+  });
+  if (!sanitizedVersion)
+    throw Error(`Error: ${version} cannot be used by semver`);
+  return sanitizedVersion;
+}


### PR DESCRIPTION
Error in migration process:
```
ERROR [modules/https-portal/migration:63] Error adding alias to container DAppNodeCore-dappmanager.dnp.dappnode.eth TypeError: Cannot read property 'aliases' of undefined
    at migrateCoreNetworkAndAliasInCompose (/usr/src/app/webpack:/src/modules/https-portal/migration.ts:121:20)
```