### PR TITLE
Fix auto updates return in loop bug

### DIFF
--- a/packages/dappmanager/src/daemons/autoUpdates/updateMyPackages.ts
+++ b/packages/dappmanager/src/daemons/autoUpdates/updateMyPackages.ts
@@ -25,21 +25,27 @@ export async function checkNewPackagesVersion(
   const dnps = await listPackages();
 
   for (const { dnpName, isDnp, version: currentVersion } of dnps) {
-    // Ignore core DNPs, and non-valid versions (semver.lte will throw)
-    if (!dnpName || !isDnp || !semver.valid(currentVersion)) continue;
-
     try {
+      // Ignore core DNPs, and non-valid versions (semver.lte will throw)
+      if (!dnpName || !isDnp || !semver.valid(currentVersion)) {
+        continue;
+      }
+
       // MUST exist an APM repo with the package dnpName
       // Check here instead of the if statement to be inside the try / catch
       const repoExists = await releaseFetcher.repoExists(dnpName);
-      if (!repoExists) return;
+      if (!repoExists) {
+        continue;
+      }
 
       const { version: newVersion } = await releaseFetcher.fetchVersion(
         dnpName
       );
 
       // This version is not an update
-      if (semver.lte(newVersion, currentVersion)) return;
+      if (semver.lte(newVersion, currentVersion)) {
+        continue;
+      }
 
       const updateData = { dnpName, currentVersion, newVersion };
 


### PR DESCRIPTION
Fixes a regression introduced in DAPPMANAGER version `v0.2.38` which prevents auto-updating non-system packages if some package previous to it is already updated.

https://github.com/dappnode/DNP_DAPPMANAGER/blob/845a220da45754d2455a18692178e23d6c55258f/packages/dappmanager/src/daemons/autoUpdates/updateMyPackages.ts#L42

Introduced in commit: https://github.com/dappnode/DNP_DAPPMANAGER/pull/563/commits/845a220da45754d2455a18692178e23d6c55258f#diff-ad2a1d84e4dc97132ac60340f7678d281cf6fa16cb18f6f2f61ce5ab503a073fR42

Depending on the ordering of the containers returned by the docker API this bug may prevent all non-core packages from being updated or only some.

---

I've reviewed all return statements in the repo and there's no other instance of a similar bug