### PR TITLE
Parse dnpName considering multi-service

### DIFF
--- a/packages/dappmanager/src/modules/docker/list/parseContainerInfo.ts
+++ b/packages/dappmanager/src/modules/docker/list/parseContainerInfo.ts
@@ -26,9 +26,7 @@ export function parseContainerInfo(container: ContainerInfo): PackageContainer {
 
   const containerName = (container.Names[0] || "").replace("/", "");
   const dnpName =
-    labels.dnpName ||
-    containerName.split(CONTAINER_NAME_PREFIX)[1] ||
-    containerName.split(CONTAINER_CORE_NAME_PREFIX)[1];
+    labels.dnpName || parseDnpNameFromContainerName(containerName);
 
   const defaultEnvironment =
     labels.defaultEnvironment && parseEnvironment(labels.defaultEnvironment);
@@ -111,4 +109,25 @@ export function parseContainerInfo(container: ContainerInfo): PackageContainer {
     defaultVolumes,
     dockerTimeout
   };
+}
+
+/**
+ * Parse dnpName from containerName considering multi-service packages
+ * @param containerName DAppNodeCore-api.wireguard.dnp.dappnode.eth
+ * @returns wireguard.dnp.dappnode.eth
+ */
+export function parseDnpNameFromContainerName(containerName: string): string {
+  const containerDomain =
+    containerName.split(CONTAINER_NAME_PREFIX)[1] ||
+    containerName.split(CONTAINER_CORE_NAME_PREFIX)[1] ||
+    containerName;
+
+  if (containerDomain.endsWith(".dappnode.eth")) {
+    // Structure: service . nameShort . repo . dappnode . eth
+    // Example: api.wireguard.dnp.dappnode.eth
+    const parts = containerDomain.trim().split(".");
+    return parts.slice(-4).join("."); // Grab the 4 last parts, which ignores the service name
+  } else {
+    return containerDomain;
+  }
 }

--- a/packages/dappmanager/test/modules/docker/parseContainerInfo.test.ts
+++ b/packages/dappmanager/test/modules/docker/parseContainerInfo.test.ts
@@ -1,8 +1,24 @@
 import "mocha";
 import { expect } from "chai";
 import { PackageContainer, PortProtocol } from "../../../src/types";
-import { parseContainerInfo } from "../../../src/modules/docker/list/parseContainerInfo";
+import {
+  parseContainerInfo,
+  parseDnpNameFromContainerName
+} from "../../../src/modules/docker/list/parseContainerInfo";
 import { dockerApiResponseContainers } from "./dockerApiSamples/containers";
+
+describe("modules / docker / parseDnpNameFromContainerName", () => {
+  const testCases = {
+    "DAppNodeCore-api.wireguard.dnp.dappnode.eth": "wireguard.dnp.dappnode.eth",
+    "DAppNodePackage-geth.dnp.dappnode.eth": "geth.dnp.dappnode.eth"
+  };
+
+  for (const [containerName, dnpName] of Object.entries(testCases)) {
+    it(containerName, () => {
+      expect(parseDnpNameFromContainerName(containerName)).to.equal(dnpName);
+    });
+  }
+});
 
 describe("modules / docker / parseContainerInfo", function() {
   it("should parse docker containers", async () => {


### PR DESCRIPTION
An old function inside the docker list response parsing assumed containers' name has a specific format only valid for single service packages. This PR makes the function a bit smarter.

Packages not installed through the DAPPMANAGER but coming from the ISO directly do not have labels. Relying on them is not a good idea so we should move away from them eventually.



