### PR TITLE
Sort VPN subpages by isInstalled

### DIFF
--- a/packages/admin-ui/src/pages/vpn/index.ts
+++ b/packages/admin-ui/src/pages/vpn/index.ts
@@ -1,3 +1,3 @@
-import VpnHome from "./components/VpnHome";
+import { VpnHome } from "./components/VpnHome";
 export { rootPath } from "./data";
 export const RootComponent = VpnHome;


### PR DESCRIPTION
Sort OpenVPN and Wireguard by placing the first the installed package. If both are installed or none, keep the same order. This will make users land first on the VPN option they have already installed.