### PR TITLE
Refactor db dynamicKeyValidate

### DIFF
--- a/packages/dappmanager/src/calls/notificationsGet.ts
+++ b/packages/dappmanager/src/calls/notificationsGet.ts
@@ -19,6 +19,6 @@ export async function notificationsGet(): Promise<PackageNotificationDb[]> {
    * Notifications are stored at `notification.{id}`
    * The key `notification` returns an object { "id1": <notification obj>, ... }
    */
-  const notifications = db.notifications.get();
+  const notifications = db.notification.getAll();
   return Object.values(notifications);
 }

--- a/packages/dappmanager/src/db/cache.ts
+++ b/packages/dappmanager/src/db/cache.ts
@@ -1,7 +1,6 @@
-import { dynamicKeyValidate } from "./dbCache";
+import { indexedByKey } from "./dbCache";
 import { Manifest, ApmVersion, Compose } from "../types";
 import semver from "semver";
-import { joinWithDot } from "./dbUtils";
 
 const CACHE = "cache";
 const CACHE_MANIFEST = `${CACHE}.manifest`;
@@ -11,61 +10,41 @@ const CACHE_IPFS = `${CACHE}.ipfs`;
 
 // cache.manifest
 
-const manifestCacheKeyGetter = (hash: string): string =>
-  joinWithDot(CACHE_MANIFEST, hash);
-const manifestCacheValidate = (hash: string, manifest?: Manifest): boolean => {
-  return (
+export const manifestCache = indexedByKey<Manifest, string>({
+  rootKey: CACHE_MANIFEST,
+  getKey: hash => hash,
+  validate: (hash: string, manifest?: Manifest) =>
     typeof hash === "string" && (!manifest || typeof manifest === "object")
-  );
-};
-
-export const manifestCache = dynamicKeyValidate<Manifest, string>(
-  manifestCacheKeyGetter,
-  manifestCacheValidate
-);
+});
 
 // cache.apm
 
 type ApmKeyArg = { name: string; version: string };
-const apmCacheKeyGetter = ({ name, version }: ApmKeyArg): string =>
-  joinWithDot(CACHE_APM, `${name}-${version}`);
-const apmCacheValidate = (
-  { name, version }: ApmKeyArg,
-  apmVersion?: ApmVersion
-): boolean =>
-  Boolean(
-    name &&
-      semver.valid(version) &&
-      (!apmVersion || apmVersion.version === version)
-  );
-
-export const apmCache = dynamicKeyValidate<ApmVersion, ApmKeyArg>(
-  apmCacheKeyGetter,
-  apmCacheValidate
-);
+export const apmCache = indexedByKey<ApmVersion, ApmKeyArg>({
+  rootKey: CACHE_APM,
+  getKey: ({ name, version }) => `${name}-${version}`,
+  validate: ({ name, version }, apmVersion) =>
+    Boolean(
+      name &&
+        semver.valid(version) &&
+        (!apmVersion || apmVersion.version === version)
+    )
+});
 
 // cache.compose
 
-const composeCacheKeyGetter = (hash: string): string =>
-  joinWithDot(CACHE_COMPOSE, hash);
-const composeCacheValidate = (hash: string, compose?: Compose): boolean => {
-  return typeof hash === "string" && (!compose || typeof compose === "object");
-};
-
-export const composeCache = dynamicKeyValidate<Compose, string>(
-  composeCacheKeyGetter,
-  composeCacheValidate
-);
+export const composeCache = indexedByKey<Compose, string>({
+  rootKey: CACHE_COMPOSE,
+  getKey: hash => hash,
+  validate: (hash, compose) =>
+    typeof hash === "string" && (!compose || typeof compose === "object")
+});
 
 // cache.ipfs
 
-const ipfsCacheKeyGetter = (hash: string): string =>
-  joinWithDot(CACHE_IPFS, hash);
-const ipfsCacheValidate = (hash: string, content?: string): boolean => {
-  return typeof hash === "string" && (!content || typeof content === "string");
-};
-
-export const ipfsCache = dynamicKeyValidate<string, string>(
-  ipfsCacheKeyGetter,
-  ipfsCacheValidate
-);
+export const ipfsCache = indexedByKey<string, string>({
+  rootKey: CACHE_IPFS,
+  getKey: hash => hash,
+  validate: (hash, content) =>
+    typeof hash === "string" && (!content || typeof content === "string")
+});

--- a/packages/dappmanager/src/db/dbCache.ts
+++ b/packages/dappmanager/src/db/dbCache.ts
@@ -4,5 +4,5 @@ import dbFactory from "./dbFactory";
 // Initialize db
 const db = dbFactory(params.DB_CACHE_PATH || "./dappmanagerdb.json");
 export const staticKey = db.staticKey;
-export const dynamicKeyValidate = db.dynamicKeyValidate;
+export const indexedByKey = db.indexedByKey;
 export const lowLevel = db.lowLevel;

--- a/packages/dappmanager/src/db/dbMain.ts
+++ b/packages/dappmanager/src/db/dbMain.ts
@@ -4,5 +4,5 @@ import dbFactory from "./dbFactory";
 // Initialize db
 const db = dbFactory(params.DB_MAIN_PATH || "./maindb.json");
 export const staticKey = db.staticKey;
-export const dynamicKeyValidate = db.dynamicKeyValidate;
+export const indexedByKey = db.indexedByKey;
 export const lowLevel = db.lowLevel;

--- a/packages/dappmanager/src/db/ethClient.ts
+++ b/packages/dappmanager/src/db/ethClient.ts
@@ -8,7 +8,6 @@ import {
   EthClientTargetPackage,
   EthClientSyncedNotificationStatus
 } from "../types";
-import { joinWithDot } from "./dbUtils";
 import { EthClientInstallStatus } from "../modules/ethClient/types";
 import { eventBus } from "../eventBus";
 
@@ -43,17 +42,15 @@ export const ethClientFallback = interceptOnSet(
 // This is necessary if there was a migration and the settings have to
 // be kept after switching between clients
 
-const ethClientUserSettingsKeyGetter = (target: EthClientTarget): string =>
-  joinWithDot(ETH_CLIENT_USER_SETTINGS, target);
-const ethClientUserSettingsValidate = (
-  id: string,
-  userSettings?: UserSettings
-): boolean => typeof id === "string" && typeof userSettings === "object";
-
-export const ethClientUserSettings = dbMain.dynamicKeyValidate<
+export const ethClientUserSettings = dbMain.indexedByKey<
   UserSettings,
   EthClientTarget
->(ethClientUserSettingsKeyGetter, ethClientUserSettingsValidate);
+>({
+  rootKey: ETH_CLIENT_USER_SETTINGS,
+  getKey: target => target,
+  validate: (id, userSettings) =>
+    typeof id === "string" && typeof userSettings === "object"
+});
 
 // Cached status, not critical
 
@@ -61,23 +58,24 @@ export const ethClientUserSettings = dbMain.dynamicKeyValidate<
  * Cache the status of the eth client install loop
  */
 export const ethClientInstallStatus = interceptOnSet(
-  dbCache.dynamicKeyValidate<EthClientInstallStatus, EthClientTarget>(
-    (target: EthClientTarget): string =>
-      joinWithDot(ETH_CLIENT_INSTALL_STATUS, target),
-    (id: string, installStatus?: EthClientInstallStatus): boolean =>
+  dbCache.indexedByKey<EthClientInstallStatus, EthClientTarget>({
+    rootKey: ETH_CLIENT_INSTALL_STATUS,
+    getKey: target => target,
+    validate: (id, installStatus) =>
       typeof id === "string" && typeof installStatus === "object"
-  )
+  })
 );
 
 /**
  * Cache the general status of the eth client, if it's available or not
  */
 export const ethClientStatus = interceptOnSet(
-  dbCache.dynamicKeyValidate<EthClientStatus, EthClientTarget>(
-    (target: EthClientTarget): string => joinWithDot(ETH_CLIENT_STATUS, target),
-    (id: string, status?: EthClientStatus): boolean =>
+  dbCache.indexedByKey<EthClientStatus, EthClientTarget>({
+    rootKey: ETH_CLIENT_STATUS,
+    getKey: target => target,
+    validate: (id, status) =>
       typeof id === "string" && typeof status === "object"
-  )
+  })
 );
 
 export const ethProviderUrl = interceptOnSet(

--- a/packages/dappmanager/src/db/fileTransferPath.ts
+++ b/packages/dappmanager/src/db/fileTransferPath.ts
@@ -1,15 +1,9 @@
 import * as dbCache from "./dbCache";
-import { joinWithDot } from "./dbUtils";
 
 const FILE_TRANSFER_PATH = "file-transfer-path";
 
-const fileTransferPathKeyGetter = (fileId: string): string =>
-  joinWithDot(FILE_TRANSFER_PATH, fileId);
-const fileTransferPathValidate = (filePath: string): boolean => {
-  return typeof filePath === "string";
-};
-
-export const fileTransferPath = dbCache.dynamicKeyValidate<string, string>(
-  fileTransferPathKeyGetter,
-  fileTransferPathValidate
-);
+export const fileTransferPath = dbCache.indexedByKey<string, string>({
+  rootKey: FILE_TRANSFER_PATH,
+  getKey: fileId => fileId,
+  validate: filePath => typeof filePath === "string"
+});

--- a/packages/dappmanager/src/db/notification.ts
+++ b/packages/dappmanager/src/db/notification.ts
@@ -1,36 +1,28 @@
-import { dynamicKeyValidate, staticKey } from "./dbCache";
+import { indexedByKey } from "./dbCache";
 import { PackageNotificationDb } from "../types";
-import { joinWithDot } from "./dbUtils";
 import { PackageNotification } from "../types";
 
 const NOTIFICATION = "notification";
 const NOTIFICATION_LAST_EMITTED_VERSION = "notification-last-emitted-version";
 
-const notificationKeyGetter = (id: string): string =>
-  joinWithDot(NOTIFICATION, id);
-const notificationValidate = (
-  id: string,
-  notification?: PackageNotificationDb
-): boolean => typeof id === "string" && typeof notification === "object";
+export const notification = indexedByKey<PackageNotificationDb, string>({
+  rootKey: NOTIFICATION,
+  getKey: id => id,
+  validate: (id, notification) =>
+    typeof id === "string" && typeof notification === "object"
+});
 
-export const notification = dynamicKeyValidate<PackageNotificationDb, string>(
-  notificationKeyGetter,
-  notificationValidate
-);
 export function notificationPush(id: string, n: PackageNotification): void {
   notification.set(id, { ...n, timestamp: Date.now(), viewed: false });
 }
-
-export const notifications = staticKey<{ [id: string]: PackageNotificationDb }>(
-  NOTIFICATION,
-  {}
-);
 
 /**
  * Register the last emitted version for a dnpName
  * Only emit notifications for versions above this one
  */
-export const notificationLastEmitVersion = dynamicKeyValidate<string, string>(
-  dnpName => joinWithDot(NOTIFICATION_LAST_EMITTED_VERSION, dnpName),
-  (dnpName, lastEmittedVersion) => typeof lastEmittedVersion === "string"
-);
+export const notificationLastEmitVersion = indexedByKey<string, string>({
+  rootKey: NOTIFICATION_LAST_EMITTED_VERSION,
+  getKey: dnpName => dnpName,
+  validate: (dnpName, lastEmittedVersion) =>
+    typeof lastEmittedVersion === "string"
+});

--- a/packages/dappmanager/src/db/package.ts
+++ b/packages/dappmanager/src/db/package.ts
@@ -1,26 +1,19 @@
 import { UpdateAvailable } from "../types";
-import { dynamicKeyValidate } from "./dbCache";
-import { joinWithDot } from "./dbUtils";
+import { indexedByKey } from "./dbCache";
 
 const PACKAGE_GETTING_STARTED_SHOW = "package-getting-started-show";
 const PACKAGE_INSTALL_TIME = "package-install-time";
 const PACKAGE_LATEST_KNOWN_VERSION = "package-latest-known-version";
 
-const keyGetterGettingStartedShow = (dnpName: string): string =>
-  joinWithDot(PACKAGE_GETTING_STARTED_SHOW, dnpName);
-const keyGetterInstallTime = (dnpName: string): string =>
-  joinWithDot(PACKAGE_INSTALL_TIME, dnpName);
-const alwaysValid = (): true => true;
+export const packageGettingStartedShow = indexedByKey<boolean, string>({
+  rootKey: PACKAGE_GETTING_STARTED_SHOW,
+  getKey: dnpName => dnpName
+});
 
-export const packageGettingStartedShow = dynamicKeyValidate<boolean, string>(
-  keyGetterGettingStartedShow,
-  alwaysValid
-);
-
-export const packageInstallTime = dynamicKeyValidate<number, string>(
-  keyGetterInstallTime,
-  alwaysValid
-);
+export const packageInstallTime = indexedByKey<number, string>({
+  rootKey: PACKAGE_INSTALL_TIME,
+  getKey: dnpName => dnpName
+});
 
 export function addPackageInstalledMetadata(dnpName: string): void {
   packageGettingStartedShow.set(dnpName, true);
@@ -31,7 +24,7 @@ export function addPackageInstalledMetadata(dnpName: string): void {
  * Register the last emitted version for a dnpName
  * Only emit notifications for versions above this one
  */
-export const packageLatestKnownVersion = dynamicKeyValidate<
-  UpdateAvailable,
-  string
->(dnpName => joinWithDot(PACKAGE_LATEST_KNOWN_VERSION, dnpName), alwaysValid);
+export const packageLatestKnownVersion = indexedByKey<UpdateAvailable, string>({
+  rootKey: PACKAGE_LATEST_KNOWN_VERSION,
+  getKey: dnpName => dnpName
+});

--- a/packages/dappmanager/src/db/system.ts
+++ b/packages/dappmanager/src/db/system.ts
@@ -56,10 +56,10 @@ export const versionData = dbCache.staticKey<PackageVersionData>(
 
 // Disk usage threshould records
 
-export const diskUsageThreshold = dbCache.dynamicKeyValidate<boolean, string>(
-  id => joinWithDot(DISK_USAGE_THRESHOLD, id),
-  () => true
-);
+export const diskUsageThreshold = dbCache.indexedByKey<boolean, string>({
+  rootKey: DISK_USAGE_THRESHOLD,
+  getKey: id => id
+});
 
 // DAppNode Name appears on the UI
 

--- a/packages/dappmanager/src/db/ui.ts
+++ b/packages/dappmanager/src/db/ui.ts
@@ -1,14 +1,9 @@
-import { dynamicKeyValidate } from "./dbMain";
+import { indexedByKey } from "./dbMain";
 import { NewFeatureId, NewFeatureStatus } from "../types";
-import { joinWithDot } from "./dbUtils";
 
 const NEW_FEATURE_STATUS = "new-feature-status";
 
-export const newFeatureStatus = dynamicKeyValidate<
-  NewFeatureStatus,
-  NewFeatureId
->(
-  (featureId: NewFeatureId): string =>
-    joinWithDot(NEW_FEATURE_STATUS, featureId),
-  () => true
-);
+export const newFeatureStatus = indexedByKey<NewFeatureStatus, NewFeatureId>({
+  rootKey: NEW_FEATURE_STATUS,
+  getKey: featureId => featureId
+});

--- a/packages/dappmanager/test/daemons/ethMultiClient/index.test.ts
+++ b/packages/dappmanager/test/daemons/ethMultiClient/index.test.ts
@@ -46,6 +46,7 @@ describe("daemons > ethMultiClient > runWatcher", () => {
         }
       },
       ethClientInstallStatus: {
+        getAll: () => ({}),
         get: (keyArg: EthClientTarget) => state.status[keyArg],
         set: (keyArg: EthClientTarget, status: EthClientInstallStatus) => {
           state.status[keyArg] = status;
@@ -61,6 +62,7 @@ describe("daemons > ethMultiClient > runWatcher", () => {
         }
       },
       ethClientUserSettings: {
+        getAll: () => ({}),
         get: (keyArg: EthClientTarget): UserSettings => {
           keyArg;
           return {};


### PR DESCRIPTION
- Use named arguments to clarify the meaning of each argument
- Do key concatenation on the factory by default
- Expose extra method `getAll()`
- Rename to better name