### PR TITLE
Fix hostpot typo

### DIFF
--- a/packages/admin-ui/src/pages/wifi/components/wifi/WifiStatus.tsx
+++ b/packages/admin-ui/src/pages/wifi/components/wifi/WifiStatus.tsx
@@ -26,7 +26,7 @@ function WifiInfo({ wifiStatus }: { wifiStatus: ContainerState }) {
   const dappnodeIdentity = useSelector(getDappnodeIdentityClean);
   return (
     <p>
-      Connect to the Wi-Fi hostpot exposed by your DAppNode using your
+      Connect to the Wi-Fi hotspot exposed by your DAppNode using your
       credentials. More information at:{" "}
       <a href={docsUrl.connectWifi}>{docsUrl.connectWifi}</a>
       {dappnodeIdentity.internalIp === dappnodeIdentity.ip &&


### PR DESCRIPTION
Just a typo. Hotspot was misspelled as hostpot.