### PR TITLE
Fix the visual bug of prysm and pyrmont package

### DIFF
--- a/packages/dappmanager/src/modules/chains/drivers/ethereum2Prysm.ts
+++ b/packages/dappmanager/src/modules/chains/drivers/ethereum2Prysm.ts
@@ -31,9 +31,7 @@ export async function ethereum2Prysm(
     return null; // OK to not be running, just ignore
   }
 
-  const container = dnp.containers[0];
-  if (!container) throw Error("no container");
-  const containerDomain = getPrivateNetworkAlias(container);
+  const containerDomain = getPrivateNetworkAlias(beaconChainContainer);
 
   // http://beacon-chain.prysm-pyrmont.dappnode:3500/
   const apiUrl = `http://${containerDomain}:3500`;


### PR DESCRIPTION
When the code of chains was done, DAppNode packages did not have multi services. The "chain method" obtains the container IP where it does the pull of the data using the index 0, instead of searching this service by its name. This PR solves this problem for PRYSM, but it would be interesting to create an issue and solving how this task is done for the other chains.

To test this fix:
1. Install pyrmont/prysm 
2. Change the graffiti
3. Look if there is an error on the card chain of the dashboard view.