### PR TITLE
Do a nullish compare on db.get()

### DIFF
--- a/packages/dappmanager/src/db/dbFactory.ts
+++ b/packages/dappmanager/src/db/dbFactory.ts
@@ -37,7 +37,7 @@ export function dbFactory(dbPath: string) {
   /* eslint-disable-next-line @typescript-eslint/explicit-function-return-type */
   function staticKey<T>(key: string, defaultValue: T) {
     return {
-      get: (): T => jsonFileDb.read()[key] || defaultValue,
+      get: (): T => jsonFileDb.read()[key] ?? defaultValue,
       set: (newValue: T): void => {
         const all = jsonFileDb.read();
         all[key] = newValue;


### PR DESCRIPTION
Otherwise if the value is a boolean and the default value is true, `db.value.get()` will always return true