### PR TITLE
Add depends_on key to compose service whitelist

### DIFF
--- a/packages/admin-ui/src/common/types.ts
+++ b/packages/admin-ui/src/common/types.ts
@@ -613,6 +613,7 @@ export interface ComposeService {
   command?: string;
   container_name: string; // "DAppNodeCore-dappmanager.dnp.dappnode.eth";
   devices?: string[];
+  depends_on?: string[];
   dns?: string; // "172.33.1.2";
   entrypoint?: string;
   env_file?: string[];

--- a/packages/dappmanager/src/modules/compose/unsafeCompose.ts
+++ b/packages/dappmanager/src/modules/compose/unsafeCompose.ts
@@ -34,6 +34,7 @@ const serviceSafeKeys: (keyof ComposeService)[] = [
   "cap_add",
   "cap_drop",
   "command",
+  "depends_on",
   "devices",
   "entrypoint",
   "environment",


### PR DESCRIPTION
It is safe to add, shouldn't have any negative impact on existing package.