### PR TITLE
HTTPs portal refresh button 

### DIFF
--- a/packages/admin-ui/src/__mock-backend__/httpsPortal.ts
+++ b/packages/admin-ui/src/__mock-backend__/httpsPortal.ts
@@ -19,6 +19,7 @@ export const httpsPortal: Pick<
   | "httpsPortalMappingRemove"
   | "httpsPortalMappingsGet"
   | "httpsPortalExposableServicesGet"
+  | "httpsPortalMappingsRecreate"
 > = {
   httpsPortalMappingAdd: async mapping => {
     mappings.set(mapping.fromSubdomain, mapping);
@@ -40,7 +41,8 @@ export const httpsPortal: Pick<
         return { ...mapping, exposed: false };
       }
     });
-  }
+  },
+  httpsPortalMappingsRecreate: async () => {}
 };
 
 /** Helper to uniquely identify mapping target services */

--- a/packages/admin-ui/src/common/routes.ts
+++ b/packages/admin-ui/src/common/routes.ts
@@ -248,6 +248,8 @@ export interface Routes {
   httpsPortalMappingsGet(): Promise<HttpsPortalMapping[]>;
   /** HTTPs Portal: get exposable services with metadata */
   httpsPortalExposableServicesGet(): Promise<ExposableServiceMapping[]>;
+  /** HTTPs Portal: recreate mappings */
+  httpsPortalMappingsRecreate(): Promise<void>;
 
   /**
    * Attempts to cat a common IPFS hash. resolves if all OK, throws otherwise
@@ -596,6 +598,7 @@ export const routesData: { [P in keyof Routes]: RouteData } = {
   httpsPortalMappingAdd: { log: true },
   httpsPortalMappingRemove: { log: true },
   httpsPortalMappingsGet: {},
+  httpsPortalMappingsRecreate: {},
   httpsPortalExposableServicesGet: {},
   ipfsTest: {},
   mountpointsGet: {},

--- a/packages/admin-ui/src/pages/system/components/Network/HttpsMappings.tsx
+++ b/packages/admin-ui/src/pages/system/components/Network/HttpsMappings.tsx
@@ -189,8 +189,15 @@ export function HttpsMappings() {
             </React.Fragment>
           ))}
         </div>
-        <hr />
-        <Button onClick={() => refreshMapping}>Refresh</Button>
+
+        {mappings.data.length !== 0 && (
+          <>
+            <hr />
+            <Button onClick={() => refreshMapping(mappings.data || [])}>
+              Refresh
+            </Button>
+          </>
+        )}
       </>
     );
   }

--- a/packages/admin-ui/src/pages/system/components/Network/HttpsMappings.tsx
+++ b/packages/admin-ui/src/pages/system/components/Network/HttpsMappings.tsx
@@ -39,8 +39,8 @@ export function HttpsMappings() {
 
       setReqStatus({ loading: true });
       await withToast(() => api.httpsPortalMappingsRecreate(), {
-        message: "Recreating HTTPs mapping...",
-        onSuccess: "Recreated HTTPs mapping"
+        message: "Recreating HTTPs mappings...",
+        onSuccess: "Recreated HTTPs mappings"
       });
 
       setReqStatus({ result: true });

--- a/packages/admin-ui/src/pages/system/components/Network/HttpsMappings.tsx
+++ b/packages/admin-ui/src/pages/system/components/Network/HttpsMappings.tsx
@@ -16,7 +16,6 @@ import newTabProps from "utils/newTabProps";
 import { ReqStatus, HttpsPortalMapping, ExposableServiceInfo } from "types";
 import { httpsPortalDnpName } from "params";
 import "./https-mapping.scss";
-import { ExposableServiceMapping } from "common";
 import Button from "components/Button";
 
 export function HttpsMappings() {
@@ -25,43 +24,25 @@ export function HttpsMappings() {
   const dnpsRequest = useApi.packagesGet();
   const dappnodeIdentity = useSelector(getDappnodeIdentityClean);
 
-  /** Refresh HTTPs Portal mapping */
-  async function refreshMapping(httpsMapping: ExposableServiceMapping[]) {
+  /** Recreate HTTPs Portal mapping */
+  async function recreateMapping() {
     if (reqStatus.loading) return;
 
     try {
       await confirmPromise({
-        title: "Refresh",
-        text: "Refresh HTTPs portal mapping",
-        label: "Refresh",
+        title: "Recreate HTTPs mappings",
+        text:
+          "You are about to recreate the HTTPs mappings. You should execute this action only in response to an error",
+        label: "Recreate",
         variant: "dappnode"
       });
 
       setReqStatus({ loading: true });
-      await withToast(
-        () =>
-          Promise.all(
-            httpsMapping.map(httpsMapping =>
-              api.httpsPortalMappingRemove(httpsMapping)
-            )
-          ),
-        {
-          message: "Removing HTTPs mapping...",
-          onSuccess: "Removed HTTPs mapping"
-        }
-      );
-      await withToast(
-        () =>
-          Promise.all(
-            httpsMapping.map(httpsMapping =>
-              api.httpsPortalMappingAdd(httpsMapping)
-            )
-          ),
-        {
-          message: "Adding HTTPs mapping...",
-          onSuccess: "Added HTTPs mapping"
-        }
-      );
+      await withToast(() => api.httpsPortalMappingsRecreate(), {
+        message: "Recreating HTTPs mapping...",
+        onSuccess: "Recreated HTTPs mapping"
+      });
+
       setReqStatus({ result: true });
     } catch (e) {
       setReqStatus({ error: e.message });
@@ -193,9 +174,8 @@ export function HttpsMappings() {
         {mappings.data.length !== 0 && (
           <>
             <hr />
-            <Button onClick={() => refreshMapping(mappings.data || [])}>
-              Refresh
-            </Button>
+            <p>Use the "Recreate" mappings button if you experience issues.</p>
+            <Button onClick={() => recreateMapping()}>Recreate</Button>
           </>
         )}
       </>

--- a/packages/dappmanager/src/calls/httpsPortal.ts
+++ b/packages/dappmanager/src/calls/httpsPortal.ts
@@ -31,6 +31,18 @@ export async function httpsPortalMappingRemove(
 }
 
 /**
+ * HTTPs Portal: recreate HTTPs portal mapping
+ */
+export async function httpsPortalMappingsRecreate(): Promise<void> {
+  const mappings = await httpsPortal.getMappings();
+
+  for (const mapping of mappings) {
+    await httpsPortal.removeMapping(mapping);
+    await httpsPortal.addMapping(mapping);
+  }
+}
+
+/**
  * HTTPs Portal: get all mappings
  */
 export async function httpsPortalMappingsGet(): Promise<HttpsPortalMapping[]> {


### PR DESCRIPTION
Containers on restart may loose it mapping in the https portal. A button to refresh the mapping should fix the issue