### PR TITLE
Allow manifest to be yaml

### DIFF
--- a/packages/dappmanager/src/params.ts
+++ b/packages/dappmanager/src/params.ts
@@ -334,7 +334,7 @@ export const getContainerName = ({
 
 export const releaseFiles = {
   manifest: {
-    regex: /dappnode_package.*\.json$/,
+    regex: /dappnode_package.*\.(json|yaml|yml)$/,
     format: FileFormat.YAML,
     maxSize: 100e3, // Limit size to ~100KB
     required: true as const,


### PR DESCRIPTION
The manifest is now parsed as YAML, but the path was not updated so it won't work.

@tropicar Could you do the same change in the DAppNodeSDK? `src/params.ts` has the same list of values. Then could you test that the DAPPMANAGER is able to install a package with a YAML manifest?