### PR TITLE
Split packages view

### DIFF
--- a/packages/admin-ui/src/pages/packages/components/FileManager/index.tsx
+++ b/packages/admin-ui/src/pages/packages/components/FileManager/index.tsx
@@ -6,6 +6,7 @@ import { CopyFileTo } from "./To";
 import { CopyFileFrom } from "./From";
 import { PackageContainer } from "common";
 import { ServiceSelector } from "../ServiceSelector";
+import SubTitle from "components/SubTitle";
 
 export const FileManager = ({
   containers
@@ -19,33 +20,34 @@ export const FileManager = ({
 
   const container = containers.find(c => c.serviceName === serviceName);
   const containerName = container?.containerName;
-  const name = serviceNames.length === 1 ? "package" : serviceName;
 
   return (
-    <Card spacing divider className="file-manager">
-      <ServiceSelector
-        serviceName={serviceName}
-        setServiceName={setServiceName}
-        containers={containers}
-      />
+    <>
+      <Card spacing divider className="file-manager">
+        <ServiceSelector
+          serviceName={serviceName}
+          setServiceName={setServiceName}
+          containers={containers}
+        />
+      </Card>
 
       {containerName && (
         <>
-          <div>
-            <div className="subtle-header">Upload file to {name}</div>
+          <SubTitle>Upload file</SubTitle>
+          <Card spacing divider className="file-manager">
             <CopyFileTo containerName={containerName} toPathDefault={to} />
-          </div>
+          </Card>
 
-          <div>
-            <div className="subtle-header">Download file from {name}</div>
+          <SubTitle>Download file</SubTitle>
+          <Card spacing divider className="file-manager">
             <CopyFileFrom
               containerName={containerName}
               fromPathDefault={from}
             />
-          </div>
+          </Card>
         </>
       )}
-    </Card>
+    </>
   );
 };
 

--- a/packages/admin-ui/src/pages/packages/components/Network/index.tsx
+++ b/packages/admin-ui/src/pages/packages/components/Network/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useState } from "react";
 import Card from "components/Card";
+import SubTitle from "components/SubTitle";
 import { PackageContainer } from "types";
 import { ServiceSelector } from "../ServiceSelector";
 import { PortsByService } from "./PortsByService";
@@ -12,36 +13,41 @@ export function Network({ containers }: { containers: PackageContainer[] }) {
   const [serviceName, setServiceName] = useState(serviceNames[0]);
   const container = containers.find(c => c.serviceName === serviceName);
   return (
-    <Card spacing className="network-editor">
-      <ServiceSelector
-        serviceName={serviceName}
-        setServiceName={setServiceName}
-        containers={containers}
-      />
-
-      {container && (
-        <>
+    <>
+      <Card spacing className="network-editor">
+        <ServiceSelector
+          serviceName={serviceName}
+          setServiceName={setServiceName}
+          containers={containers}
+        />
+        {container && (
           <div>
             <strong>Container IP: </strong>
             {container.ip || "Not available"}
           </div>
+        )}
+      </Card>
 
-          <div className="subtle-header">HTTPS DOMAIN MAPPING</div>
-          <HttpsMappings
-            dnpName={container.dnpName}
-            serviceName={container.serviceName}
-          />
+      {container && (
+        <>
+          <SubTitle>Public port mapping</SubTitle>
+          <Card spacing className="network-editor">
+            <PortsByService
+              dnpName={container.dnpName}
+              serviceName={container.serviceName}
+              ports={container.ports}
+            />
+          </Card>
 
-          <hr />
-
-          <div className="subtle-header">PUBLIC PORT MAPPING</div>
-          <PortsByService
-            dnpName={container.dnpName}
-            serviceName={container.serviceName}
-            ports={container.ports}
-          />
+          <SubTitle>HTTPs domain mapping</SubTitle>
+          <Card spacing className="network-editor">
+            <HttpsMappings
+              dnpName={container.dnpName}
+              serviceName={container.serviceName}
+            />
+          </Card>
         </>
       )}
-    </Card>
+    </>
   );
 }


### PR DESCRIPTION
The packages > network view is a bit overloaded and confusing. Splitting it into multiple cards give it some breathing room. For consistency, the files view is also splitted