### PR TITLE
Add IPFS gateway proxy

### DIFF
--- a/packages/dappmanager/src/ethForward/index.ts
+++ b/packages/dappmanager/src/ethForward/index.ts
@@ -1,137 +1,73 @@
-import http from "http";
-import httpProxy from "http-proxy";
 import express from "express";
 import params from "../params";
-import { EthProviderError } from "../modules/ethClient";
-import { ipfs } from "../modules/ipfs";
-import { urlJoin } from "../utils/url";
+import { getIpfsProxyHandler, ProxyType } from "./ipfsProxy";
 import { ResolveDomainWithCache } from "./resolveDomain";
-import * as views from "./views";
-import {
-  NodeNotAvailable,
-  ProxyError,
-  EnsResolverError,
-  NotFoundError,
-  Content
-} from "./types";
-import { logs } from "../logs";
 
 export function getEthForwardMiddleware(): express.RequestHandler {
-  const ethForwardHandler = getEthForwardHandler();
-  return (req, res, next): void => {
-    if (isDwebRequest(req)) ethForwardHandler(req, res);
-    else next();
-  };
-}
-
-/**
- * Convert a decentralized content into a fetchable URL
- * @param content
- */
-function getTargetUrl(content: Content): string {
-  switch (content.location) {
-    case "ipfs":
-      return urlJoin(params.ETHFORWARD_IPFS_REDIRECT, content.hash);
-    case "swarm":
-      return urlJoin(params.ETHFORWARD_SWARM_REDIRECT, content.hash);
-  }
-}
-
-/**
- * Check if a request is for a decentralized website, based on their host
- * - decentral.eth => true
- * - my.dappmanager.dnp.dappnode.eth => false
- * - my.dappnode => false
- */
-function isDwebRequest(req: http.IncomingMessage): boolean {
-  const domain = req.headers.host;
-  return (
-    typeof domain === "string" &&
-    domain.endsWith(".eth") &&
-    !domain.endsWith("dnp.dappnode.eth")
-  );
-}
-
-/**
- * Start eth forward http proxy
- */
-function getEthForwardHandler(): (
-  req: http.IncomingMessage,
-  res: http.ServerResponse
-) => Promise<void> {
-  logs.info(`IPFS redirect set to: ${params.ETHFORWARD_IPFS_REDIRECT}`);
-  logs.info(`SWARM redirect set to: ${params.ETHFORWARD_SWARM_REDIRECT}`);
-
-  const proxy = httpProxy.createProxyServer({});
-  proxy.on("error", e => {
-    logs.error(`ETHFORWARD proxy error`, e);
-  });
-
   // Create a domain resolver with cache
   const resolveDomain = ResolveDomainWithCache();
+  // Start ethforward http proxy: Resolves .eth domains
+  const ethForwardHandler = getIpfsProxyHandler<string>(
+    ProxyType.ETHFORWARD,
+    async (_req, domain) => await resolveDomain(domain)
+  );
 
-  return async function ethForwardProxyHttpHandler(
-    req: http.IncomingMessage,
-    res: http.ServerResponse
-  ): Promise<void> {
-    const domain = req.headers.host;
+  // Start IPFS gateway proxy: Serve IPFS content from the DAPPMANAGER
+  const ipfsGatewayProxydHandler = getIpfsProxyHandler<string>(
+    ProxyType.IPFS_GATEWAY,
+    async (_req, hash) => ({ location: "ipfs", hash })
+  );
+
+  return (req, res, next): void => {
     try {
-      if (!domain) throw new TypeError(`req host is not defined`);
-
-      const content = await resolveDomain(domain);
-      const target = getTargetUrl(content);
-      logs.debug(`Proxying ${domain} to ${target}`, content);
-
-      // Must change the host from something not *.eth, to prevent the IPFS node
-      // from trying to resolve the domain with DNSLink and causing an error
-      req.headers.host = "dappmanager.dappnode";
-
-      // Note: Must use the promise constructor otherwise proxy.web breaks
-      // due to no proper binding of its underlying 'this'
-      //   Cannot read property 'length' of undefined
-      //   src/node_modules/http-proxy/lib/http-proxy/index.js:72:31
-      await new Promise<http.IncomingMessage>((resolve, reject) => {
-        proxy.web(req, res, { target }, (e: Error | undefined, proxyRes) => {
-          if (!e) return resolve(proxyRes);
-          // Indicates that the host is unreachable.
-          // Usually happens when the node is not running
-          if (e.message.includes("EHOSTUNREACH"))
-            reject(new NodeNotAvailable(e.message, content.location));
-          else reject(new ProxyError(e.message, target));
-        });
-      });
-
-      if (content.location === "ipfs" && params.ETHFORWARD_PIN_ON_VISIT)
-        ipfs.pinAddNoThrow(content.hash);
-    } catch (e) {
-      /**
-       * Returns the response error HTML. Use function format to make sure
-       * a single HTML is returned to the res stream
-       */
-      function errorToResponseHtml(e: Error, domain?: string): string {
-        logs.debug(`ETHFORWARD Error: ${e.message}`);
-
-        // Not found views
-        if (e instanceof EnsResolverError || e instanceof NotFoundError)
-          return views.notFound(e);
-
-        // Node not available views
-        if (e instanceof EthProviderError) return views.noEth(e);
-        if (e instanceof NodeNotAvailable)
-          if (e.location === "swarm") return views.noSwarm(e);
-          else if (e.location === "ipfs") return views.noIpfs(e);
-
-        // Proxy errors
-        if (e instanceof ProxyError) return views.unknownError(e);
-
-        // Unknown errors, log to error
-        logs.error(`ETHFORWARD Unknown error resolving ${domain}`, e);
-        return views.unknownError(e);
+      console.trace("HANDLING REQUEST!");
+      const domain = parseEthDomainHost(req);
+      if (domain !== null) {
+        ethForwardHandler(req, res, domain);
+        return;
       }
 
-      res.writeHead(200, { "Content-Type": "text/html" });
-      res.write(errorToResponseHtml(e, domain));
-      res.end();
+      const hash = parseIpfsGatewayProxyReqHash(req.url);
+      if (hash !== null) {
+        ipfsGatewayProxydHandler(req, res, hash);
+        return;
+      }
+
+      next();
+    } catch (e) {
+      next(e);
     }
   };
+}
+
+function parseEthDomainHost(req: express.Request): string | null {
+  // Check if a request is for a decentralized website, based on their host
+  // - decentral.eth => true
+  // - my.dappmanager.dnp.dappnode.eth => false
+  // - my.dappnode => false
+  const domain = req.headers.host;
+  return typeof domain === "string" &&
+    domain.endsWith(".eth") &&
+    !domain.endsWith("dnp.dappnode.eth")
+    ? domain
+    : null;
+}
+
+/**
+ * @param reqUrl Must be the parsed path, i.e. `/ipfs-gateway-proxy/Qm`
+ */
+export function parseIpfsGatewayProxyReqHash(reqUrl: string): string | null {
+  // Check if this request is for the IFPS gateway proxy,
+  // - my.dappnode/ipfs-gateway-proxy/Qm -> true
+  // - my.dappnode -> false
+  // - decentral.eth -> false
+  if (typeof reqUrl !== "string") return null;
+
+  let pathname = reqUrl;
+  if (!pathname.startsWith("/")) pathname = "/" + pathname;
+  if (pathname.startsWith(params.IPFS_GATEWAY)) {
+    return pathname.slice(params.IPFS_GATEWAY.length);
+  } else {
+    return null;
+  }
 }

--- a/packages/dappmanager/src/ethForward/ipfsProxy.ts
+++ b/packages/dappmanager/src/ethForward/ipfsProxy.ts
@@ -1,0 +1,132 @@
+import http from "http";
+import httpProxy from "http-proxy";
+import express from "express";
+import params from "../params";
+import { EthProviderError } from "../modules/ethClient";
+import { ipfs } from "../modules/ipfs";
+import { urlJoin } from "../utils/url";
+import { logs } from "../logs";
+import * as views from "./views";
+import {
+  NodeNotAvailable,
+  ProxyError,
+  EnsResolverError,
+  NotFoundError,
+  Content
+} from "./types";
+
+export enum ProxyType {
+  ETHFORWARD = "ETHFORWARD",
+  IPFS_GATEWAY = "IPFS_GATEWAY"
+}
+
+/**
+ * Generalized proxy constructor for both ETHFORWARD and IPFS gateway proxy
+ */
+export function getIpfsProxyHandler<T>(
+  proxyType: ProxyType,
+  getContent: (req: express.Request, data: T) => Promise<Content>
+): (req: express.Request, res: express.Response, data: T) => Promise<void> {
+  const proxy = httpProxy.createProxyServer({});
+  proxy.on("error", e => {
+    logs.error(`${proxyType} proxy error`, e);
+  });
+
+  logs.info(
+    `Starting ${proxyType} proxy: IPFS -> ${params.ETHFORWARD_IPFS_REDIRECT} SWARM -> ${params.ETHFORWARD_SWARM_REDIRECT}`
+  );
+
+  return async function ethForwardProxyHttpHandler(
+    req,
+    res,
+    data
+  ): Promise<void> {
+    try {
+      const content = await getContent(req, data);
+      const target = getTargetUrl(proxyType, content);
+      logs.debug(`${proxyType} proxying ${req.url} to ${target}`, content);
+
+      // Must change the host from something not *.eth, to prevent the IPFS node
+      // from trying to resolve the domain with DNSLink and causing an error
+      req.headers.host = "dappmanager.dappnode";
+
+      // Note: Must use the promise constructor otherwise proxy.web breaks
+      // due to no proper binding of its underlying 'this'
+      //   Cannot read property 'length' of undefined
+      //   src/node_modules/http-proxy/lib/http-proxy/index.js:72:31
+      await new Promise<http.IncomingMessage>((resolve, reject) => {
+        proxy.web(req, res, { target }, (e: Error | undefined, proxyRes) => {
+          if (!e) return resolve(proxyRes);
+          // Indicates that the host is unreachable.
+          // Usually happens when the node is not running
+          if (e.message.includes("EHOSTUNREACH"))
+            reject(new NodeNotAvailable(e.message, content.location));
+          else reject(new ProxyError(e.message, target));
+        });
+      });
+
+      if (content.location === "ipfs" && params.ETHFORWARD_PIN_ON_VISIT)
+        ipfs.pinAddNoThrow(content.hash);
+    } catch (e) {
+      res.writeHead(200, { "Content-Type": "text/html" });
+      res.write(errorToResponseHtml(e, req.url));
+      res.end();
+    }
+  };
+}
+
+/**
+ * Given the proxy type and content return a target URL for proxying
+ *
+ * - ETHFORWARD: A decentralized site `decentral.eth/image.png` has to be converted
+ *   to `ipfs.dappnode:8080/Qm1234/image.png`. We want to append the path to the new
+ *   URL which includes the hash of the content
+ *
+ * - IPFS_GATEWAY: A request to `my.dappnode/ipfs/Qm1234/image.png` to be converted
+ *   to `ipfs.dappnode:8080/Qm1234/image.png`. We only need to proxy to a new hostname
+ *   the hash and path information is already present in the request
+ */
+function getTargetUrl(proxyType: ProxyType, content: Content): string {
+  switch (proxyType) {
+    case ProxyType.ETHFORWARD:
+      switch (content.location) {
+        case "ipfs":
+          return urlJoin(params.ETHFORWARD_IPFS_REDIRECT, "ipfs", content.hash);
+        case "swarm":
+          return urlJoin(params.ETHFORWARD_SWARM_REDIRECT, content.hash);
+      }
+
+    case ProxyType.IPFS_GATEWAY:
+      switch (content.location) {
+        case "ipfs":
+          return params.ETHFORWARD_IPFS_REDIRECT;
+        case "swarm":
+          return params.ETHFORWARD_SWARM_REDIRECT;
+      }
+  }
+}
+
+/**
+ * Returns the response error HTML. Use function format to make sure
+ * a single HTML is returned to the res stream
+ */
+function errorToResponseHtml(e: Error, domain?: string): string {
+  logs.debug(`ETHFORWARD Error: ${e.message}`);
+
+  // Not found views
+  if (e instanceof EnsResolverError || e instanceof NotFoundError)
+    return views.notFound(e);
+
+  // Node not available views
+  if (e instanceof EthProviderError) return views.noEth(e);
+  if (e instanceof NodeNotAvailable)
+    if (e.location === "swarm") return views.noSwarm(e);
+    else if (e.location === "ipfs") return views.noIpfs(e);
+
+  // Proxy errors
+  if (e instanceof ProxyError) return views.unknownError(e);
+
+  // Unknown errors, log to error
+  logs.error(`ETHFORWARD Unknown error resolving ${domain}`, e);
+  return views.unknownError(e);
+}

--- a/packages/dappmanager/src/modules/docker/list/parseContainerInfo.ts
+++ b/packages/dappmanager/src/modules/docker/list/parseContainerInfo.ts
@@ -13,7 +13,7 @@ import {
   parseVolumeMappings,
   readContainerLabels
 } from "../../compose";
-import { multiaddressToGatewayUrl } from "../../../utils/distributedFile";
+import { multiaddressToIpfsGatewayUrl } from "../../../utils/distributedFile";
 import { isPortMappingDeletable } from "./isPortMappingDeletable";
 import { parseExitCodeFromStatus } from "./parseExitCodeFromStatus";
 
@@ -100,7 +100,7 @@ export function parseContainerInfo(container: ContainerInfo): PackageContainer {
 
     // Additional package metadata to avoid having to read the manifest
     dependencies: labels.dependencies || {},
-    avatarUrl: labels.avatar ? multiaddressToGatewayUrl(labels.avatar) : "",
+    avatarUrl: labels.avatar ? multiaddressToIpfsGatewayUrl(labels.avatar) : "",
     origin: labels.origin,
     chain: labels.chain,
     canBeFullnode: allowedFullnodeDnpNames.includes(dnpName),

--- a/packages/dappmanager/src/params.ts
+++ b/packages/dappmanager/src/params.ts
@@ -80,7 +80,8 @@ const params = {
   SIGNATURE_PREFIX: "\x1dDappnode Signed Message:",
 
   // HTTP API parameters
-  IPFS_GATEWAY: "http://ipfs.dappnode:8080/ipfs/",
+  /** Use the internal ipfs gateway proxy so the UI works served from the HTTPs Portal */
+  IPFS_GATEWAY: "/ipfs/",
   HTTP_API_PORT: process.env.HTTP_API_PORT || 80,
   HTTP_CORS_WHITELIST: [
     "http://localhost:3000",
@@ -234,7 +235,7 @@ const params = {
   ],
 
   // ETHFORWARD / HTTP proxy params
-  ETHFORWARD_IPFS_REDIRECT: "http://ipfs.dappnode:8080/ipfs/",
+  ETHFORWARD_IPFS_REDIRECT: "http://ipfs.dappnode:8080",
   ETHFORWARD_SWARM_REDIRECT: "http://swarm.dappnode",
   ETHFORWARD_PIN_ON_VISIT: true,
 

--- a/packages/dappmanager/src/utils/distributedFile.ts
+++ b/packages/dappmanager/src/utils/distributedFile.ts
@@ -10,8 +10,12 @@ export function fileToGatewayUrl(distributedFile?: DistributedFile): string {
   // Fallback
   if (!distributedFile || !distributedFile.hash) return "";
 
-  const hash = normalizeHash(distributedFile.hash);
-  return `${params.IPFS_GATEWAY}${hash}`;
+  switch (distributedFile.source) {
+    case "ipfs":
+      return `${params.IPFS_GATEWAY}${normalizeHash(distributedFile.hash)}`;
+    default:
+      throw Error(`Source not supported: ${distributedFile.source}`);
+  }
 }
 
 /**
@@ -32,7 +36,7 @@ export function fileToMultiaddress(distributedFile?: DistributedFile): string {
  * @param multiaddress "/ipfs/Qm"
  * @returns link to fetch file "http://ipfs-gateway/Qm7763518d4"
  */
-export function multiaddressToGatewayUrl(multiaddress: string): string {
+export function multiaddressToIpfsGatewayUrl(multiaddress: string): string {
   const hash = normalizeHash(multiaddress);
   return fileToGatewayUrl({ source: "ipfs", hash, size: 0 });
 }
@@ -46,7 +50,7 @@ export function multiaddressToGatewayUrl(multiaddress: string): string {
  * @param hash "/ipfs/Qm" | "ipfs:Qm" | "Qm"
  * @returns "Qm"
  */
-export function normalizeHash(hash: string): string {
+function normalizeHash(hash: string): string {
   return (
     hash
       // remove any number of trailing slashes

--- a/packages/dappmanager/test/ethForward/ipfsGatewayProxy.test.ts
+++ b/packages/dappmanager/test/ethForward/ipfsGatewayProxy.test.ts
@@ -1,0 +1,37 @@
+import { expect } from "chai";
+import { parseIpfsGatewayProxyReqHash } from "../../src/ethForward";
+
+describe("IPFS gateway proxy", () => {
+  describe("Parse IPFS path", () => {
+    const testCases: { id: string; url: string; hash: string | null }[] = [
+      { id: "Empty string", url: "", hash: null },
+      { id: "Bad type", url: ({} as unknown) as string, hash: null },
+      {
+        id: "With subpath",
+        url: "/ipfs/QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG/readme",
+        hash: "QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG/readme"
+      },
+      {
+        id: "With subpath that matches the ipfs route",
+        url: "/ipfs/QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG/ipfs/readme",
+        hash: "QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG/ipfs/readme"
+      },
+      {
+        id: "Just a normal hash",
+        url: "/ipfs/QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG",
+        hash: "QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG"
+      },
+      {
+        id: "Using IP a host",
+        url: "/ipfs/QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG",
+        hash: "QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG"
+      }
+    ];
+
+    for (const { id, url, hash } of testCases) {
+      it(id, () => {
+        expect(parseIpfsGatewayProxyReqHash(url)).to.equal(hash);
+      });
+    }
+  });
+});

--- a/packages/dappmanager/test/integration/fetchRelease.test.int.ts
+++ b/packages/dappmanager/test/integration/fetchRelease.test.int.ts
@@ -181,8 +181,7 @@ describe("Fetch releases", () => {
         reqVersion: mainDnpReleaseHash,
         semVersion: mainVersion,
         origin: mainDnpReleaseHash,
-        avatarUrl:
-          "http://ipfs.dappnode:8080/ipfs/QmNrfF93ppvjDGeabQH8H8eeCDLci2F8fptkvj94WN78pt",
+        avatarUrl: "/ipfs/QmNrfF93ppvjDGeabQH8H8eeCDLci2F8fptkvj94WN78pt",
         metadata: {
           name: dnpNameMain,
           version: mainVersion,
@@ -345,8 +344,7 @@ describe("Fetch releases", () => {
         reqVersion: mainDnpReleaseHash,
         semVersion: mainVersion,
         origin: mainDnpReleaseHash,
-        avatarUrl:
-          "http://ipfs.dappnode:8080/ipfs/QmQZ9sohpdB7NDDXcPfuPtpJ5TrMGxLWATpQUiaifUhrd2",
+        avatarUrl: "/ipfs/QmQZ9sohpdB7NDDXcPfuPtpJ5TrMGxLWATpQUiaifUhrd2",
         metadata: {
           name: dnpNameMain,
           version: mainVersion,

--- a/packages/dappmanager/test/modules/docker/parseContainerInfo.test.ts
+++ b/packages/dappmanager/test/modules/docker/parseContainerInfo.test.ts
@@ -389,8 +389,7 @@ describe("modules / docker / parseContainerInfo", function() {
         running: true,
         exitCode: null,
         dependencies: {},
-        avatarUrl:
-          "http://ipfs.dappnode:8080/ipfs/QmQnHxr4YAVdtqzHnsDYvmXizxptSYyaj3YwTjoiLshVwF",
+        avatarUrl: "/ipfs/QmQnHxr4YAVdtqzHnsDYvmXizxptSYyaj3YwTjoiLshVwF",
         origin: "/ipfs/QmeBfnwgsNcEmbmxENBWtgkv5YZsAhiaDsoYd7nMTV1wKV",
         chain: "ethereum",
         canBeFullnode: false,
@@ -785,8 +784,7 @@ describe("modules / docker / parseContainerInfo", function() {
         canBeFullnode: false
       },
       {
-        avatarUrl:
-          "http://ipfs.dappnode:8080/ipfs/QmaZZVsVqaWwVLe36HhvKj3QEPt7hM1GL8kemNvsZd5F5x",
+        avatarUrl: "/ipfs/QmaZZVsVqaWwVLe36HhvKj3QEPt7hM1GL8kemNvsZd5F5x",
         canBeFullnode: false,
         containerId:
           "ba4765113dd6016da8b35dfe367493186f3bfd34d88eca03ccf894f7045710fa",


### PR DESCRIPTION
Fixes https://github.com/dappnode/DNP_DAPPMANAGER/issues/760

Attaches a new HTTP proxy to the Ethfoward where requests with a pathname that starts with `ipfs-gateway-proxy` will be proxied to ipfs.dappnode:8080/ipfs

Re-uses the same code from the Ethforward, it's error handling and error views

---

I have not tested it yet on a real DAppNode