### PR TITLE
dappstore explorer: fetch SC APM registry 

### DIFF
--- a/packages/admin-ui/src/__mock-backend__/index.ts
+++ b/packages/admin-ui/src/__mock-backend__/index.ts
@@ -224,7 +224,8 @@ export const otherCalls: Omit<Routes, keyof typeof namedSpacedCalls> = {
   runHostSecurityUpdates: async () =>
     "Security updates have been executed successfully, no reboot needed",
   natRenewalEnable: async () => {},
-  natRenewalIsEnabled: async () => true
+  natRenewalIsEnabled: async () => true,
+  fetchRegistry: async () => []
 };
 
 export const calls: Routes = {

--- a/packages/admin-ui/src/common/routes.ts
+++ b/packages/admin-ui/src/common/routes.ts
@@ -37,7 +37,8 @@ import {
   InstalledPackageDataApiReturn,
   WifiReport,
   CurrentWifiCredentials,
-  LocalProxyingStatus
+  LocalProxyingStatus,
+  RegistryItem
 } from "./types";
 
 export interface Routes {
@@ -218,6 +219,11 @@ export interface Routes {
    * Fetch directory summary
    */
   fetchDirectory: () => Promise<DirectoryItem[]>;
+
+  /**
+   * Fetch registry summary
+   */
+  fetchRegistry: () => Promise<RegistryItem[]>;
 
   /**
    * Fetch extended info about a new DNP
@@ -620,6 +626,7 @@ export const routesData: { [P in keyof Routes]: RouteData } = {
   ethClientTargetSet: { log: true },
   fetchCoreUpdateData: {},
   fetchDirectory: {},
+  fetchRegistry: {},
   fetchDnpRequest: {},
   getUserActionLogs: {},
   httpsPortalMappingAdd: { log: true },

--- a/packages/admin-ui/src/common/types.ts
+++ b/packages/admin-ui/src/common/types.ts
@@ -115,7 +115,26 @@ interface DirectoryItemBasic {
   whitelisted: boolean;
   isFeatured: boolean;
 }
+
+interface RegistryItemBasic {
+  index: number;
+  name: string;
+}
 export interface DirectoryItemOk extends DirectoryItemBasic {
+  status: "ok";
+  description: string; // = metadata.shortDescription || metadata.description
+  avatarUrl: string; // Must be URL to a resource in a DAPPMANAGER API
+  isInstalled: boolean; // Show "UPDATE"
+  isUpdated: boolean; // Show "UPDATED"
+  featuredStyle?: {
+    featuredBackground?: string;
+    featuredColor?: string;
+    featuredAvatarFilter?: string;
+  };
+  categories: string[];
+}
+
+export interface RegistryItemOk extends RegistryItemBasic {
   status: "ok";
   description: string; // = metadata.shortDescription || metadata.description
   avatarUrl: string; // Must be URL to a resource in a DAPPMANAGER API
@@ -133,7 +152,14 @@ export interface DirectoryItemError extends DirectoryItemBasic {
   status: "error";
   message: string;
 }
+export interface RegistryItemError extends RegistryItemBasic {
+  status: "error";
+  message: string;
+}
+
 export type DirectoryItem = DirectoryItemOk | DirectoryItemError;
+
+export type RegistryItem = RegistryItemOk | RegistryItemError;
 
 export interface RequestStatus {
   loading?: boolean;
@@ -738,6 +764,7 @@ export interface PackageNotificationDb extends PackageNotification {
 export type UpdateType = "major" | "minor" | "patch" | null;
 
 export type DirectoryDnpStatus = "Deleted" | "Active" | "Developing";
+
 export interface DirectoryDnp {
   name: string;
   status: number;
@@ -746,6 +773,13 @@ export interface DirectoryDnp {
   directoryId: number;
   isFeatured: boolean;
   featuredIndex: number;
+  manifest?: Manifest;
+  avatar?: string;
+}
+
+export interface RegistryPublic {
+  name: string;
+  position: number;
   manifest?: Manifest;
   avatar?: string;
 }

--- a/packages/dappmanager/package.json
+++ b/packages/dappmanager/package.json
@@ -60,7 +60,7 @@
     "data-uri-to-buffer": "^2.0.0",
     "deepmerge": "^2.2.1",
     "dockerode": "^3.2.1",
-    "ethers": "^4.0.38",
+    "ethers": "^5.4.4",
     "express": "^4.17.1",
     "express-fileupload": "^1.1.5",
     "helmet": "^4.4.1",

--- a/packages/dappmanager/src/calls/fetchDirectory.ts
+++ b/packages/dappmanager/src/calls/fetchDirectory.ts
@@ -82,7 +82,7 @@ export async function fetchDirectory(): Promise<DirectoryItem[]> {
 /**
  * Get a short description and trim it
  */
-function getShortDescription(metadata: {
+export function getShortDescription(metadata: {
   description?: string;
   shortDescription?: string;
 }): string {
@@ -115,6 +115,6 @@ const fallbackCategories: { [dnpName: string]: string[] } = {
  * until all of them are updated
  * @param dnpName "bitcoin.dnp.dappnode.eth"
  */
-function getFallBackCategories(dnpName: string): string[] {
+export function getFallBackCategories(dnpName: string): string[] {
   return fallbackCategories[dnpName];
 }

--- a/packages/dappmanager/src/calls/fetchRegistry.ts
+++ b/packages/dappmanager/src/calls/fetchRegistry.ts
@@ -1,0 +1,86 @@
+import { getEthersProvider } from "../modules/ethClient";
+import { ReleaseFetcher } from "../modules/release";
+import { listPackages } from "../modules/docker/list";
+import { getRegistry } from "../modules/registry";
+import { eventBus } from "../eventBus";
+import { throttle } from "lodash";
+import { NoImageForArchError } from "../modules/release/errors";
+import { logs } from "../logs";
+import { RegistryItem } from "../types";
+import { fileToGatewayUrl } from "../utils/distributedFile";
+import { getIsInstalled, getIsUpdated } from "./fetchDnpRequest";
+import { getShortDescription, getFallBackCategories } from "./fetchDirectory";
+
+const defaultEnsName = "public.dnp.dappnode";
+const fistBlockPublicRegistry = 6312046;
+
+const loadThrottle = 500; // 0.5 seconds
+
+/**
+ * Fetches all package names in the registry SC.
+ */
+export async function fetchRegistry(
+  addressOrEnsName = defaultEnsName
+): Promise<RegistryItem[]> {
+  const provider = await getEthersProvider();
+  const releaseFetcher = new ReleaseFetcher();
+
+  const dnpList = await listPackages();
+
+  const registry = await getRegistry(
+    provider,
+    addressOrEnsName,
+    fistBlockPublicRegistry
+  );
+  const registryPublicDnps: RegistryItem[] = [];
+
+  let registryDnpsPending: RegistryItem[] = [];
+  // Prevent sending way to many updates in case the fetching process is fast
+  const emitRegistryUpdate = throttle(() => {
+    eventBus.registry.emit(registryDnpsPending);
+    registryDnpsPending = [];
+  }, loadThrottle);
+
+  function pushRegistryItem(item: RegistryItem): void {
+    registryPublicDnps.push(item);
+    registryDnpsPending.push(item);
+    emitRegistryUpdate();
+  }
+
+  await Promise.all(
+    registry.map(
+      async ({ name }, index): Promise<void> => {
+        const registryItemBasic = { index, name };
+        try {
+          // Now resolve the last version of the package
+          const release = await releaseFetcher.getRelease(name);
+          const { metadata, avatarFile } = release;
+
+          pushRegistryItem({
+            ...registryItemBasic,
+            status: "ok",
+            description: getShortDescription(metadata),
+            avatarUrl: fileToGatewayUrl(avatarFile), // Must be URL to a resource in a DAPPMANAGER API
+            isInstalled: getIsInstalled(release, dnpList),
+            isUpdated: getIsUpdated(release, dnpList),
+            featuredStyle: metadata.style,
+            categories: metadata.categories || getFallBackCategories(name) || []
+          });
+        } catch (e) {
+          if (e instanceof NoImageForArchError) {
+            logs.debug(`Package ${name} is not available in current arch`);
+          } else {
+            logs.error(`Error fetching ${name} release`, e);
+            pushRegistryItem({
+              ...registryItemBasic,
+              status: "error",
+              message: e.message
+            });
+          }
+        }
+      }
+    )
+  );
+
+  return registryPublicDnps;
+}

--- a/packages/dappmanager/src/calls/index.ts
+++ b/packages/dappmanager/src/calls/index.ts
@@ -15,6 +15,7 @@ export { ethClientFallbackSet } from "./ethClientFallbackSet";
 export { fetchCoreUpdateData } from "./fetchCoreUpdateData";
 export { fetchDirectory } from "./fetchDirectory";
 export { fetchDnpRequest } from "./fetchDnpRequest";
+export { fetchRegistry } from "./fetchRegistry";
 export { getUserActionLogs } from "./getUserActionLogs";
 export * from "./httpsPortal";
 export { ipfsTest } from "./ipfsTest";

--- a/packages/dappmanager/src/contracts/registry.ts
+++ b/packages/dappmanager/src/contracts/registry.ts
@@ -2,7 +2,6 @@
 
 // This SC allows to create ENS for dappnode like public.dappnode.eth and dnp.public.eth
 
-// public.dappnode.eth (0x9f85ae5aefe4a3eff39d9a44212aae21dd15079a) and dnp.dappnode.eth (0x266bfdb2124a68beb6769dc887bd655f78778923)
 // are generated from the same SC: APM Registry
 // To get into this SC is necessary to do in Etherscan:
 //     1. Verify proxy
@@ -12,6 +11,8 @@
 
 export const contractName = "registry";
 export const address = "0x1d9Bdf492e59A306DDa59E5aA13E7F1C7D89197A";
+// public.dappnode.eth: 0x9f85ae5aefe4a3eff39d9a44212aae21dd15079a
+// dnp.dappnode.eth: 0x266bfdb2124a68beb6769dc887bd655f78778923
 export const abi = [
   {
     constant: true,

--- a/packages/dappmanager/src/contracts/registry.ts
+++ b/packages/dappmanager/src/contracts/registry.ts
@@ -1,0 +1,230 @@
+// APM REGISTRY SMART CONTRACT: https://etherscan.io/address/0x1d9bdf492e59a306dda59e5aa13e7f1c7d89197a#code
+
+// This SC allows to create ENS for dappnode like public.dappnode.eth and dnp.public.eth
+
+// public.dappnode.eth (0x9f85ae5aefe4a3eff39d9a44212aae21dd15079a) and dnp.dappnode.eth (0x266bfdb2124a68beb6769dc887bd655f78778923)
+// are generated from the same SC: APM Registry
+// To get into this SC is necessary to do in Etherscan:
+//     1. Verify proxy
+//     2. Read as proxy
+//     3. Go to the source SC
+// This is because the SC is "upgradable".
+
+export const contractName = "registry";
+export const address = "0x1d9Bdf492e59A306DDa59E5aA13E7F1C7D89197A";
+export const abi = [
+  {
+    constant: true,
+    inputs: [],
+    name: "REPO_APP_NAME",
+    outputs: [{ name: "", type: "string" }],
+    payable: false,
+    stateMutability: "view",
+    type: "function"
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: "APM_APP_NAME",
+    outputs: [{ name: "", type: "string" }],
+    payable: false,
+    stateMutability: "view",
+    type: "function"
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: "ENS_SUB_APP_NAME",
+    outputs: [{ name: "", type: "string" }],
+    payable: false,
+    stateMutability: "view",
+    type: "function"
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: "registrar",
+    outputs: [{ name: "", type: "address" }],
+    payable: false,
+    stateMutability: "view",
+    type: "function"
+  },
+  {
+    constant: false,
+    inputs: [
+      { name: "_name", type: "string" },
+      { name: "_dev", type: "address" },
+      { name: "_initialSemanticVersion", type: "uint16[3]" },
+      { name: "_contractAddress", type: "address" },
+      { name: "_contentURI", type: "bytes" }
+    ],
+    name: "newRepoWithVersion",
+    outputs: [{ name: "", type: "address" }],
+    payable: false,
+    stateMutability: "nonpayable",
+    type: "function"
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: "CREATE_REPO_ROLE",
+    outputs: [{ name: "", type: "bytes32" }],
+    payable: false,
+    stateMutability: "view",
+    type: "function"
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: "EVMSCRIPT_REGISTRY_APP_ID",
+    outputs: [{ name: "", type: "bytes32" }],
+    payable: false,
+    stateMutability: "view",
+    type: "function"
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: "appId",
+    outputs: [{ name: "", type: "bytes32" }],
+    payable: false,
+    stateMutability: "view",
+    type: "function"
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: "getInitializationBlock",
+    outputs: [{ name: "", type: "uint256" }],
+    payable: false,
+    stateMutability: "view",
+    type: "function"
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: "EVMSCRIPT_REGISTRY_APP",
+    outputs: [{ name: "", type: "bytes32" }],
+    payable: false,
+    stateMutability: "view",
+    type: "function"
+  },
+  {
+    constant: true,
+    inputs: [
+      { name: "_sender", type: "address" },
+      { name: "_role", type: "bytes32" },
+      { name: "params", type: "uint256[]" }
+    ],
+    name: "canPerform",
+    outputs: [{ name: "", type: "bool" }],
+    payable: false,
+    stateMutability: "view",
+    type: "function"
+  },
+  {
+    constant: false,
+    inputs: [
+      { name: "_name", type: "string" },
+      { name: "_dev", type: "address" }
+    ],
+    name: "newRepo",
+    outputs: [{ name: "", type: "address" }],
+    payable: false,
+    stateMutability: "nonpayable",
+    type: "function"
+  },
+  {
+    constant: false,
+    inputs: [{ name: "_registrar", type: "address" }],
+    name: "initialize",
+    outputs: [],
+    payable: false,
+    stateMutability: "nonpayable",
+    type: "function"
+  },
+  {
+    constant: false,
+    inputs: [
+      { name: "_kernel", type: "address" },
+      { name: "_appId", type: "bytes32" },
+      { name: "_initializePayload", type: "bytes" }
+    ],
+    name: "newAppProxyPinned",
+    outputs: [{ name: "", type: "address" }],
+    payable: false,
+    stateMutability: "nonpayable",
+    type: "function"
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: "kernel",
+    outputs: [{ name: "", type: "address" }],
+    payable: false,
+    stateMutability: "view",
+    type: "function"
+  },
+  {
+    constant: false,
+    inputs: [
+      { name: "_kernel", type: "address" },
+      { name: "_appId", type: "bytes32" }
+    ],
+    name: "newAppProxy",
+    outputs: [{ name: "", type: "address" }],
+    payable: false,
+    stateMutability: "nonpayable",
+    type: "function"
+  },
+  {
+    constant: false,
+    inputs: [
+      { name: "_kernel", type: "address" },
+      { name: "_appId", type: "bytes32" },
+      { name: "_initializePayload", type: "bytes" }
+    ],
+    name: "newAppProxy",
+    outputs: [{ name: "", type: "address" }],
+    payable: false,
+    stateMutability: "nonpayable",
+    type: "function"
+  },
+  {
+    constant: true,
+    inputs: [{ name: "_script", type: "bytes" }],
+    name: "getExecutor",
+    outputs: [{ name: "", type: "address" }],
+    payable: false,
+    stateMutability: "view",
+    type: "function"
+  },
+  {
+    constant: false,
+    inputs: [
+      { name: "_kernel", type: "address" },
+      { name: "_appId", type: "bytes32" }
+    ],
+    name: "newAppProxyPinned",
+    outputs: [{ name: "", type: "address" }],
+    payable: false,
+    stateMutability: "nonpayable",
+    type: "function"
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: false, name: "id", type: "bytes32" },
+      { indexed: false, name: "name", type: "string" },
+      { indexed: false, name: "repo", type: "address" }
+    ],
+    name: "NewRepo",
+    type: "event"
+  },
+  {
+    anonymous: false,
+    inputs: [{ indexed: false, name: "proxy", type: "address" }],
+    name: "NewAppProxy",
+    type: "event"
+  }
+];

--- a/packages/dappmanager/src/contracts/repository.ts
+++ b/packages/dappmanager/src/contracts/repository.ts
@@ -1,5 +1,12 @@
+// REPOSITORY SMART CONTRACT: https://etherscan.io/address/0x95b9067d07d6c96a63a3119285b0aa6092e32a4b#code
+
+// This SC creates repos for DAppNodePackages to control versioning
+
 export const contractName = "repository";
-export const address = "dynamic";
+// Address is dynamic because it will deppend of the ENS, example: poligon.public.dappnode.eth
+// 0xec2A48F81A79aD576160f14A541afF5fC4c997AF https://etherscan.io/address/0xec2a48f81a79ad576160f14a541aff5fc4c997af
+// The source ABI Implementation is: https://etherscan.io/address/0x95b9067d07d6c96a63a3119285b0aa6092e32a4b#code
+export const address = "0x95B9067D07d6C96a63A3119285B0aa6092E32a4b";
 export const abi = [
   {
     constant: true,

--- a/packages/dappmanager/src/eventBus.ts
+++ b/packages/dappmanager/src/eventBus.ts
@@ -9,10 +9,12 @@ import {
   PackageNotification,
   DirectoryItem
 } from "./types";
+import { RegistryItem } from "./common";
 
 interface EventTypes {
   chainData: ChainData[];
   directory: DirectoryItem[];
+  registry: RegistryItem[];
   logUi: ProgressLog;
   logUserAction: UserActionLog;
   notification: PackageNotification;
@@ -33,6 +35,7 @@ interface EventTypes {
 const eventBusData: { [P in keyof EventTypes]: {} } = {
   chainData: {},
   directory: {},
+  registry: {},
   logUi: {},
   logUserAction: {},
   notification: {},
@@ -41,6 +44,7 @@ const eventBusData: { [P in keyof EventTypes]: {} } = {
   // Events without arguments
   telegramStatusChanged: {},
   initializedDb: {},
+
   requestAutoUpdateData: {},
   requestChainData: {},
   requestDevices: {},

--- a/packages/dappmanager/src/modules/apm/apmUtils.ts
+++ b/packages/dappmanager/src/modules/apm/apmUtils.ts
@@ -17,7 +17,10 @@ export function parseApmVersionReturn(
     version: res.semanticVersion.join("."),
     // Second argument = true: ignore UTF8 parsing errors
     // Let downstream code identify the content hash as wrong
-    contentUri: ethers.utils.toUtf8String(res.contentURI, true)
+    contentUri: ethers.utils.toUtf8String(
+      res.contentURI,
+      ethers.utils.Utf8ErrorFuncs.ignore
+    )
   };
 }
 

--- a/packages/dappmanager/src/modules/apm/fetchApmVersionsMetadata.ts
+++ b/packages/dappmanager/src/modules/apm/fetchApmVersionsMetadata.ts
@@ -1,10 +1,8 @@
 import { ethers } from "ethers";
 import { ApmVersionMetadata } from "./types";
 import { getTimestamp } from "./apmUtils";
-
-const repoAbi = [
-  "event NewVersion(uint256 versionId, uint16[3] semanticVersion)"
-];
+import { Interface } from "ethers/lib/utils";
+import { abi } from "../../contracts/registry";
 
 /**
  * Fetches the new repos logs from a registry
@@ -20,31 +18,75 @@ export async function fetchApmVersionsMetadata(
   // Change this method if the web3 library is not ethjs
   // await ensureAncientBlocks();
 
-  const repo = new ethers.utils.Interface(repoAbi);
+  const repo = new ethers.utils.Interface(abi);
 
   const result = await provider.getLogs({
     address: addressOrEnsName, // or contractEnsName,
     fromBlock: fromBlock || 0,
     toBlock: "latest",
-    topics: [repo.events.NewVersion.topic]
+    topics: [getTopicFromEvent(repo, "NewVersion")]
   });
 
   return await Promise.all(
     result.map(
-      async (event): Promise<ApmVersionMetadata> => {
+      async (log): Promise<ApmVersionMetadata> => {
         // Parse values
-        const parsedLog = repo.parseLog(event);
-        if (!parsedLog || !parsedLog.values)
+        const parsedLog = repo.parseLog(log);
+
+        if (!parsedLog || !parsedLog.args)
           throw Error(`Error parsing NewRepo event`);
         // const versionId = parsedLog.values.versionId.toNumber();
         return {
-          version: parsedLog.values.semanticVersion.join("."),
+          version: parsedLog.args.semanticVersion.join("."),
           // Parse tx data
-          txHash: event.transactionHash,
-          blockNumber: event.blockNumber,
-          timestamp: await getTimestamp(event.blockNumber, provider)
+          txHash: log.transactionHash,
+          blockNumber: log.blockNumber,
+          timestamp: await getTimestamp(log.blockNumber, provider)
         };
       }
     )
   );
+}
+
+// Utils
+
+export function getParsedLogs(
+  iface: Interface,
+  logs: ethers.providers.Log[],
+  topic: string
+): ethers.utils.LogDescription[] {
+  const parsedLogs: ethers.utils.LogDescription[] = [];
+  for (const log of logs) {
+    if (!log.topics.find(logTopic => logTopic === topic))
+      throw Error(`Topic ${topic} not found`);
+    parsedLogs.push(iface.parseLog(log));
+  }
+  return parsedLogs;
+}
+
+export function getArgFromParsedLogs(
+  parsedLogs: ethers.utils.LogDescription[],
+  argDesired: string
+): string[] {
+  const logsResultArray = parsedLogs.map(parsedLog => parsedLog.args);
+
+  const argsDesired: string[] = [];
+  for (const logResult of logsResultArray) {
+    for (const arg of logResult) {
+      if (Object.keys(arg) === [argDesired]) argsDesired.push(arg.name);
+    }
+  }
+
+  return argsDesired;
+}
+
+/** Get a topic from a given event, if either of event or topic does not exist error */
+export function getTopicFromEvent(iface: Interface, eventName: string): string {
+  const event = Object.values(iface.events).find(
+    eventValue => eventValue.name === eventName
+  );
+  if (!event) throw Error(`Event ${eventName} not found`);
+  const topic = iface.getEventTopic(event);
+  if (!topic) throw Error(`Topic not found on event ${event}`);
+  return topic;
 }

--- a/packages/dappmanager/src/modules/registry/getRegistry.ts
+++ b/packages/dappmanager/src/modules/registry/getRegistry.ts
@@ -1,0 +1,133 @@
+import { RegistryPublic } from "../../types";
+import { ethers } from "ethers";
+import { abi } from "../../contracts/registry";
+import { Interface } from "ethers/lib/utils";
+import { isEnsDomain } from "../../utils/validate";
+import { notUndefined } from "../../utils/typingHelpers";
+
+// Topic name
+const eventNewRepo = "NewRepo";
+
+// Index of name in logs of Registry SC
+const indexOfPackageName = 1;
+
+export async function getRegistry(
+  provider: ethers.providers.Provider,
+  addressOrEnsName: string,
+  fromBlock?: number,
+  toBlock?: number
+): Promise<RegistryPublic[]> {
+  const ensName = await provider.resolveName(addressOrEnsName);
+  if (!ensName) throw Error(`ENS name ${ensName} does not exist`);
+
+  const iface = new ethers.utils.Interface(abi);
+
+  const topic = getTopicFromEvent(iface, eventNewRepo);
+
+  const logs = await provider
+    .getLogs({
+      address: addressOrEnsName, // or contractEnsName,
+      fromBlock: fromBlock || 0,
+      toBlock: toBlock || "latest",
+      topics: [topic]
+    })
+    .catch(e => {
+      throw Error(
+        `Error retrieving logs from ${addressOrEnsName}. Error: ${e}`
+      );
+    });
+
+  const parsedLogs = getParsedLogs(iface, logs, topic);
+
+  const dappNodePackagesNames = getArgFromParsedLogs(
+    parsedLogs,
+    indexOfPackageName
+  );
+
+  const numberOfDAppNodePackages = dappNodePackagesNames.length;
+
+  const registryIds: number[] = [];
+  for (let i = 0; i < numberOfDAppNodePackages; i++) {
+    registryIds.push(i);
+  }
+
+  const packages = await Promise.all(
+    registryIds.map(
+      async (i): Promise<RegistryPublic | undefined> => {
+        const name = createFullPackageName(
+          addressOrEnsName,
+          dappNodePackagesNames[i]
+        );
+        // Make sure the DNP is not Deprecated or Deleted
+        if (!isEnsDomain(name)) return;
+
+        return {
+          name,
+          position: i
+        };
+      }
+    )
+  );
+
+  return sortRegistryPackages(packages.filter(notUndefined));
+}
+
+// Utils
+
+/** */
+export function createFullPackageName(
+  ensName: string,
+  packageName: string
+): string {
+  return `${packageName}.${ensName}`;
+}
+
+/** Sort DAppNode packages alphabetically */
+export function sortRegistryPackages(
+  packages: RegistryPublic[]
+): RegistryPublic[] {
+  return packages.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/** Parse logs from hexadecimal format*/
+export function getParsedLogs(
+  iface: Interface,
+  logs: ethers.providers.Log[],
+  topic: string
+): ethers.utils.LogDescription[] {
+  const parsedLogs: ethers.utils.LogDescription[] = [];
+  for (const log of logs) {
+    if (!log.topics.find(logTopic => logTopic === topic))
+      throw Error(`Topic ${topic} not found`);
+    parsedLogs.push(iface.parseLog(log));
+  }
+  return parsedLogs;
+}
+
+/** Get args from the log. There must be known the index of the arg to get */
+export function getArgFromParsedLogs(
+  parsedLogs: ethers.utils.LogDescription[],
+  argDesiredIndex: number
+): string[] {
+  const logsResultArray = parsedLogs.map(parsedLog => parsedLog.args);
+
+  const argsDesired: string[] = [];
+  for (const logResult of logsResultArray) {
+    const packageName = logResult[argDesiredIndex];
+    if (packageName && !packageName.includes("0x"))
+      argsDesired.push(packageName);
+  }
+
+  return argsDesired;
+}
+
+/** Get a topic from a given event, if either event or topic does not exist then error */
+export function getTopicFromEvent(iface: Interface, eventName: string): string {
+  const event = Object.values(iface.events).find(
+    eventValue => eventValue.name === eventName
+  );
+  if (!event) throw Error(`Event ${eventName} not found`);
+  const topic = iface.getEventTopic(event);
+  if (!topic) throw Error(`Topic not found on event ${event}`);
+  return topic;
+}

--- a/packages/dappmanager/src/modules/registry/index.ts
+++ b/packages/dappmanager/src/modules/registry/index.ts
@@ -1,0 +1,1 @@
+export * from "./getRegistry";

--- a/packages/dappmanager/test/modules/smartContracts/fetchRegistryNewRepos.test.ts
+++ b/packages/dappmanager/test/modules/smartContracts/fetchRegistryNewRepos.test.ts
@@ -1,0 +1,96 @@
+import "mocha";
+import { expect } from "chai";
+import { ethers } from "ethers";
+import {
+  getTopicFromEvent,
+  getParsedLogs,
+  getArgFromParsedLogs
+} from "../../../src/modules/apm/fetchApmVersionsMetadata";
+import { abi } from "../../../src/contracts/registry";
+
+describe.only("Apm > fetchApmVersionsMetadata > getTopicFromEvent", () => {
+  const iface = new ethers.utils.Interface(abi);
+  const logs = [
+    {
+      blockNumber: 8497779,
+      blockHash:
+        "0x091c7535941aed4e0a68b8a26f19c359b69d8518767b352c120c3c0d22720e19",
+      transactionIndex: 23,
+      removed: false,
+      address: "0x9F85AE5aeFE4a3eFF39d9A44212aae21Dd15079A",
+      data:
+        "0x424563bbed4a267a3338d9a5772c5671677042c6fdab1d992fe3b2bb845931630000000000000000000000000000000000000000000000000000000000000060000000000000000000000000ee09d2b1772495028939cd8cee59ca0f0bc6bba100000000000000000000000000000000000000000000000000000000000000077472696e69747900000000000000000000000000000000000000000000000000",
+      topics: [
+        "0x526d4ccf8c3d7b6f0b6d4cc0de526d515c87d1ea3bd264ace0b5c2e70d1b2208"
+      ],
+      transactionHash:
+        "0x76ec638a1fd642976274d501460de73e0eafdd90817e70b672e538718975ba6d",
+      logIndex: 23
+    },
+    {
+      blockNumber: 8593620,
+      blockHash:
+        "0x7ba7136b509da6d148a51673cf154c57ce8136c8bdc6d99e6dd690ea0ffbfac9",
+      transactionIndex: 91,
+      removed: false,
+      address: "0x9F85AE5aeFE4a3eFF39d9A44212aae21Dd15079A",
+      data:
+        "0x2e3da36a87d14fb6b3e0a7c6baad472a411d1271529917e75c4de28d6f46e9f300000000000000000000000000000000000000000000000000000000000000600000000000000000000000001b66cc0563e32f60e929bff26ccbb7084f98821b000000000000000000000000000000000000000000000000000000000000000e6d6173746572657468657265756d000000000000000000000000000000000000",
+      topics: [
+        "0x526d4ccf8c3d7b6f0b6d4cc0de526d515c87d1ea3bd264ace0b5c2e70d1b2208"
+      ],
+      transactionHash:
+        "0x508478ce46c94cec853361d777feaed6bb429ff909d53bca44f97c09f4a1d3d6",
+      logIndex: 46
+    },
+    {
+      blockNumber: 8656925,
+      blockHash:
+        "0x7843db9fe1056a0fe108bb7fcab29361738073ed12c7220722a9c57f1f19f890",
+      transactionIndex: 162,
+      removed: false,
+      address: "0x9F85AE5aeFE4a3eFF39d9A44212aae21Dd15079A",
+      data:
+        "0xb65f0ce53546196631dc3a0d3bbdc77677ca672cb2dad349744b7a978f6157130000000000000000000000000000000000000000000000000000000000000060000000000000000000000000191b717c27677b3dc8903230030b6747614c45f500000000000000000000000000000000000000000000000000000000000000057a63617368000000000000000000000000000000000000000000000000000000",
+      topics: [
+        "0x526d4ccf8c3d7b6f0b6d4cc0de526d515c87d1ea3bd264ace0b5c2e70d1b2208"
+      ],
+      transactionHash:
+        "0x37fcdc918a5109a636ccbe1e94be0d9d5b914eb8cd34ac82791d8a65bb0aebb7",
+      logIndex: 136
+    },
+    {
+      blockNumber: 8773406,
+      blockHash:
+        "0xffe360d504fac6eb3a1455db27e242f3f4cbb8fcdf4c843f1b695343102dc34c",
+      transactionIndex: 187,
+      removed: false,
+      address: "0x9F85AE5aeFE4a3eFF39d9A44212aae21Dd15079A",
+      data:
+        "0x55cfa467689f95088f0cbea7cf28725e809228b3ee7af8b749fdafd6a917c0cd0000000000000000000000000000000000000000000000000000000000000060000000000000000000000000cd870fa2f92978e64626ce6b24f2e2d39d04c1890000000000000000000000000000000000000000000000000000000000000008706f6c6b61646f74000000000000000000000000000000000000000000000000",
+      topics: [
+        "0x526d4ccf8c3d7b6f0b6d4cc0de526d515c87d1ea3bd264ace0b5c2e70d1b2208"
+      ],
+      transactionHash:
+        "0xa93e49229fd4ba49a64e3436d0adf678edc9decfc06c72445afb32b6d83f3575",
+      logIndex: 119
+    }
+  ];
+  let topic: string;
+  let parsedLogs: ethers.utils.LogDescription[];
+
+  it("Should get topic from event", () => {
+    topic = getTopicFromEvent(iface, "NewRepo");
+    console.log(topic);
+  });
+
+  it("Should get parsed logs", () => {
+    parsedLogs = getParsedLogs(iface, logs, topic);
+    console.log(parsedLogs);
+  });
+
+  it("Should get arg from parsed logs", () => {
+    const args = getArgFromParsedLogs(parsedLogs, "name");
+    console.log(args);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1185,6 +1185,345 @@
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
   integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
 
+"@ethersproject/abi@5.4.0", "@ethersproject/abi@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.4.0.tgz#a6d63bdb3672f738398846d4279fa6b6c9818242"
+  integrity sha512-9gU2H+/yK1j2eVMdzm6xvHSnMxk8waIHQGYCZg5uvAyH0rsAzxkModzBSpbAkAuhKFEovC2S9hM4nPuLym8IZw==
+  dependencies:
+    "@ethersproject/address" "^5.4.0"
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/constants" "^5.4.0"
+    "@ethersproject/hash" "^5.4.0"
+    "@ethersproject/keccak256" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+    "@ethersproject/strings" "^5.4.0"
+
+"@ethersproject/abstract-provider@5.4.1", "@ethersproject/abstract-provider@^5.4.0":
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.4.1.tgz#e404309a29f771bd4d28dbafadcaa184668c2a6e"
+  integrity sha512-3EedfKI3LVpjSKgAxoUaI+gB27frKsxzm+r21w9G60Ugk+3wVLQwhi1LsEJAKNV7WoZc8CIpNrATlL1QFABjtQ==
+  dependencies:
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/networks" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+    "@ethersproject/transactions" "^5.4.0"
+    "@ethersproject/web" "^5.4.0"
+
+"@ethersproject/abstract-signer@5.4.1", "@ethersproject/abstract-signer@^5.4.0":
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.4.1.tgz#e4e9abcf4dd4f1ba0db7dff9746a5f78f355ea81"
+  integrity sha512-SkkFL5HVq1k4/25dM+NWP9MILgohJCgGv5xT5AcRruGz4ILpfHeBtO/y6j+Z3UN/PAjDeb4P7E51Yh8wcGNLGA==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.4.0"
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+
+"@ethersproject/address@5.4.0", "@ethersproject/address@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.4.0.tgz#ba2d00a0f8c4c0854933b963b9a3a9f6eb4a37a3"
+  integrity sha512-SD0VgOEkcACEG/C6xavlU1Hy3m5DGSXW3CUHkaaEHbAPPsgi0coP5oNPsxau8eTlZOk/bpa/hKeCNoK5IzVI2Q==
+  dependencies:
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/keccak256" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/rlp" "^5.4.0"
+
+"@ethersproject/base64@5.4.0", "@ethersproject/base64@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.4.0.tgz#7252bf65295954c9048c7ca5f43e5c86441b2a9a"
+  integrity sha512-CjQw6E17QDSSC5jiM9YpF7N1aSCHmYGMt9bWD8PWv6YPMxjsys2/Q8xLrROKI3IWJ7sFfZ8B3flKDTM5wlWuZQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.4.0"
+
+"@ethersproject/basex@5.4.0", "@ethersproject/basex@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/basex/-/basex-5.4.0.tgz#0a2da0f4e76c504a94f2b21d3161ed9438c7f8a6"
+  integrity sha512-J07+QCVJ7np2bcpxydFVf/CuYo9mZ7T73Pe7KQY4c1lRlrixMeblauMxHXD0MPwFmUHZIILDNViVkykFBZylbg==
+  dependencies:
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+
+"@ethersproject/bignumber@5.4.1", "@ethersproject/bignumber@^5.4.0":
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.4.1.tgz#64399d3b9ae80aa83d483e550ba57ea062c1042d"
+  integrity sha512-fJhdxqoQNuDOk6epfM7yD6J8Pol4NUCy1vkaGAkuujZm0+lNow//MKu1hLhRiYV4BsOHyBv5/lsTjF+7hWwhJg==
+  dependencies:
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    bn.js "^4.11.9"
+
+"@ethersproject/bytes@5.4.0", "@ethersproject/bytes@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.4.0.tgz#56fa32ce3bf67153756dbaefda921d1d4774404e"
+  integrity sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==
+  dependencies:
+    "@ethersproject/logger" "^5.4.0"
+
+"@ethersproject/constants@5.4.0", "@ethersproject/constants@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.4.0.tgz#ee0bdcb30bf1b532d2353c977bf2ef1ee117958a"
+  integrity sha512-tzjn6S7sj9+DIIeKTJLjK9WGN2Tj0P++Z8ONEIlZjyoTkBuODN+0VfhAyYksKi43l1Sx9tX2VlFfzjfmr5Wl3Q==
+  dependencies:
+    "@ethersproject/bignumber" "^5.4.0"
+
+"@ethersproject/contracts@5.4.1":
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/contracts/-/contracts-5.4.1.tgz#3eb4f35b7fe60a962a75804ada2746494df3e470"
+  integrity sha512-m+z2ZgPy4pyR15Je//dUaymRUZq5MtDajF6GwFbGAVmKz/RF+DNIPwF0k5qEcL3wPGVqUjFg2/krlCRVTU4T5w==
+  dependencies:
+    "@ethersproject/abi" "^5.4.0"
+    "@ethersproject/abstract-provider" "^5.4.0"
+    "@ethersproject/abstract-signer" "^5.4.0"
+    "@ethersproject/address" "^5.4.0"
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/constants" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+    "@ethersproject/transactions" "^5.4.0"
+
+"@ethersproject/hash@5.4.0", "@ethersproject/hash@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.4.0.tgz#d18a8e927e828e22860a011f39e429d388344ae0"
+  integrity sha512-xymAM9tmikKgbktOCjW60Z5sdouiIIurkZUr9oW5NOex5uwxrbsYG09kb5bMcNjlVeJD3yPivTNzViIs1GCbqA==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.4.0"
+    "@ethersproject/address" "^5.4.0"
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/keccak256" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+    "@ethersproject/strings" "^5.4.0"
+
+"@ethersproject/hdnode@5.4.0", "@ethersproject/hdnode@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hdnode/-/hdnode-5.4.0.tgz#4bc9999b9a12eb5ce80c5faa83114a57e4107cac"
+  integrity sha512-pKxdS0KAaeVGfZPp1KOiDLB0jba11tG6OP1u11QnYfb7pXn6IZx0xceqWRr6ygke8+Kw74IpOoSi7/DwANhy8Q==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.4.0"
+    "@ethersproject/basex" "^5.4.0"
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/pbkdf2" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+    "@ethersproject/sha2" "^5.4.0"
+    "@ethersproject/signing-key" "^5.4.0"
+    "@ethersproject/strings" "^5.4.0"
+    "@ethersproject/transactions" "^5.4.0"
+    "@ethersproject/wordlists" "^5.4.0"
+
+"@ethersproject/json-wallets@5.4.0", "@ethersproject/json-wallets@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/json-wallets/-/json-wallets-5.4.0.tgz#2583341cfe313fc9856642e8ace3080154145e95"
+  integrity sha512-igWcu3fx4aiczrzEHwG1xJZo9l1cFfQOWzTqwRw/xcvxTk58q4f9M7cjh51EKphMHvrJtcezJ1gf1q1AUOfEQQ==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.4.0"
+    "@ethersproject/address" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/hdnode" "^5.4.0"
+    "@ethersproject/keccak256" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/pbkdf2" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+    "@ethersproject/random" "^5.4.0"
+    "@ethersproject/strings" "^5.4.0"
+    "@ethersproject/transactions" "^5.4.0"
+    aes-js "3.0.0"
+    scrypt-js "3.0.1"
+
+"@ethersproject/keccak256@5.4.0", "@ethersproject/keccak256@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.4.0.tgz#7143b8eea4976080241d2bd92e3b1f1bf7025318"
+  integrity sha512-FBI1plWet+dPUvAzPAeHzRKiPpETQzqSUWR1wXJGHVWi4i8bOSrpC3NwpkPjgeXG7MnugVc1B42VbfnQikyC/A==
+  dependencies:
+    "@ethersproject/bytes" "^5.4.0"
+    js-sha3 "0.5.7"
+
+"@ethersproject/logger@5.4.0", "@ethersproject/logger@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.4.0.tgz#f39adadf62ad610c420bcd156fd41270e91b3ca9"
+  integrity sha512-xYdWGGQ9P2cxBayt64d8LC8aPFJk6yWCawQi/4eJ4+oJdMMjEBMrIcIMZ9AxhwpPVmnBPrsB10PcXGmGAqgUEQ==
+
+"@ethersproject/networks@5.4.2", "@ethersproject/networks@^5.4.0":
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/networks/-/networks-5.4.2.tgz#2247d977626e97e2c3b8ee73cd2457babde0ce35"
+  integrity sha512-eekOhvJyBnuibfJnhtK46b8HimBc5+4gqpvd1/H9LEl7Q7/qhsIhM81dI9Fcnjpk3jB1aTy6bj0hz3cifhNeYw==
+  dependencies:
+    "@ethersproject/logger" "^5.4.0"
+
+"@ethersproject/pbkdf2@5.4.0", "@ethersproject/pbkdf2@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/pbkdf2/-/pbkdf2-5.4.0.tgz#ed88782a67fda1594c22d60d0ca911a9d669641c"
+  integrity sha512-x94aIv6tiA04g6BnazZSLoRXqyusawRyZWlUhKip2jvoLpzJuLb//KtMM6PEovE47pMbW+Qe1uw+68ameJjB7g==
+  dependencies:
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/sha2" "^5.4.0"
+
+"@ethersproject/properties@5.4.0", "@ethersproject/properties@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.4.0.tgz#38ba20539b44dcc5d5f80c45ad902017dcdbefe7"
+  integrity sha512-7jczalGVRAJ+XSRvNA6D5sAwT4gavLq3OXPuV/74o3Rd2wuzSL035IMpIMgei4CYyBdialJMrTqkOnzccLHn4A==
+  dependencies:
+    "@ethersproject/logger" "^5.4.0"
+
+"@ethersproject/providers@5.4.3":
+  version "5.4.3"
+  resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.4.3.tgz#4cd7ccd9e12bc3875b33df8b24abf735663958a5"
+  integrity sha512-VURwkaWPoUj7jq9NheNDT5Iyy64Qcyf6BOFDwVdHsmLmX/5prNjFrgSX3GHPE4z1BRrVerDxe2yayvXKFm/NNg==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.4.0"
+    "@ethersproject/abstract-signer" "^5.4.0"
+    "@ethersproject/address" "^5.4.0"
+    "@ethersproject/basex" "^5.4.0"
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/constants" "^5.4.0"
+    "@ethersproject/hash" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/networks" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+    "@ethersproject/random" "^5.4.0"
+    "@ethersproject/rlp" "^5.4.0"
+    "@ethersproject/sha2" "^5.4.0"
+    "@ethersproject/strings" "^5.4.0"
+    "@ethersproject/transactions" "^5.4.0"
+    "@ethersproject/web" "^5.4.0"
+    bech32 "1.1.4"
+    ws "7.4.6"
+
+"@ethersproject/random@5.4.0", "@ethersproject/random@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/random/-/random-5.4.0.tgz#9cdde60e160d024be39cc16f8de3b9ce39191e16"
+  integrity sha512-pnpWNQlf0VAZDEOVp1rsYQosmv2o0ITS/PecNw+mS2/btF8eYdspkN0vIXrCMtkX09EAh9bdk8GoXmFXM1eAKw==
+  dependencies:
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+
+"@ethersproject/rlp@5.4.0", "@ethersproject/rlp@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/rlp/-/rlp-5.4.0.tgz#de61afda5ff979454e76d3b3310a6c32ad060931"
+  integrity sha512-0I7MZKfi+T5+G8atId9QaQKHRvvasM/kqLyAH4XxBCBchAooH2EX5rL9kYZWwcm3awYV+XC7VF6nLhfeQFKVPg==
+  dependencies:
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+
+"@ethersproject/sha2@5.4.0", "@ethersproject/sha2@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/sha2/-/sha2-5.4.0.tgz#c9a8db1037014cbc4e9482bd662f86c090440371"
+  integrity sha512-siheo36r1WD7Cy+bDdE1BJ8y0bDtqXCOxRMzPa4bV1TGt/eTUUt03BHoJNB6reWJD8A30E/pdJ8WFkq+/uz4Gg==
+  dependencies:
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    hash.js "1.1.7"
+
+"@ethersproject/signing-key@5.4.0", "@ethersproject/signing-key@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/signing-key/-/signing-key-5.4.0.tgz#2f05120984e81cf89a3d5f6dec5c68ee0894fbec"
+  integrity sha512-q8POUeywx6AKg2/jX9qBYZIAmKSB4ubGXdQ88l40hmATj29JnG5pp331nAWwwxPn2Qao4JpWHNZsQN+bPiSW9A==
+  dependencies:
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+    bn.js "^4.11.9"
+    elliptic "6.5.4"
+    hash.js "1.1.7"
+
+"@ethersproject/solidity@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/solidity/-/solidity-5.4.0.tgz#1305e058ea02dc4891df18b33232b11a14ece9ec"
+  integrity sha512-XFQTZ7wFSHOhHcV1DpcWj7VXECEiSrBuv7JErJvB9Uo+KfCdc3QtUZV+Vjh/AAaYgezUEKbCtE6Khjm44seevQ==
+  dependencies:
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/keccak256" "^5.4.0"
+    "@ethersproject/sha2" "^5.4.0"
+    "@ethersproject/strings" "^5.4.0"
+
+"@ethersproject/strings@5.4.0", "@ethersproject/strings@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.4.0.tgz#fb12270132dd84b02906a8d895ae7e7fa3d07d9a"
+  integrity sha512-k/9DkH5UGDhv7aReXLluFG5ExurwtIpUfnDNhQA29w896Dw3i4uDTz01Quaptbks1Uj9kI8wo9tmW73wcIEaWA==
+  dependencies:
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/constants" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+
+"@ethersproject/transactions@5.4.0", "@ethersproject/transactions@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.4.0.tgz#a159d035179334bd92f340ce0f77e83e9e1522e0"
+  integrity sha512-s3EjZZt7xa4BkLknJZ98QGoIza94rVjaEed0rzZ/jB9WrIuu/1+tjvYCWzVrystXtDswy7TPBeIepyXwSYa4WQ==
+  dependencies:
+    "@ethersproject/address" "^5.4.0"
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/constants" "^5.4.0"
+    "@ethersproject/keccak256" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+    "@ethersproject/rlp" "^5.4.0"
+    "@ethersproject/signing-key" "^5.4.0"
+
+"@ethersproject/units@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/units/-/units-5.4.0.tgz#d57477a4498b14b88b10396062c8cbbaf20c79fe"
+  integrity sha512-Z88krX40KCp+JqPCP5oPv5p750g+uU6gopDYRTBGcDvOASh6qhiEYCRatuM/suC4S2XW9Zz90QI35MfSrTIaFg==
+  dependencies:
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/constants" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+
+"@ethersproject/wallet@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/wallet/-/wallet-5.4.0.tgz#fa5b59830b42e9be56eadd45a16a2e0933ad9353"
+  integrity sha512-wU29majLjM6AjCjpat21mPPviG+EpK7wY1+jzKD0fg3ui5fgedf2zEu1RDgpfIMsfn8fJHJuzM4zXZ2+hSHaSQ==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.4.0"
+    "@ethersproject/abstract-signer" "^5.4.0"
+    "@ethersproject/address" "^5.4.0"
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/hash" "^5.4.0"
+    "@ethersproject/hdnode" "^5.4.0"
+    "@ethersproject/json-wallets" "^5.4.0"
+    "@ethersproject/keccak256" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+    "@ethersproject/random" "^5.4.0"
+    "@ethersproject/signing-key" "^5.4.0"
+    "@ethersproject/transactions" "^5.4.0"
+    "@ethersproject/wordlists" "^5.4.0"
+
+"@ethersproject/web@5.4.0", "@ethersproject/web@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.4.0.tgz#49fac173b96992334ed36a175538ba07a7413d1f"
+  integrity sha512-1bUusGmcoRLYgMn6c1BLk1tOKUIFuTg8j+6N8lYlbMpDesnle+i3pGSagGNvwjaiLo4Y5gBibwctpPRmjrh4Og==
+  dependencies:
+    "@ethersproject/base64" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+    "@ethersproject/strings" "^5.4.0"
+
+"@ethersproject/wordlists@5.4.0", "@ethersproject/wordlists@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/wordlists/-/wordlists-5.4.0.tgz#f34205ec3bbc9e2c49cadaee774cf0b07e7573d7"
+  integrity sha512-FemEkf6a+EBKEPxlzeVgUaVSodU7G0Na89jqKjmWMlDB0tomoU8RlEMgUvXyqtrg8N4cwpLh8nyRnm1Nay1isA==
+  dependencies:
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/hash" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+    "@ethersproject/strings" "^5.4.0"
+
 "@evocateur/libnpmaccess@^3.1.2":
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/@evocateur/libnpmaccess/-/libnpmaccess-3.1.2.tgz#ecf7f6ce6b004e9f942b098d92200be4a4b1c845"
@@ -4107,6 +4446,11 @@ bcryptjs@^2.4.3:
   resolved "https://registry.yarnpkg.com/bcryptjs/-/bcryptjs-2.4.3.tgz#9ab5627b93e60621ff7cdac5da9733027df1d0cb"
   integrity sha1-mrVie5PmBiH/fNrF2pczAn3x0Ms=
 
+bech32@1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
+  integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
+
 before-after-hook@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.1.0.tgz#b6c03487f44e24200dd30ca5e6a1979c5d2fb635"
@@ -4218,6 +4562,11 @@ bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.4.0:
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.9.tgz#26d556829458f9d1e81fc48952493d0ba3507828"
   integrity sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==
 
+bn.js@^4.11.9:
+  version "4.12.0"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
+  integrity sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==
+
 bn.js@^5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.1.2.tgz#c9686902d3c9a27729f43ab10f9d79c2004da7b0"
@@ -4319,7 +4668,7 @@ braces@^3.0.1, braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
-brorand@^1.0.1:
+brorand@^1.0.1, brorand@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
   integrity sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=
@@ -6383,18 +6732,18 @@ electron-to-chromium@^1.3.378, electron-to-chromium@^1.3.488:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.515.tgz#96683d2c2be9bf83f6cca75d504a7b443d763c08"
   integrity sha512-C9h2yLQwNSK/GTtWQsA9O6mLKv0ubmiAQgmz1HvHnAIH8g5Sje1shWxcooumbGiwgqvZ9yrTYULe4seMTgMYqQ==
 
-elliptic@6.5.2:
-  version "6.5.2"
-  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.2.tgz#05c5678d7173c049d8ca433552224a495d0e3762"
-  integrity sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==
+elliptic@6.5.4:
+  version "6.5.4"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
+  integrity sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==
   dependencies:
-    bn.js "^4.4.0"
-    brorand "^1.0.1"
+    bn.js "^4.11.9"
+    brorand "^1.1.0"
     hash.js "^1.0.0"
-    hmac-drbg "^1.0.0"
-    inherits "^2.0.1"
-    minimalistic-assert "^1.0.0"
-    minimalistic-crypto-utils "^1.0.0"
+    hmac-drbg "^1.0.1"
+    inherits "^2.0.4"
+    minimalistic-assert "^1.0.1"
+    minimalistic-crypto-utils "^1.0.1"
 
 elliptic@^6.0.0, elliptic@^6.5.2:
   version "6.5.3"
@@ -6940,20 +7289,41 @@ ethereum-blockies-base64@^1.0.2:
   dependencies:
     pnglib "0.0.1"
 
-ethers@^4.0.38:
-  version "4.0.47"
-  resolved "https://registry.yarnpkg.com/ethers/-/ethers-4.0.47.tgz#91b9cd80473b1136dd547095ff9171bd1fc68c85"
-  integrity sha512-hssRYhngV4hiDNeZmVU/k5/E8xmLG8UpcNUzg6mb7lqhgpFPH/t7nuv20RjRrEf0gblzvi2XwR5Te+V3ZFc9pQ==
+ethers@^5.4.4:
+  version "5.4.4"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.4.4.tgz#35cce530505b84c699da944162195cfb3f894947"
+  integrity sha512-zaTs8yaDjfb0Zyj8tT6a+/hEkC+kWAA350MWRp6yP5W7NdGcURRPMOpOU+6GtkfxV9wyJEShWesqhE/TjdqpMA==
   dependencies:
-    aes-js "3.0.0"
-    bn.js "^4.4.0"
-    elliptic "6.5.2"
-    hash.js "1.1.3"
-    js-sha3 "0.5.7"
-    scrypt-js "2.0.4"
-    setimmediate "1.0.4"
-    uuid "2.0.1"
-    xmlhttprequest "1.8.0"
+    "@ethersproject/abi" "5.4.0"
+    "@ethersproject/abstract-provider" "5.4.1"
+    "@ethersproject/abstract-signer" "5.4.1"
+    "@ethersproject/address" "5.4.0"
+    "@ethersproject/base64" "5.4.0"
+    "@ethersproject/basex" "5.4.0"
+    "@ethersproject/bignumber" "5.4.1"
+    "@ethersproject/bytes" "5.4.0"
+    "@ethersproject/constants" "5.4.0"
+    "@ethersproject/contracts" "5.4.1"
+    "@ethersproject/hash" "5.4.0"
+    "@ethersproject/hdnode" "5.4.0"
+    "@ethersproject/json-wallets" "5.4.0"
+    "@ethersproject/keccak256" "5.4.0"
+    "@ethersproject/logger" "5.4.0"
+    "@ethersproject/networks" "5.4.2"
+    "@ethersproject/pbkdf2" "5.4.0"
+    "@ethersproject/properties" "5.4.0"
+    "@ethersproject/providers" "5.4.3"
+    "@ethersproject/random" "5.4.0"
+    "@ethersproject/rlp" "5.4.0"
+    "@ethersproject/sha2" "5.4.0"
+    "@ethersproject/signing-key" "5.4.0"
+    "@ethersproject/solidity" "5.4.0"
+    "@ethersproject/strings" "5.4.0"
+    "@ethersproject/transactions" "5.4.0"
+    "@ethersproject/units" "5.4.0"
+    "@ethersproject/wallet" "5.4.0"
+    "@ethersproject/web" "5.4.0"
+    "@ethersproject/wordlists" "5.4.0"
 
 event-emitter@^0.3.5:
   version "0.3.5"
@@ -8102,15 +8472,7 @@ hash-base@^3.0.0:
     readable-stream "^3.6.0"
     safe-buffer "^5.2.0"
 
-hash.js@1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.3.tgz#340dedbe6290187151c1ea1d777a3448935df846"
-  integrity sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==
-  dependencies:
-    inherits "^2.0.3"
-    minimalistic-assert "^1.0.0"
-
-hash.js@^1.0.0, hash.js@^1.0.3:
+hash.js@1.1.7, hash.js@^1.0.0, hash.js@^1.0.3:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
   integrity sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==
@@ -8145,7 +8507,7 @@ history@^4.9.0:
     tiny-warning "^1.0.0"
     value-equal "^1.0.1"
 
-hmac-drbg@^1.0.0:
+hmac-drbg@^1.0.0, hmac-drbg@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
   integrity sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=
@@ -14480,10 +14842,10 @@ schema-utils@^2.5.0, schema-utils@^2.6.0, schema-utils@^2.6.1, schema-utils@^2.6
     ajv "^6.12.2"
     ajv-keywords "^3.4.1"
 
-scrypt-js@2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/scrypt-js/-/scrypt-js-2.0.4.tgz#32f8c5149f0797672e551c07e230f834b6af5f16"
-  integrity sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw==
+scrypt-js@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/scrypt-js/-/scrypt-js-3.0.1.tgz#d314a57c2aef69d1ad98a138a21fe9eafa9ee312"
+  integrity sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==
 
 scss-tokenizer@^0.2.3:
   version "0.2.3"
@@ -14617,11 +14979,6 @@ set-value@^2.0.0, set-value@^2.0.1:
     is-extendable "^0.1.1"
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
-
-setimmediate@1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.4.tgz#20e81de622d4a02588ce0c8da8973cbcf1d3138f"
-  integrity sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48=
 
 setimmediate@^1.0.4:
   version "1.0.5"
@@ -16377,11 +16734,6 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
-uuid@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.1.tgz#c2a30dedb3e535d72ccf82e343941a50ba8533ac"
-  integrity sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=
-
 uuid@^3.0.1, uuid@^3.2.1, uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
@@ -17047,6 +17399,11 @@ write@1.0.3:
   dependencies:
     mkdirp "^0.5.1"
 
+ws@7.4.6:
+  version "7.4.6"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
+  integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
+
 ws@^5.2.0:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.2.tgz#dffef14866b8e8dc9133582514d1befaf96e980f"
@@ -17102,11 +17459,6 @@ xmlhttprequest-ssl@~1.5.4:
   version "1.5.5"
   resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz#c2876b06168aadc40e57d97e81191ac8f4398b3e"
   integrity sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=
-
-xmlhttprequest@1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz#67fe075c5c24fef39f9d65f5f7b7fe75171968fc"
-  integrity sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=
 
 xregexp@^4.3.0:
   version "4.3.0"


### PR DESCRIPTION
## Current situation

Right now the dappstore is only showing packages from the custom **[directory](https://etherscan.io/address/0xf19F629642C6697Af77d8316BeF8DE0de3A27a70)** SC which at the end, points to the APM registry with the ENS **[dnp.dappnode.eth](https://etherscan.io/address/0x266bfdb2124a68beb6769dc887bd655f78778923)**. This is controlled by dappnode association

## Dappstore decentralization roadmap
On the roadmap of the decentralization of the dappstore, has been taken as the first approach to allow showing in the dappstore dappnode packages from the APM registry with ENS:
- **[public.dappnode.eth](https://etherscan.io/address/0x9f85ae5aefe4a3eff39d9a44212aae21dd15079a)**: this domain will be the default one to be shown
- **<custom>.dappnode.eth**

These domains must be shown with big warnings advising of the potential danger to download and install those packages

## PR changes
- Definition of registry SC (abi, address, etc)
- Updated ethers library
- Fetch APM registry SC logs
- Parse logs and get dappnode packages names from logs
- Create similar data to the already created Directory data structure
- Tests for all the new backend functionalities

## Todo
- [ ] Backend
- [ ] Backend tests
- [ ] Frontend 
   - [ ] Button for **public.dappnode.eth** and searcher for **<custom>.dappnode.eth**
   - [ ] Big warnings for both options from above
   - [ ] Dappstore for Registry (copy logic from Directory and modify it with small changes in the data structure)
- [ ] Frontend review
