### PR TITLE
Adding proper alias for dappmanager

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,5 +29,6 @@ services:
         ipv4_address: 172.33.1.7
         aliases:
           - dappmanager.dappnode
+          - my.dappnode
     logging:
       driver: journald


### PR DESCRIPTION
Adding `my.dappnode` alias is necessary for DNS resolution