### PR TITLE
Allow docker-compose service pid property

### DIFF
--- a/packages/admin-ui/src/common/types.ts
+++ b/packages/admin-ui/src/common/types.ts
@@ -631,6 +631,7 @@ export interface ComposeService {
   network_mode?: string;
   networks?: ComposeServiceNetworks;
   ports?: string[];
+  pid?: string;
   privileged?: boolean;
   restart?: string; // "unless-stopped";
   stop_grace_period?: string;


### PR DESCRIPTION
Allow docker-compose service pid property. Only allow `service:*` values for security reasons

Fixes https://github.com/dappnode/DNP_DAPPMANAGER/issues/857