### PR TITLE
Improve avahi spawner

### DIFF
--- a/packages/dappmanager/src/daemons/index.ts
+++ b/packages/dappmanager/src/daemons/index.ts
@@ -11,7 +11,7 @@ import { startVpnBridgeDaemon } from "./vpnBridge";
 
 export function startDaemons(signal: AbortSignal): void {
   startAutoUpdatesDaemon(signal);
-  startAvahiDaemon();
+  startAvahiDaemon(signal);
   startDiskUsageDaemon(signal);
   startDynDnsDaemon(signal);
   startEthMultiClientDaemon(signal);

--- a/packages/dappmanager/src/utils/shell.ts
+++ b/packages/dappmanager/src/utils/shell.ts
@@ -19,11 +19,9 @@ const defaultTimeout = 15 * 60 * 1000; // ms
  */
 export default async function shell(
   cmd: string | string[],
-  options: { timeout?: number; noTimeout?: boolean; maxBuffer?: number } = {}
+  options: { timeout?: number; maxBuffer?: number } = {}
 ): Promise<string> {
-  const timeout = options.noTimeout
-    ? undefined
-    : options.timeout || defaultTimeout;
+  const timeout = options.timeout || defaultTimeout;
   const maxBuffer = options && options.maxBuffer;
   const cmdStr = Array.isArray(cmd) ? cmd.join(" ") : cmd;
   try {


### PR DESCRIPTION
- Use child_process.spawn, has not stream buffer limits nor timeouts