### PR TITLE
removed vpn from mandatory package

### DIFF
--- a/packages/admin-ui/src/params.ts
+++ b/packages/admin-ui/src/params.ts
@@ -52,7 +52,6 @@ export const vpnDnpName = "vpn.dnp.dappnode.eth";
 export const dappmanagerDnpName = "dappmanager.dnp.dappnode.eth";
 export const mandatoryCoreDnps = [
   dappmanagerDnpName,
-  vpnDnpName,
   ipfsDnpName,
   bindDnpName
   // WIFI package is not mandatory to be running


### PR DESCRIPTION
VPN is not longer a mandatory core package, it can be removed/installed on demmand. For this reason it must be removed from the support check