### PR TITLE
Button to open ports using UPnP

### DIFF
--- a/packages/admin-ui/src/__mock-backend__/index.ts
+++ b/packages/admin-ui/src/__mock-backend__/index.ts
@@ -222,7 +222,8 @@ export const otherCalls: Omit<Routes, keyof typeof namedSpacedCalls> = {
   }),
   runHostSecurityUpdates: async () =>
     "Security updates have been executed successfully, no reboot needed",
-  upnpPortsOpen: async () => {}
+  natRenewalEnable: async () => {},
+  natRenewalStatusGet: async () => true
 };
 
 export const calls: Routes = {

--- a/packages/admin-ui/src/__mock-backend__/index.ts
+++ b/packages/admin-ui/src/__mock-backend__/index.ts
@@ -223,7 +223,7 @@ export const otherCalls: Omit<Routes, keyof typeof namedSpacedCalls> = {
   runHostSecurityUpdates: async () =>
     "Security updates have been executed successfully, no reboot needed",
   natRenewalEnable: async () => {},
-  natRenewalStatusGet: async () => true
+  natRenewalIsEnabled: async () => true
 };
 
 export const calls: Routes = {

--- a/packages/admin-ui/src/__mock-backend__/index.ts
+++ b/packages/admin-ui/src/__mock-backend__/index.ts
@@ -221,7 +221,8 @@ export const otherCalls: Omit<Routes, keyof typeof namedSpacedCalls> = {
     ]
   }),
   runHostSecurityUpdates: async () =>
-    "Security updates have been executed successfully, no reboot needed"
+    "Security updates have been executed successfully, no reboot needed",
+  upnpPortsOpen: async () => {}
 };
 
 export const calls: Routes = {

--- a/packages/admin-ui/src/common/routes.ts
+++ b/packages/admin-ui/src/common/routes.ts
@@ -543,7 +543,10 @@ export interface Routes {
   /**
    * Attemps to open ports using UPnP
    */
-  upnpPortsOpen: (kwargs: { enableNatRenewal: boolean }) => Promise<void>;
+  natRenewalEnable: (kwargs: { enableNatRenewal: boolean }) => Promise<void>;
+
+  /** Returns nat renewal status */
+  natRenewalStatusGet: () => Promise<boolean>;
 
   /**
    * Removes a docker volume by name
@@ -665,7 +668,8 @@ export const routesData: { [P in keyof Routes]: RouteData } = {
   sshStatusSet: { log: true },
   systemInfoGet: {},
   runHostSecurityUpdates: {},
-  upnpPortsOpen: {},
+  natRenewalEnable: {},
+  natRenewalStatusGet: {},
   volumeRemove: { log: true },
   volumesGet: {},
   ipPublicGet: {},

--- a/packages/admin-ui/src/common/routes.ts
+++ b/packages/admin-ui/src/common/routes.ts
@@ -541,6 +541,11 @@ export interface Routes {
   runHostSecurityUpdates: () => Promise<string>;
 
   /**
+   * Attemps to open ports using UPnP
+   */
+  upnpPortsOpen: () => Promise<void>;
+
+  /**
    * Removes a docker volume by name
    * @param name Full volume name: "bitcoindnpdappnodeeth_bitcoin_data"
    */
@@ -660,6 +665,7 @@ export const routesData: { [P in keyof Routes]: RouteData } = {
   sshStatusSet: { log: true },
   systemInfoGet: {},
   runHostSecurityUpdates: {},
+  upnpPortsOpen: {},
   volumeRemove: { log: true },
   volumesGet: {},
   ipPublicGet: {},

--- a/packages/admin-ui/src/common/routes.ts
+++ b/packages/admin-ui/src/common/routes.ts
@@ -543,7 +543,7 @@ export interface Routes {
   /**
    * Attemps to open ports using UPnP
    */
-  upnpPortsOpen: () => Promise<void>;
+  upnpPortsOpen: (kwargs: { enableNatRenewal: boolean }) => Promise<void>;
 
   /**
    * Removes a docker volume by name

--- a/packages/admin-ui/src/common/routes.ts
+++ b/packages/admin-ui/src/common/routes.ts
@@ -546,7 +546,7 @@ export interface Routes {
   natRenewalEnable: (kwargs: { enableNatRenewal: boolean }) => Promise<void>;
 
   /** Returns nat renewal status */
-  natRenewalStatusGet: () => Promise<boolean>;
+  natRenewalIsEnabled: () => Promise<boolean>;
 
   /**
    * Removes a docker volume by name
@@ -669,7 +669,7 @@ export const routesData: { [P in keyof Routes]: RouteData } = {
   systemInfoGet: {},
   runHostSecurityUpdates: {},
   natRenewalEnable: {},
-  natRenewalStatusGet: {},
+  natRenewalIsEnabled: {},
   volumeRemove: { log: true },
   volumesGet: {},
   ipPublicGet: {},

--- a/packages/admin-ui/src/pages/support/components/Ports.tsx
+++ b/packages/admin-ui/src/pages/support/components/Ports.tsx
@@ -38,7 +38,7 @@ export default function Ports() {
   const systemInfo = useApi.systemInfoGet();
 
   return (
-    <Card>
+    <Card spacing>
       {systemInfo.data ? (
         <>
           {systemInfo.data.publicIp !== systemInfo.data.internalIp ? (

--- a/packages/admin-ui/src/pages/support/components/Ports.tsx
+++ b/packages/admin-ui/src/pages/support/components/Ports.tsx
@@ -7,33 +7,6 @@ import Card from "components/Card";
 import { useApi } from "api";
 import { PortsStatusTable } from "./PortsStatusTable";
 
-function UpnpStatus({
-  isUpnpEnabled,
-  localIp
-}: {
-  isUpnpEnabled: boolean;
-  localIp: string;
-}) {
-  return (
-    <>
-      {isUpnpEnabled ? (
-        <Ok ok={true} msg={"DAppNode has detected UPnP as enabled"} />
-      ) : (
-        <>
-          <Ok ok={false} msg={"DAppNode has detected UPnP as disabled"} />
-          <p>
-            Enable UPnP or manually open and associate the necessary ports in
-            the router to the DAppNode local Ip:
-            <strong>{localIp}</strong>
-          </p>
-          <br />
-          <strong>UDP ports must be manually checked in the router</strong>
-        </>
-      )}
-    </>
-  );
-}
-
 export default function Ports() {
   const systemInfo = useApi.systemInfoGet();
 
@@ -43,10 +16,25 @@ export default function Ports() {
         <>
           {systemInfo.data.publicIp !== systemInfo.data.internalIp ? (
             <>
-              <UpnpStatus
-                isUpnpEnabled={systemInfo.data.upnpAvailable}
-                localIp={systemInfo.data.internalIp}
-              />
+              {systemInfo.data.upnpAvailable ? (
+                <Ok ok={true} msg={"DAppNode has detected UPnP as enabled"} />
+              ) : (
+                <>
+                  <Ok
+                    ok={false}
+                    msg={"DAppNode has detected UPnP as disabled"}
+                  />
+                  <p>
+                    Enable UPnP or manually open and associate the necessary
+                    ports in the router to the DAppNode local Ip:
+                    <strong>{systemInfo.data.internalIp}</strong>
+                  </p>
+                  <br />
+                  <strong>
+                    UDP ports must be manually checked in the router
+                  </strong>
+                </>
+              )}
             </>
           ) : (
             <Ok

--- a/packages/admin-ui/src/pages/support/components/Ports.tsx
+++ b/packages/admin-ui/src/pages/support/components/Ports.tsx
@@ -1,15 +1,11 @@
-import React, { useState } from "react";
+import React from "react";
 
 import Loading from "../../../components/Loading";
 import ErrorView from "../../../components/ErrorView";
 import Ok from "components/Ok";
 import Card from "components/Card";
-import Button from "components/Button";
-import { withToast } from "components/toast/Toast";
-
-import { useApi, api } from "api";
+import { useApi } from "api";
 import { PortsStatusTable } from "./PortsStatusTable";
-import { ReqStatus } from "types";
 
 function UpnpStatus({
   isUpnpEnabled,
@@ -39,22 +35,7 @@ function UpnpStatus({
 }
 
 export default function Ports() {
-  const [reqStatus, setReqStatus] = useState<ReqStatus>({});
   const systemInfo = useApi.systemInfoGet();
-
-  async function openPorts() {
-    try {
-      setReqStatus({ loading: true });
-      await withToast(() => api.upnpPortsOpen(), {
-        message: "Attemping to open ports with UPnP..",
-        onSuccess: "Successfully opened ports"
-      });
-      setReqStatus({ result: true });
-    } catch (e) {
-      setReqStatus({ error: e });
-      console.error("Error on upnpPortsOpen", e);
-    }
-  }
 
   return (
     <Card>
@@ -66,10 +47,6 @@ export default function Ports() {
                 isUpnpEnabled={systemInfo.data.upnpAvailable}
                 localIp={systemInfo.data.internalIp}
               />
-              <br />
-              <Button disabled={reqStatus.loading} onClick={openPorts}>
-                Refresh UPnP
-              </Button>
             </>
           ) : (
             <Ok

--- a/packages/admin-ui/src/pages/support/components/Ports.tsx
+++ b/packages/admin-ui/src/pages/support/components/Ports.tsx
@@ -1,36 +1,76 @@
+import React, { useState } from "react";
+
 import Loading from "../../../components/Loading";
 import ErrorView from "../../../components/ErrorView";
 import Ok from "components/Ok";
 import Card from "components/Card";
-import React from "react";
+import Button from "components/Button";
+import { withToast } from "components/toast/Toast";
 
-import { useApi } from "api";
+import { useApi, api } from "api";
 import { PortsStatusTable } from "./PortsStatusTable";
+import { ReqStatus } from "types";
+
+function UpnpStatus({
+  isUpnpEnabled,
+  localIp
+}: {
+  isUpnpEnabled: boolean;
+  localIp: string;
+}) {
+  return (
+    <>
+      {isUpnpEnabled ? (
+        <Ok ok={true} msg={"DAppNode has detected UPnP as enabled"} />
+      ) : (
+        <>
+          <Ok ok={false} msg={"DAppNode has detected UPnP as disabled"} />
+          <p>
+            Enable UPnP or manually open and associate the necessary ports in
+            the router to the DAppNode local Ip:
+            <strong>{localIp}</strong>
+          </p>
+          <br />
+          <strong>UDP ports must be manually checked in the router</strong>
+        </>
+      )}
+    </>
+  );
+}
 
 export default function Ports() {
+  const [reqStatus, setReqStatus] = useState<ReqStatus>({});
   const systemInfo = useApi.systemInfoGet();
+
+  async function openPorts() {
+    try {
+      setReqStatus({ loading: true });
+      await withToast(() => api.upnpPortsOpen(), {
+        message: "Attemping to open ports with UPnP..",
+        onSuccess: "Successfully opened ports"
+      });
+      setReqStatus({ result: true });
+    } catch (e) {
+      setReqStatus({ error: e });
+      console.error("Error on upnpPortsOpen", e);
+    }
+  }
 
   return (
     <Card>
       {systemInfo.data ? (
         <>
           {systemInfo.data.publicIp !== systemInfo.data.internalIp ? (
-            systemInfo.data.upnpAvailable ? (
-              <Ok ok={true} msg={"DAppNode has detected UPnP as enabled"} />
-            ) : (
-              <>
-                <Ok ok={false} msg={"DAppNode has detected UPnP as disabled"} />
-                <p>
-                  Enable UPnP or manually open and associate the necessary ports
-                  in the router to the DAppNode local Ip:
-                  <strong>{systemInfo.data.internalIp}</strong>
-                </p>
-                <br />
-                <strong>
-                  UDP ports must be manually checked in the router
-                </strong>
-              </>
-            )
+            <>
+              <UpnpStatus
+                isUpnpEnabled={systemInfo.data.upnpAvailable}
+                localIp={systemInfo.data.internalIp}
+              />
+              <br />
+              <Button disabled={reqStatus.loading} onClick={openPorts}>
+                Refresh UPnP
+              </Button>
+            </>
           ) : (
             <Ok
               ok={true}

--- a/packages/admin-ui/src/pages/support/components/PortsStatusTable.tsx
+++ b/packages/admin-ui/src/pages/support/components/PortsStatusTable.tsx
@@ -118,10 +118,14 @@ export function PortsStatusTable({
   async function upnpOpen() {
     try {
       setUpnpOpenReqStatus({ loading: true });
-      await withToast(() => api.natRenewalEnable({ enableNatRenewal: true }), {
-        message: "Attemping to open ports with UPnP..",
-        onSuccess: "Successfully opened ports"
-      });
+      await withToast(
+        () =>
+          api.natRenewalEnable({ enableNatRenewal: !natRenewalStatus.data }),
+        {
+          message: "Refreshing UPnP port mapping..",
+          onSuccess: "Successfully mapped ports using UPnP"
+        }
+      );
       setUpnpOpenReqStatus({ result: true });
       if (upnpReqStatus.result) await upnpStatusGet();
       if (apiReqStatus.result) await apiStatusGet();

--- a/packages/admin-ui/src/pages/support/components/PortsStatusTable.tsx
+++ b/packages/admin-ui/src/pages/support/components/PortsStatusTable.tsx
@@ -115,12 +115,11 @@ export function PortsStatusTable({
       }
   }
 
-  async function upnpOpen() {
+  async function onUpnpSwitchToggle(checked: boolean) {
     try {
       setUpnpOpenReqStatus({ loading: true });
       await withToast(
-        () =>
-          api.natRenewalEnable({ enableNatRenewal: !natRenewalStatus.data }),
+        () => api.natRenewalEnable({ enableNatRenewal: checked }),
         {
           message: "Refreshing UPnP port mapping..",
           onSuccess: "Successfully mapped ports using UPnP"
@@ -171,11 +170,15 @@ export function PortsStatusTable({
               {(apiReqStatus.result || apiReqStatus.loading) && (
                 <th>Status (API) *</th>
               )}
-              {apiReqStatus.error && <ErrorView error={apiReqStatus.error} />}
+              {apiReqStatus.error && (
+                <ErrorView hideIcon red error={apiReqStatus.error} />
+              )}
               {(upnpReqStatus.result || upnpReqStatus.loading) && (
                 <th>Status (UPnP) **</th>
               )}
-              {upnpReqStatus.error && <ErrorView error={upnpReqStatus.error} />}
+              {upnpReqStatus.error && (
+                <ErrorView hideIcon red error={upnpReqStatus.error} />
+              )}
             </tr>
           </thead>
           <tbody>
@@ -241,7 +244,7 @@ export function PortsStatusTable({
               id="upnp-switch"
               checked={natRenewalStatus.data === true}
               disabled={upnpOpenReqStatus.loading}
-              onToggle={upnpOpen}
+              onToggle={onUpnpSwitchToggle}
             />
           </div>
         )}

--- a/packages/admin-ui/src/pages/support/components/PortsStatusTable.tsx
+++ b/packages/admin-ui/src/pages/support/components/PortsStatusTable.tsx
@@ -87,7 +87,7 @@ export function PortsStatusTable({
 
   const portsToOpen = useApi.portsToOpenGet();
 
-  const natRenewalStatus = useApi.natRenewalStatusGet();
+  const natRenewalStatus = useApi.natRenewalIsEnabled();
 
   async function apiStatusGet() {
     if (portsToOpen.data)

--- a/packages/admin-ui/src/pages/support/components/PortsStatusTable.tsx
+++ b/packages/admin-ui/src/pages/support/components/PortsStatusTable.tsx
@@ -15,6 +15,7 @@ import {
   PortToOpen,
   UpnpTablePortStatus
 } from "common/types";
+import Switch from "components/Switch";
 
 function RenderApiStatus({
   apiScanResult,
@@ -86,6 +87,8 @@ export function PortsStatusTable({
 
   const portsToOpen = useApi.portsToOpenGet();
 
+  const natRenewalStatus = useApi.natRenewalStatusGet();
+
   async function apiStatusGet() {
     if (portsToOpen.data)
       try {
@@ -115,7 +118,7 @@ export function PortsStatusTable({
   async function upnpOpen() {
     try {
       setUpnpOpenReqStatus({ loading: true });
-      await withToast(() => api.upnpPortsOpen({ enableNatRenewal: true }), {
+      await withToast(() => api.natRenewalEnable({ enableNatRenewal: true }), {
         message: "Attemping to open ports with UPnP..",
         onSuccess: "Successfully opened ports"
       });
@@ -124,7 +127,7 @@ export function PortsStatusTable({
       if (apiReqStatus.result) await apiStatusGet();
     } catch (e) {
       setUpnpOpenReqStatus({ error: e });
-      console.error("Error on upnpPortsOpen", e);
+      console.error("Error on natRenewalEnable", e);
     }
   }
 
@@ -143,26 +146,15 @@ export function PortsStatusTable({
             API Scan
           </Button>
           {isUpnpEnabled ? (
-            <>
-              <Button
-                variant={"dappnode"}
-                className="float-right"
-                onClick={upnpStatusGet}
-                style={{ margin: "auto 5px auto" }}
-                disabled={upnpReqStatus.loading === true}
-              >
-                UPnP Scan
-              </Button>
-              <Button
-                variant={"dappnode"}
-                className="float-right"
-                style={{ margin: "auto 5px auto" }}
-                disabled={upnpOpenReqStatus.loading}
-                onClick={upnpOpen}
-              >
-                Refresh UPnP
-              </Button>
-            </>
+            <Button
+              variant={"dappnode"}
+              className="float-right"
+              onClick={upnpStatusGet}
+              style={{ margin: "auto 5px auto" }}
+              disabled={upnpReqStatus.loading === true}
+            >
+              UPnP Scan
+            </Button>
           ) : null}
         </SubTitle>
 
@@ -237,6 +229,18 @@ export function PortsStatusTable({
             Only available if UPnP is enabled.
           </p>
         ) : null}
+
+        {isUpnpEnabled && (
+          <div>
+            <Switch
+              label="UPnP port mapping is enabled"
+              id="upnp-switch"
+              checked={natRenewalStatus.data === true}
+              disabled={upnpOpenReqStatus.loading}
+              onToggle={upnpOpen}
+            />
+          </div>
+        )}
       </>
     );
   if (portsToOpen.error) return <ErrorView error={portsToOpen.error} />;

--- a/packages/admin-ui/src/pages/support/components/PortsStatusTable.tsx
+++ b/packages/admin-ui/src/pages/support/components/PortsStatusTable.tsx
@@ -120,8 +120,8 @@ export function PortsStatusTable({
         onSuccess: "Successfully opened ports"
       });
       setUpnpOpenReqStatus({ result: true });
-      await upnpStatusGet();
-      await apiStatusGet();
+      if (upnpReqStatus.result) await upnpStatusGet();
+      if (apiReqStatus.result) await apiStatusGet();
     } catch (e) {
       setUpnpOpenReqStatus({ error: e });
       console.error("Error on upnpPortsOpen", e);

--- a/packages/admin-ui/src/pages/support/components/PortsStatusTable.tsx
+++ b/packages/admin-ui/src/pages/support/components/PortsStatusTable.tsx
@@ -115,7 +115,7 @@ export function PortsStatusTable({
   async function upnpOpen() {
     try {
       setUpnpOpenReqStatus({ loading: true });
-      await withToast(() => api.upnpPortsOpen(), {
+      await withToast(() => api.upnpPortsOpen({ enableNatRenewal: true }), {
         message: "Attemping to open ports with UPnP..",
         onSuccess: "Successfully opened ports"
       });

--- a/packages/dappmanager/src/calls/index.ts
+++ b/packages/dappmanager/src/calls/index.ts
@@ -52,7 +52,7 @@ export { statsDiskGet } from "./statsDiskGet";
 export { systemInfoGet } from "./systemInfoGet";
 export { runHostSecurityUpdates } from "./runHostSecurityUpdates";
 export * from "./telegram";
-export { natRenewalStatusGet, natRenewalEnable } from "./natRenewal";
+export { natRenewalIsEnabled, natRenewalEnable } from "./natRenewal";
 export { volumeRemove } from "./volumeRemove";
 export { volumesGet } from "./volumesGet";
 export * from "./wireguard";

--- a/packages/dappmanager/src/calls/index.ts
+++ b/packages/dappmanager/src/calls/index.ts
@@ -52,6 +52,7 @@ export { statsDiskGet } from "./statsDiskGet";
 export { systemInfoGet } from "./systemInfoGet";
 export { runHostSecurityUpdates } from "./runHostSecurityUpdates";
 export * from "./telegram";
+export { upnpPortsOpen } from "./upnpPortsOpen";
 export { volumeRemove } from "./volumeRemove";
 export { volumesGet } from "./volumesGet";
 export * from "./wireguard";

--- a/packages/dappmanager/src/calls/index.ts
+++ b/packages/dappmanager/src/calls/index.ts
@@ -52,7 +52,7 @@ export { statsDiskGet } from "./statsDiskGet";
 export { systemInfoGet } from "./systemInfoGet";
 export { runHostSecurityUpdates } from "./runHostSecurityUpdates";
 export * from "./telegram";
-export { upnpPortsOpen } from "./upnpPortsOpen";
+export { natRenewalStatusGet, natRenewalEnable } from "./natRenewal";
 export { volumeRemove } from "./volumeRemove";
 export { volumesGet } from "./volumesGet";
 export * from "./wireguard";

--- a/packages/dappmanager/src/calls/natRenewal.ts
+++ b/packages/dappmanager/src/calls/natRenewal.ts
@@ -6,12 +6,12 @@ export async function natRenewalEnable({
 }: {
   enableNatRenewal: boolean;
 }): Promise<void> {
-  db.isNatRenewalEnabled.set(enableNatRenewal);
+  db.isNatRenewalDisabled.set(!enableNatRenewal);
   if (enableNatRenewal) {
     throttledNatRenewal();
   }
 }
 
 export async function natRenewalStatusGet(): Promise<boolean> {
-  return db.isNatRenewalEnabled.get();
+  return !db.isNatRenewalDisabled.get();
 }

--- a/packages/dappmanager/src/calls/natRenewal.ts
+++ b/packages/dappmanager/src/calls/natRenewal.ts
@@ -12,6 +12,6 @@ export async function natRenewalEnable({
   }
 }
 
-export async function natRenewalStatusGet(): Promise<boolean> {
+export async function natRenewalIsEnabled(): Promise<boolean> {
   return !db.isNatRenewalDisabled.get();
 }

--- a/packages/dappmanager/src/calls/natRenewal.ts
+++ b/packages/dappmanager/src/calls/natRenewal.ts
@@ -1,16 +1,17 @@
 import { throttledNatRenewal } from "../daemons/natRenewal";
 import * as db from "../db";
 
-export async function upnpPortsOpen({
+export async function natRenewalEnable({
   enableNatRenewal
 }: {
   enableNatRenewal: boolean;
 }): Promise<void> {
+  db.isNatRenewalEnabled.set(enableNatRenewal);
   if (enableNatRenewal) {
-    db.isNatRenewalEnabled.set(true);
-    throttledNatRenewal();
-  } else {
-    db.isNatRenewalEnabled.set(false);
     throttledNatRenewal();
   }
+}
+
+export async function natRenewalStatusGet(): Promise<boolean> {
+  return db.isNatRenewalEnabled.get();
 }

--- a/packages/dappmanager/src/calls/upnpPortsOpen.ts
+++ b/packages/dappmanager/src/calls/upnpPortsOpen.ts
@@ -1,0 +1,19 @@
+import getPortsToOpen from "../daemons/natRenewal/getPortsToOpen";
+import * as upnpc from "../modules/upnpc";
+import { listContainers } from "../modules/docker/list";
+import getLocalIp from "../utils/getLocalIp";
+
+export async function upnpPortsOpen(): Promise<void> {
+  try {
+    const localIp = await getLocalIp();
+    if (!localIp) throw Error("localIp not detected");
+    const containers = await listContainers();
+    const portsToOpen = getPortsToOpen(containers);
+    for (const portToOpen of portsToOpen) {
+      await upnpc.open(portToOpen, localIp);
+    }
+  } catch (e) {
+    e.message = `Error on upnpPortsOpen: ${e}`;
+    throw e;
+  }
+}

--- a/packages/dappmanager/src/calls/upnpPortsOpen.ts
+++ b/packages/dappmanager/src/calls/upnpPortsOpen.ts
@@ -1,19 +1,5 @@
-import getPortsToOpen from "../daemons/natRenewal/getPortsToOpen";
-import * as upnpc from "../modules/upnpc";
-import { listContainers } from "../modules/docker/list";
-import getLocalIp from "../utils/getLocalIp";
+import { throttledNatRenewal } from "../daemons/natRenewal";
 
 export async function upnpPortsOpen(): Promise<void> {
-  try {
-    const localIp = await getLocalIp();
-    if (!localIp) throw Error("localIp not detected");
-    const containers = await listContainers();
-    const portsToOpen = getPortsToOpen(containers);
-    for (const portToOpen of portsToOpen) {
-      await upnpc.open(portToOpen, localIp);
-    }
-  } catch (e) {
-    e.message = `Error on upnpPortsOpen: ${e}`;
-    throw e;
-  }
+  throttledNatRenewal();
 }

--- a/packages/dappmanager/src/calls/upnpPortsOpen.ts
+++ b/packages/dappmanager/src/calls/upnpPortsOpen.ts
@@ -1,5 +1,16 @@
 import { throttledNatRenewal } from "../daemons/natRenewal";
+import * as db from "../db";
 
-export async function upnpPortsOpen(): Promise<void> {
-  throttledNatRenewal();
+export async function upnpPortsOpen({
+  enableNatRenewal
+}: {
+  enableNatRenewal: boolean;
+}): Promise<void> {
+  if (enableNatRenewal) {
+    db.isNatRenewalEnabled.set(true);
+    throttledNatRenewal();
+  } else {
+    db.isNatRenewalEnabled.set(false);
+    throttledNatRenewal();
+  }
 }

--- a/packages/dappmanager/src/daemons/natRenewal/index.ts
+++ b/packages/dappmanager/src/daemons/natRenewal/index.ts
@@ -7,7 +7,6 @@ import getPortsToOpen from "./getPortsToOpen";
 import getLocalIp from "../../utils/getLocalIp";
 // Utils
 import {
-  runAtMostEvery,
   runAtMostEveryIntervals,
   runOnlyOneSequentially
 } from "../../utils/asyncFlows";

--- a/packages/dappmanager/src/daemons/natRenewal/index.ts
+++ b/packages/dappmanager/src/daemons/natRenewal/index.ts
@@ -132,7 +132,8 @@ export const throttledNatRenewal = runOnlyOneSequentially(natRenewal);
 export function startNatRenewalDaemon(signal: AbortSignal): void {
   // TEMPRARY: This solution will make to run an empty loop if false
   function enableNatRenewal(): void {
-    if (db.isNatRenewalEnabled.get() === true) throttledNatRenewal();
+    if (db.isNatRenewalDisabled.get() === true) return;
+    throttledNatRenewal();
   }
 
   eventBus.runNatRenewal.on(() => {

--- a/packages/dappmanager/src/daemons/natRenewal/index.ts
+++ b/packages/dappmanager/src/daemons/natRenewal/index.ts
@@ -118,18 +118,18 @@ function portId(port: PackagePort): string {
 }
 
 /**
+ * runOnlyOneSequentially makes sure that natRenewal is not run twice
+ * in parallel. Also, if multiple requests to run natRenewal, they will
+ * be ignored and run only once more after the previous natRenewal is
+ * completed.
+ */
+export const throttledNatRenewal = runOnlyOneSequentially(natRenewal);
+
+/**
  * NAT renewal daemon.
  * Makes sure all necessary ports are mapped using UPNP
  */
 export function startNatRenewalDaemon(signal: AbortSignal): void {
-  /**
-   * runOnlyOneSequentially makes sure that natRenewal is not run twice
-   * in parallel. Also, if multiple requests to run natRenewal, they will
-   * be ignored and run only once more after the previous natRenewal is
-   * completed.
-   */
-  const throttledNatRenewal = runOnlyOneSequentially(natRenewal);
-
   eventBus.runNatRenewal.on(() => {
     throttledNatRenewal();
   });

--- a/packages/dappmanager/src/daemons/natRenewal/index.ts
+++ b/packages/dappmanager/src/daemons/natRenewal/index.ts
@@ -130,12 +130,18 @@ export const throttledNatRenewal = runOnlyOneSequentially(natRenewal);
  * Makes sure all necessary ports are mapped using UPNP
  */
 export function startNatRenewalDaemon(signal: AbortSignal): void {
+  function enableNatRenewal(): void {
+    if (db.isNatRenewalEnabled.get()) throttledNatRenewal();
+    db.isNatRenewalEnabled.set(false);
+    return;
+  }
+
   eventBus.runNatRenewal.on(() => {
-    throttledNatRenewal();
+    enableNatRenewal();
   });
 
   runAtMostEveryIntervals(
-    async () => throttledNatRenewal(),
+    async () => enableNatRenewal(),
     [
       // User may turn-on UPnP right after installing DAppNode.
       // So run this daemon 2 times a bit more frequently for that case.

--- a/packages/dappmanager/src/daemons/natRenewal/index.ts
+++ b/packages/dappmanager/src/daemons/natRenewal/index.ts
@@ -130,10 +130,9 @@ export const throttledNatRenewal = runOnlyOneSequentially(natRenewal);
  * Makes sure all necessary ports are mapped using UPNP
  */
 export function startNatRenewalDaemon(signal: AbortSignal): void {
+  // TEMPRARY: This solution will make to run an empty loop if false
   function enableNatRenewal(): void {
-    if (db.isNatRenewalEnabled.get()) throttledNatRenewal();
-    db.isNatRenewalEnabled.set(false);
-    return;
+    if (db.isNatRenewalEnabled.get() === true) throttledNatRenewal();
   }
 
   eventBus.runNatRenewal.on(() => {

--- a/packages/dappmanager/src/daemons/natRenewal/index.ts
+++ b/packages/dappmanager/src/daemons/natRenewal/index.ts
@@ -131,17 +131,17 @@ export const throttledNatRenewal = runOnlyOneSequentially(natRenewal);
  */
 export function startNatRenewalDaemon(signal: AbortSignal): void {
   // TEMPRARY: This solution will make to run an empty loop if false
-  function enableNatRenewal(): void {
-    if (db.isNatRenewalDisabled.get() === true) return;
+  function runThrottledNatRenewalIfEnabled(): void {
+    if (db.isNatRenewalDisabled.get() === true) return; // is disabled, skip
     throttledNatRenewal();
   }
 
   eventBus.runNatRenewal.on(() => {
-    enableNatRenewal();
+    runThrottledNatRenewalIfEnabled();
   });
 
   runAtMostEveryIntervals(
-    async () => enableNatRenewal(),
+    async () => runThrottledNatRenewalIfEnabled(),
     [
       // User may turn-on UPnP right after installing DAppNode.
       // So run this daemon 2 times a bit more frequently for that case.

--- a/packages/dappmanager/src/db/upnp.ts
+++ b/packages/dappmanager/src/db/upnp.ts
@@ -5,7 +5,7 @@ import { PackagePort } from "../types";
 const UPNP_AVAILABLE = "upnp-available";
 const UPNP_PORT_MAPPINGS = "upnp-port-mappings";
 const PORTS_TO_OPEN = "ports-to-ppen";
-const IS_NAT_RENEWAL_ENABLED = "nat-enabled";
+const IS_NAT_RENEWAL_ENABLED = "is-nat-renewal-enabled";
 
 export const upnpAvailable = dbCache.staticKey<boolean>(UPNP_AVAILABLE, false);
 

--- a/packages/dappmanager/src/db/upnp.ts
+++ b/packages/dappmanager/src/db/upnp.ts
@@ -5,6 +5,7 @@ import { PackagePort } from "../types";
 const UPNP_AVAILABLE = "upnp-available";
 const UPNP_PORT_MAPPINGS = "upnp-port-mappings";
 const PORTS_TO_OPEN = "ports-to-ppen";
+const IS_NAT_RENEWAL_ENABLED = "nat-enabled";
 
 export const upnpAvailable = dbCache.staticKey<boolean>(UPNP_AVAILABLE, false);
 
@@ -14,3 +15,8 @@ export const upnpPortMappings = dbCache.staticKey<UpnpPortMapping[]>(
 );
 
 export const portsToOpen = dbCache.staticKey<PackagePort[]>(PORTS_TO_OPEN, []);
+
+export const isNatRenewalEnabled = dbCache.staticKey<boolean>(
+  IS_NAT_RENEWAL_ENABLED,
+  true
+);

--- a/packages/dappmanager/src/db/upnp.ts
+++ b/packages/dappmanager/src/db/upnp.ts
@@ -18,5 +18,5 @@ export const portsToOpen = dbCache.staticKey<PackagePort[]>(PORTS_TO_OPEN, []);
 
 export const isNatRenewalDisabled = dbCache.staticKey<boolean>(
   IS_NAT_RENEWAL_DISABLED,
-  true
+  false
 );

--- a/packages/dappmanager/src/db/upnp.ts
+++ b/packages/dappmanager/src/db/upnp.ts
@@ -5,7 +5,7 @@ import { PackagePort } from "../types";
 const UPNP_AVAILABLE = "upnp-available";
 const UPNP_PORT_MAPPINGS = "upnp-port-mappings";
 const PORTS_TO_OPEN = "ports-to-ppen";
-const IS_NAT_RENEWAL_ENABLED = "is-nat-renewal-enabled";
+const IS_NAT_RENEWAL_DISABLED = "is-nat-renewal-disabled";
 
 export const upnpAvailable = dbCache.staticKey<boolean>(UPNP_AVAILABLE, false);
 
@@ -16,7 +16,7 @@ export const upnpPortMappings = dbCache.staticKey<UpnpPortMapping[]>(
 
 export const portsToOpen = dbCache.staticKey<PackagePort[]>(PORTS_TO_OPEN, []);
 
-export const isNatRenewalEnabled = dbCache.staticKey<boolean>(
-  IS_NAT_RENEWAL_ENABLED,
+export const isNatRenewalDisabled = dbCache.staticKey<boolean>(
+  IS_NAT_RENEWAL_DISABLED,
   true
 );

--- a/packages/dappmanager/src/modules/upnpc/upnpcCommand.ts
+++ b/packages/dappmanager/src/modules/upnpc/upnpcCommand.ts
@@ -1,11 +1,10 @@
 import shell from "../../utils/shell";
 import parseGeneralErrors from "./parseGeneralErrors";
+import getDappmanagerImage from "../../utils/getDappmanagerImage";
 
 export default async function upnpcCommand(cmd: string): Promise<string> {
   try {
-    const image = await shell(
-      `docker inspect DAppNodeCore-dappmanager.dnp.dappnode.eth -f '{{.Config.Image}}'`
-    );
+    const image = await getDappmanagerImage();
     return await shell(
       `docker run --rm --net=host --entrypoint=/usr/bin/upnpc ${image} ${cmd}`
     );

--- a/packages/dappmanager/src/utils/getInternalIp.ts
+++ b/packages/dappmanager/src/utils/getInternalIp.ts
@@ -1,11 +1,10 @@
 import isIp from "is-ip";
 import shell from "./shell";
+import getDappmanagerImage from "./getDappmanagerImage";
 
 export default async function getInternalIp(): Promise<string> {
   try {
-    const image = await shell(
-      `docker inspect DAppNodeCore-dappmanager.dnp.dappnode.eth -f '{{.Config.Image}}'`
-    );
+    const image = await getDappmanagerImage();
     const output = await shell(
       `docker run --rm --net=host --entrypoint=/sbin/ip ${image} route get 1`
     );

--- a/packages/dappmanager/src/utils/getLocalIp.ts
+++ b/packages/dappmanager/src/utils/getLocalIp.ts
@@ -1,6 +1,7 @@
 import shell from "./shell";
 import isIp from "is-ip";
 import { logs } from "../logs";
+import getDappmanagerImage from "./getDappmanagerImage";
 
 export default async function getLocalIp(options?: {
   silent: boolean;
@@ -8,9 +9,7 @@ export default async function getLocalIp(options?: {
   const silent = options && options.silent;
 
   try {
-    const image = await shell(
-      `docker inspect DAppNodeCore-dappmanager.dnp.dappnode.eth -f '{{.Config.Image}}'`
-    );
+    const image = await getDappmanagerImage();
     const output = await shell(
       `docker run --rm --net=host --entrypoint=/sbin/ip ${image} route get 1`
     );


### PR DESCRIPTION
Added button in **support > ports** to attemp to open ports using UPnP. This may be useful if the `NAT RENEWAL` daemon fails so the user would be able to open ports using UPnP manually.