### PR TITLE
Add package updates view in dashboard

### DIFF
--- a/packages/admin-ui/src/__mock-backend__/data/dnps/lightningNetwork.ts
+++ b/packages/admin-ui/src/__mock-backend__/data/dnps/lightningNetwork.ts
@@ -156,13 +156,16 @@ Content in the first column | Content in the second column
 
   installedData: {
     version: "0.1.0",
-
     userSettings: {
       environment: {
         [serviceName]: {
           ENV_NAME: "ENV_VALUE"
         }
       }
+    },
+    updateAvailable: {
+      newVersion: "0.1.1",
+      upstreamVersion: "0.7.0-beta"
     }
   },
   installedContainers: {

--- a/packages/admin-ui/src/common/routes.ts
+++ b/packages/admin-ui/src/common/routes.ts
@@ -18,7 +18,6 @@ import {
   VpnDevice,
   PackageNotificationDb,
   UserActionLog,
-  InstalledPackageData,
   InstalledPackageDetailData,
   PackageEnvs,
   HostStatCpu,
@@ -34,7 +33,8 @@ import {
   DockerUpdateStatus,
   WireguardDeviceCredentials,
   ExposableServiceMapping,
-  HostDiagnoseItem
+  HostDiagnoseItem,
+  InstalledPackageDataApiReturn
 } from "./types";
 
 export interface Routes {
@@ -319,7 +319,7 @@ export interface Routes {
   /**
    * Returns the list of current containers associated to packages
    */
-  packagesGet: () => Promise<InstalledPackageData[]>;
+  packagesGet: () => Promise<InstalledPackageDataApiReturn[]>;
 
   /**
    * Toggles the visibility of a getting started block

--- a/packages/admin-ui/src/common/types.ts
+++ b/packages/admin-ui/src/common/types.ts
@@ -508,6 +508,10 @@ export interface PackageContainer {
   // envs?: PackageEnvs;
 }
 
+export interface InstalledPackageDataApiReturn extends InstalledPackageData {
+  updateAvailable: UpdateAvailable | null;
+}
+
 export type InstalledPackageData = Pick<
   PackageContainer,
   | "dnpName"

--- a/packages/admin-ui/src/pages/dashboard/components/ChainCard.tsx
+++ b/packages/admin-ui/src/pages/dashboard/components/ChainCard.tsx
@@ -1,12 +1,25 @@
 import React from "react";
-import Card from "components/Card";
+import { useChainData } from "hooks/chainData";
 import ProgressBar from "react-bootstrap/ProgressBar";
+import Card from "components/Card";
 import RenderMarkdown from "components/RenderMarkdown";
 import { prettyDnpName } from "utils/format";
 import { ChainData } from "types";
 import { HelpTo } from "components/Help";
 
-export default function ChainCard(chain: ChainData) {
+export function ChainCards() {
+  const chainData = useChainData();
+
+  return (
+    <div className="dashboard-cards">
+      {chainData.map(chain => (
+        <ChainCard key={chain.dnpName} {...chain} />
+      ))}
+    </div>
+  );
+}
+
+function ChainCard(chain: ChainData) {
   const { dnpName, name, message, help, progress, error, syncing } = chain;
   return (
     <Card className="chain-card">

--- a/packages/admin-ui/src/pages/dashboard/components/Dashboard.tsx
+++ b/packages/admin-ui/src/pages/dashboard/components/Dashboard.tsx
@@ -15,14 +15,20 @@ export default function Dashboard() {
     <>
       <Title title={title} />
 
-      <SubTitle>Package updates</SubTitle>
-      <PackageUpdates />
+      <div className="dashboard-layout">
+        <div className="dashboard-right">
+          <SubTitle>Package updates</SubTitle>
+          <PackageUpdates />
+        </div>
 
-      <SubTitle>Chains</SubTitle>
-      <ChainCards />
+        <div className="dashboard-left">
+          <SubTitle>Chains</SubTitle>
+          <ChainCards />
 
-      <SubTitle>Machine stats</SubTitle>
-      <HostStats />
+          <SubTitle>Machine stats</SubTitle>
+          <HostStats />
+        </div>
+      </div>
     </>
   );
 }

--- a/packages/admin-ui/src/pages/dashboard/components/Dashboard.tsx
+++ b/packages/admin-ui/src/pages/dashboard/components/Dashboard.tsx
@@ -1,27 +1,25 @@
 import React from "react";
 // Own module
 import { title } from "../data";
-import ChainCard from "./ChainCard";
+import { ChainCards } from "./ChainCard";
 import { HostStats } from "./HostStats";
-import "./dashboard.scss";
+import { PackageUpdates } from "./PackageUpdates";
 // Components
 import SubTitle from "components/SubTitle";
 import Title from "components/Title";
-import { useChainData } from "hooks/chainData";
+
+import "./dashboard.scss";
 
 export default function Dashboard() {
-  const chainData = useChainData();
-
   return (
     <>
       <Title title={title} />
 
+      <SubTitle>Package updates</SubTitle>
+      <PackageUpdates />
+
       <SubTitle>Chains</SubTitle>
-      <div className="dashboard-cards">
-        {chainData.map(chain => (
-          <ChainCard key={chain.dnpName} {...chain} />
-        ))}
-      </div>
+      <ChainCards />
 
       <SubTitle>Machine stats</SubTitle>
       <HostStats />

--- a/packages/admin-ui/src/pages/dashboard/components/PackageUpdates.tsx
+++ b/packages/admin-ui/src/pages/dashboard/components/PackageUpdates.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import Alert from "react-bootstrap/esm/Alert";
+import { useApi } from "api";
+import { rootPath as installerRootPath } from "pages/installer";
+import { UpdateAvailable } from "types";
+import { NavLink } from "react-router-dom";
+import Button from "components/Button";
+import ErrorView from "components/ErrorView";
+import Ok from "components/Ok";
+import CardList from "components/CardList";
+import { prettyDnpName } from "utils/format";
+import { urlJoin } from "utils/url";
+
+export function PackageUpdates() {
+  const dnps = useApi.packagesGet();
+
+  if (dnps.error) return <ErrorView error={dnps.error} hideIcon red />;
+  if (dnps.isValidating) return <Ok loading msg="Loading packages" />;
+  if (!dnps.data) return <ErrorView error={"No data"} hideIcon red />;
+
+  const updatesAvailable: {
+    dnpName: string;
+    updateAvailable: UpdateAvailable;
+  }[] = [];
+  for (const dnp of dnps.data) {
+    if (dnp.updateAvailable) {
+      updatesAvailable.push({
+        dnpName: dnp.dnpName,
+        updateAvailable: dnp.updateAvailable
+      });
+    }
+  }
+
+  return (
+    <div className="dashboard-cards">
+      <div className="package-updates">
+        {updatesAvailable.length === 0 ? (
+          <Alert className="package-updates-card" variant="success">
+            All packages are up to date
+          </Alert>
+        ) : (
+          <CardList className="package-updates">
+            {updatesAvailable.map(({ dnpName, updateAvailable }) => (
+              <div className="package-update-item">
+                <span>
+                  <strong>{prettyDnpName(dnpName)}</strong> to version{" "}
+                  {updateAvailable.newVersion}{" "}
+                  {updateAvailable.upstreamVersion &&
+                    `(${updateAvailable.upstreamVersion} upstream)`}
+                </span>
+                <NavLink to={urlJoin(installerRootPath, dnpName)}>
+                  <Button variant="dappnode">Update</Button>
+                </NavLink>
+              </div>
+            ))}
+          </CardList>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/admin-ui/src/pages/dashboard/components/dashboard.scss
+++ b/packages/admin-ui/src/pages/dashboard/components/dashboard.scss
@@ -1,10 +1,21 @@
-.help-text-relaunch {
-  color: var(--light-text-color);
-  transition: 0.15s ease;
+.dashboard-layout {
+  display: grid;
+  grid-gap: var(--default-spacing);
+  grid-template-columns: 60% auto;
+  grid-template-rows: auto;
+  grid-template-areas: "left right";
 
-  &:hover {
-    color: var(--dappnode-color);
+  @media screen and (max-width: 65rem) {
+    display: block;
   }
+}
+
+.dashboard-right {
+  grid-area: right;
+}
+
+.dashboard-left {
+  grid-area: left;
 }
 
 .dashboard-cards {

--- a/packages/admin-ui/src/pages/dashboard/components/dashboard.scss
+++ b/packages/admin-ui/src/pages/dashboard/components/dashboard.scss
@@ -15,6 +15,11 @@
   &.half {
     grid-template-columns: repeat(auto-fill, minmax(7.5em, 1fr));
   }
+
+  .package-updates {
+    // Give the single card a max width that matches the other cards
+    grid-column: 1 / 4;
+  }
 }
 
 /* Chain cards and  Stats cards */
@@ -56,4 +61,18 @@
 }
 .stats-card .text {
   margin-bottom: 0;
+}
+
+// Package updates card
+
+.package-update-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  // Make buttons smaller so the list is not that big
+  button {
+    padding: 3px 12px;
+    font-size: 94%;
+  }
 }

--- a/packages/dappmanager/src/db/dbFactory.ts
+++ b/packages/dappmanager/src/db/dbFactory.ts
@@ -64,7 +64,7 @@ export default function dbFactory(dbPath: string) {
       joinWithDot(rootKey, getKey(keyArg));
 
     return {
-      getAll: (): { [key: string]: T } => get(rootKey),
+      getAll: (): { [key: string]: T } => get(rootKey) || {},
       get: (keyArg: K): T | undefined => {
         const value = get(keyGetter(keyArg));
         if (!validate || validate(keyArg, value)) return value;


### PR DESCRIPTION
- Extend `packagesGet()` call to return last known version added in https://github.com/dappnode/DNP_DAPPMANAGER/pull/686
- Show a list of packages to update with an update button
- Button re-directs to install package

**Future todo**:
- Install all button
- Should also add an install queue system so not everything is updated at once

![Screenshot from 2021-04-02 00-18-09](https://user-images.githubusercontent.com/35266934/113359917-0a526600-9349-11eb-9ab8-52b9d9ac0bbc.png)

In big sreens

![Screenshot from 2021-04-02 00-33-05](https://user-images.githubusercontent.com/35266934/113360906-06bfde80-934b-11eb-9f21-ed9cb1751636.png)
