### PR TITLE
Add unique alias for dappmanager Admin UI

### DIFF
--- a/packages/dappmanager/src/domains.ts
+++ b/packages/dappmanager/src/domains.ts
@@ -1,4 +1,4 @@
-import { getContainerDomain } from "./params";
+import params, { getContainerDomain } from "./params";
 
 export function stripCharacters(s: string): string {
   return s.replace(RegExp("_", "g"), "");
@@ -31,6 +31,7 @@ export function getPrivateNetworkAliases(
   container: ContainerNames & { isMain: boolean }
 ): string[] {
   const aliases: string[] = [getPrivateNetworkAlias(container)];
+
   if (container.isMain) {
     const rootAlias = getPrivateNetworkAlias({
       dnpName: container.dnpName,
@@ -38,6 +39,11 @@ export function getPrivateNetworkAliases(
     });
     aliases.push(rootAlias);
   }
+
+  // Special unique alias for the Admin UI
+  if (container.dnpName === params.dappmanagerDnpName)
+    aliases.push(params.DAPPMANAGER_ALIAS);
+
   return aliases;
 }
 

--- a/packages/dappmanager/src/modules/compose/unsafeCompose.ts
+++ b/packages/dappmanager/src/modules/compose/unsafeCompose.ts
@@ -1,4 +1,12 @@
-import { mapValues, pick, omit, toPairs, sortBy, fromPairs } from "lodash";
+import {
+  mapValues,
+  pick,
+  omit,
+  toPairs,
+  sortBy,
+  fromPairs,
+  uniq
+} from "lodash";
 import params, { getImageTag, getContainerName } from "../../params";
 import { getIsCore } from "../manifest/getIsCore";
 import { cleanCompose } from "./clean";
@@ -132,13 +140,18 @@ function parseUnsafeServiceNetworks(
   const networksObj = parseServiceNetworks(serviceNetworks || {});
 
   // Only allow customizing config for core packages
-  const dnpPrivateNetwork = isCore ? networksObj[dnpPrivateNetworkName] : {};
+  const dnpPrivateNetwork = isCore
+    ? networksObj[dnpPrivateNetworkName] || {}
+    : {};
 
   return {
     ...networksObj,
     [dnpPrivateNetworkName]: {
       ...dnpPrivateNetwork,
-      aliases: getPrivateNetworkAliases(service)
+      aliases: uniq([
+        ...(dnpPrivateNetwork.aliases || []),
+        ...getPrivateNetworkAliases(service)
+      ])
     }
   };
 }

--- a/packages/dappmanager/src/params.ts
+++ b/packages/dappmanager/src/params.ts
@@ -145,6 +145,9 @@ const params = {
   ETH_MAINNET_RPC_URL_REMOTE:
     process.env.ETH_MAINNET_RPC_URL_REMOTE || "https://web3.dappnode.net",
 
+  // DAPPMANAGER alias
+  DAPPMANAGER_ALIAS: "my.dappnode",
+
   // DAppNode specific names
   bindDnpName: "bind.dnp.dappnode.eth",
   coreDnpName: "core.dnp.dappnode.eth",

--- a/packages/dappmanager/test/modules/releaseSpecs/dappmanager/docker-compose.parsed.yml
+++ b/packages/dappmanager/test/modules/releaseSpecs/dappmanager/docker-compose.parsed.yml
@@ -10,6 +10,7 @@ services:
       network:
         ipv4_address: 172.33.1.7
         aliases:
+          - "my.dappnode"
           - "dappmanager.dappnode"
     restart: always
     volumes:

--- a/packages/dappmanager/test/modules/releaseSpecs/dappmanager/docker-compose.yml
+++ b/packages/dappmanager/test/modules/releaseSpecs/dappmanager/docker-compose.yml
@@ -25,5 +25,7 @@ services:
     networks:
       network:
         ipv4_address: 172.33.1.7
+        aliases:
+          - my.dappnode
     logging:
       driver: journald


### PR DESCRIPTION
- Add `my.dappnode` alias to dappmanager
- Keep custom aliases for core packages