### PR TITLE
Do not show wifi log when wifi is running OR stopped

### DIFF
--- a/packages/admin-ui/src/pages/wifi/components/wifi/WifiStatus.tsx
+++ b/packages/admin-ui/src/pages/wifi/components/wifi/WifiStatus.tsx
@@ -130,7 +130,9 @@ export default function WifiStatus(): JSX.Element {
             </div>
           </div>
 
-          {wifiDnp.data.containers[0].state !== "running" && wifiReport.data ? (
+          {wifiDnp.data.containers[0].state !== "running" &&
+          wifiDnp.data.containers[0].state !== "paused" &&
+          wifiReport.data ? (
             <WifiLog wifiReport={wifiReport.data} />
           ) : null}
         </Card>


### PR DESCRIPTION
Stopped is a user action, totally expected. The log should be something to show when something unexpected happened, this means a wifi status different than running and stopped