### PR TITLE
Fix owncloud predefined exposasable service

### DIFF
--- a/packages/dappmanager/src/modules/https-portal/exposable/predefined.ts
+++ b/packages/dappmanager/src/modules/https-portal/exposable/predefined.ts
@@ -161,7 +161,7 @@ export const exposablePredefined: {
       description: "JSON RPC endpoint for Zcash"
     }
   ],
-  "owncloud.public.dappnode.eth": [
+  "owncloud.dnp.dappnode.eth": [
     {
       fromSubdomain: "owncloud",
       dnpName: "owncloud.dnp.dappnode.eth",


### PR DESCRIPTION
Fix the little error that affects including owncloud package as a predefined exposable service for HTTPS.
Fix #739 