### PR TITLE
Connect wallet feature (blocked)

### DIFF
--- a/packages/admin-ui/src/__mock-backend__/index.ts
+++ b/packages/admin-ui/src/__mock-backend__/index.ts
@@ -224,7 +224,39 @@ export const otherCalls: Omit<Routes, keyof typeof namedSpacedCalls> = {
   runHostSecurityUpdates: async () =>
     "Security updates have been executed successfully, no reboot needed",
   natRenewalEnable: async () => {},
-  natRenewalIsEnabled: async () => true
+  natRenewalIsEnabled: async () => true,
+  ethClientsGet: async () => [
+    {
+      ok: true,
+      url: "http://geth.dappnode:8545",
+      dnpName: "geth.dnp.dappnode.eth",
+      chainId: "0x1"
+    },
+    {
+      ok: true,
+      url: "http://goerli-geth.dappnode:8545",
+      dnpName: "goerli-geth.dnp.dappnode.eth",
+      chainId: "0x5"
+    },
+    {
+      ok: true,
+      url: "http://nethermind-xdai.dappnode:8545",
+      dnpName: "nethermind-xdai.dnp.dappnode.eth",
+      chainId: "0x64"
+    },
+    {
+      ok: true,
+      url: "http://ropsten.dappnode:8545",
+      dnpName: "ropsten.dnp.dappnode.eth",
+      chainId: "0x3"
+    },
+    {
+      ok: true,
+      url: "http://rinkeby.dappnode:8545",
+      dnpName: "rinkeby.dnp.dappnode.eth",
+      chainId: "0x4"
+    }
+  ]
 };
 
 export const calls: Routes = {

--- a/packages/admin-ui/src/common/routes.ts
+++ b/packages/admin-ui/src/common/routes.ts
@@ -37,7 +37,8 @@ import {
   InstalledPackageDataApiReturn,
   WifiReport,
   CurrentWifiCredentials,
-  LocalProxyingStatus
+  LocalProxyingStatus,
+  EthClient
 } from "./types";
 
 export interface Routes {
@@ -208,6 +209,11 @@ export interface Routes {
     target: EthClientTarget;
     deletePrevEthClient?: boolean;
   }) => Promise<void>;
+
+  /**
+   * Return array of available clients to connect a wallet (i.e metmask)
+   */
+  ethClientsGet: () => Promise<EthClient[]>;
 
   /**
    * Return formated core update data
@@ -618,6 +624,7 @@ export const routesData: { [P in keyof Routes]: RouteData } = {
   dockerEngineUpdateCheck: {},
   ethClientFallbackSet: { log: true },
   ethClientTargetSet: { log: true },
+  ethClientsGet: {},
   fetchCoreUpdateData: {},
   fetchDirectory: {},
   fetchDnpRequest: {},

--- a/packages/admin-ui/src/common/routes.ts
+++ b/packages/admin-ui/src/common/routes.ts
@@ -38,7 +38,7 @@ import {
   WifiReport,
   CurrentWifiCredentials,
   LocalProxyingStatus,
-  EthClient
+  EthClientWallet
 } from "./types";
 
 export interface Routes {
@@ -213,7 +213,7 @@ export interface Routes {
   /**
    * Return array of available clients to connect a wallet (i.e metmask)
    */
-  ethClientsGet: () => Promise<EthClient[]>;
+  ethClientsGet: () => Promise<EthClientWallet[]>;
 
   /**
    * Return formated core update data

--- a/packages/admin-ui/src/common/types.ts
+++ b/packages/admin-ui/src/common/types.ts
@@ -1189,6 +1189,13 @@ export interface VolumeData extends VolumeOwnershipData {
   fileSystem?: MountpointData;
 }
 
+export type EthClients = "geth" | "erigon" | "nethermind" | "turbogeth";
+export interface EthClient {
+  ethclient: Partial<EthClients>;
+  status: EthClientStatus;
+  rpcEndpoint: string;
+}
+
 /**
  * Eth provider / client types
  * Manage the Ethereum multi-client setup

--- a/packages/admin-ui/src/common/types.ts
+++ b/packages/admin-ui/src/common/types.ts
@@ -1189,13 +1189,6 @@ export interface VolumeData extends VolumeOwnershipData {
   fileSystem?: MountpointData;
 }
 
-export type EthClients = "geth" | "erigon" | "nethermind" | "turbogeth";
-export interface EthClient {
-  ethclient: Partial<EthClients>;
-  status: EthClientStatus;
-  rpcEndpoint: string;
-}
-
 /**
  * Eth provider / client types
  * Manage the Ethereum multi-client setup
@@ -1221,9 +1214,13 @@ export type EthClientFallback = "on" | "off";
 
 export type EthClientStatus = EthClientStatusOk | EthClientStatusError;
 
+export type EthClientWallet = EthClientWalletOk | EthClientStatusError;
+
 export type EthClientStatusOk =
   // All okay, client is functional
   { ok: true; url: string; dnpName: string };
+
+export type EthClientWalletOk = EthClientStatusOk & { chainId: string };
 
 export type EthClientStatusError =
   // Unexpected error

--- a/packages/admin-ui/src/pages/dashboard/components/ConnectWallet.tsx
+++ b/packages/admin-ui/src/pages/dashboard/components/ConnectWallet.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { ethers } from "ethers";
+import CardList from "components/CardList";
+import { useApi } from "api";
+import ErrorView from "components/ErrorView";
+import Ok from "components/Ok";
+import Alert from "react-bootstrap/esm/Alert";
+
+declare global {
+  interface Window {
+    ethereum: any;
+  }
+}
+
+export default function ConnectWallet() {
+  const ethClients = useApi.ethClientsGet();
+
+  async function connectWallet() {
+    await window.ethereum.enable();
+    const provider = new ethers.providers.Web3Provider(window.ethereum);
+  }
+
+  if (ethClients.error)
+    return <ErrorView error={ethClients.error} hideIcon red />;
+  if (ethClients.isValidating) return <Ok loading msg="Loading eth clients" />;
+  if (!ethClients.data) return <ErrorView error={"No data"} hideIcon red />;
+
+  return (
+    <div className="dashboard-cards">
+      <div className="connect-wallet">
+        {ethClients.data.length === 0 ? (
+          <Alert className="connect-wallet-card" variant="success">
+            No eth client detected, get one from the dappstore
+          </Alert>
+        ) : (
+          <CardList className="connect-wallet">
+            {ethClients.data.map(ethClient => (
+              <span></span>
+            ))}
+          </CardList>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/admin-ui/src/pages/dashboard/components/Dashboard.tsx
+++ b/packages/admin-ui/src/pages/dashboard/components/Dashboard.tsx
@@ -9,6 +9,7 @@ import SubTitle from "components/SubTitle";
 import Title from "components/Title";
 
 import "./dashboard.scss";
+import ConnectWallet from "./ConnectWallet";
 
 export default function Dashboard() {
   return (
@@ -19,6 +20,9 @@ export default function Dashboard() {
         <div className="dashboard-right">
           <SubTitle>Package updates</SubTitle>
           <PackageUpdates />
+
+          <SubTitle>Connect wallet</SubTitle>
+          <ConnectWallet />
         </div>
 
         <div className="dashboard-left">

--- a/packages/admin-ui/src/pages/dashboard/components/dashboard.scss
+++ b/packages/admin-ui/src/pages/dashboard/components/dashboard.scss
@@ -27,7 +27,8 @@
     grid-template-columns: repeat(auto-fill, minmax(7.5em, 1fr));
   }
 
-  .package-updates {
+  .package-updates,
+  .connect-wallet {
     // Give the single card a max width that matches the other cards
     grid-column: 1 / 4;
   }
@@ -76,7 +77,8 @@
 
 // Package updates card
 
-.package-update-item {
+.package-update-item,
+.connect-wallet-item {
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/packages/dappmanager/src/calls/ethClientsGet.ts
+++ b/packages/dappmanager/src/calls/ethClientsGet.ts
@@ -1,3 +1,5 @@
-import { EthClient } from "../types";
+import { EthClientWallet } from "../types";
 
-export async function ethClientsGet(): Promise<EthClient[]> {}
+export async function ethClientsGet(): Promise<EthClientWallet[]> {
+  return [];
+}

--- a/packages/dappmanager/src/calls/ethClientsGet.ts
+++ b/packages/dappmanager/src/calls/ethClientsGet.ts
@@ -1,0 +1,3 @@
+import { EthClient } from "../types";
+
+export async function ethClientsGet(): Promise<EthClient[]> {}

--- a/packages/dappmanager/src/calls/index.ts
+++ b/packages/dappmanager/src/calls/index.ts
@@ -12,6 +12,7 @@ export * from "./dockerUpdate";
 export { dappnodeWebNameSet } from "./dappnodeWebNameSet";
 export { ethClientTargetSet } from "./ethClientTargetSet";
 export { ethClientFallbackSet } from "./ethClientFallbackSet";
+export { ethClientsGet } from "./ethClientsGet";
 export { fetchCoreUpdateData } from "./fetchCoreUpdateData";
 export { fetchDirectory } from "./fetchDirectory";
 export { fetchDnpRequest } from "./fetchDnpRequest";


### PR DESCRIPTION
### UIX improvement
This PR aims to facilitate to the user how to connect his/her wallet to any RPC endpoint of a package. Right now the procedure is:
- Get the RPC endpoint from the package view
- Get the chain ID of the blockchain app
- Open a wallet provider such as metamask and create a new network based on these values

Ideally, the user would just need to click a button and a new pop-up from metamask would get into action asking to add a new network called "DAppNode geth" or similar with all those values already fulfilled. This is possible to achieve with `switchEthereumChain` and `addEthereumChain` from the Metamask API: https://docs.metamask.io/guide/rpc-api.html#usage-with-wallet-switchethereumchain

The result should look something similar to 
![image](https://user-images.githubusercontent.com/41727368/129685489-9fbea78d-3732-464b-b1d1-456bd8418be4.png)


### Blockers
- No possible to add a new network with a chain ID mark as "default" by Metamask: Ethereum mainnet (0x1), Rinkeby (0x4), Goerli (0x5), Ropsten (0x3) and Koban()
- Not possible to use RPC urls without **HTTPS**
