### PR TITLE
Remove VPN as mandatory dependency

### DIFF
--- a/packages/dappmanager/src/params.ts
+++ b/packages/dappmanager/src/params.ts
@@ -173,22 +173,19 @@ const params = {
   ],
   corePackagesThatMustBeRunning: [
     "bind.dnp.dappnode.eth",
-    "dappmanager.dnp.dappnode.eth",
-    "vpn.dnp.dappnode.eth"
+    "dappmanager.dnp.dappnode.eth"
   ],
   corePackagesNotAutoupdatable: [
     "core.dnp.dappnode.eth",
     "bind.dnp.dappnode.eth",
     "dappmanager.dnp.dappnode.eth",
     "ipfs.dnp.dappnode.eth",
-    "vpn.dnp.dappnode.eth",
     "wifi.dnp.dappnode.eth"
   ],
   corePackagesNotRemovable: [
     "bind.dnp.dappnode.eth",
     "dappmanager.dnp.dappnode.eth",
     "ipfs.dnp.dappnode.eth",
-    "vpn.dnp.dappnode.eth",
     "wifi.dnp.dappnode.eth"
   ],
 


### PR DESCRIPTION
In new DAPPMANAGER version it will invite users to install vpn.dnp.dappnode.eth if it's not installed.

Requires https://github.com/dappnode/DNP_CORE/pull/71
Closes https://github.com/dappnode/DNP_DAPPMANAGER/issues/809
Closes https://github.com/dappnode/DNP_DAPPMANAGER/issues/802