### PR TITLE
Add bug link on packages view

### DIFF
--- a/packages/admin-ui/src/pages/packages/components/Info/Links.tsx
+++ b/packages/admin-ui/src/pages/packages/components/Info/Links.tsx
@@ -2,8 +2,15 @@ import React from "react";
 import newTabProps from "utils/newTabProps";
 import { MdHome, MdSettingsRemote, MdSettings, MdInfo } from "react-icons/md";
 import { PackageReleaseMetadata } from "types";
+import { AiFillBug } from "react-icons/ai";
 
-export function Links({ links }: { links: PackageReleaseMetadata["links"] }) {
+export function Links({
+  links,
+  bugs
+}: {
+  links: PackageReleaseMetadata["links"];
+  bugs: PackageReleaseMetadata["bugs"];
+}) {
   const linksArray =
     typeof links === "object"
       ? Object.entries(links || {})
@@ -15,11 +22,14 @@ export function Links({ links }: { links: PackageReleaseMetadata["links"] }) {
       ? [{ name: "homepage", url: links }]
       : [];
 
+  if (linksArray && bugs) linksArray.push({ name: "report", url: bugs.url });
+
   const items = linksArray.map(({ name, url }) =>
     name === "homepage" ||
     name === "ui" ||
     name === "webui" ||
-    name === "gateway" ? (
+    name === "gateway" ||
+    name === "report" ? (
       <a className="links-url" href={url} {...newTabProps}>
         <span className="links-icon">
           {name === "homepage" ? (
@@ -28,6 +38,8 @@ export function Links({ links }: { links: PackageReleaseMetadata["links"] }) {
             <MdHome />
           ) : name === "gateway" ? (
             <MdSettingsRemote />
+          ) : name === "report" ? (
+            <AiFillBug />
           ) : null}
         </span>
         <span>{name}</span>

--- a/packages/admin-ui/src/pages/packages/components/Info/index.tsx
+++ b/packages/admin-ui/src/pages/packages/components/Info/index.tsx
@@ -33,7 +33,7 @@ export function Info({
   // Show the version from `docker ps`, which the one affecting logic
   const { dnpName, version, origin } = dnp;
   // Show the upstream version from the manifest which is used for metadata only
-  const { upstreamVersion, links } = manifest || {};
+  const { upstreamVersion, links, bugs } = manifest || {};
 
   useEffect(() => {
     setGettingStartedIsShown(Boolean(gettingStartedShow));
@@ -108,7 +108,10 @@ export function Info({
 
           <div>
             {/* Support legacy manifests,  homepage = {userui: "http://some.link"} */}
-            <Links links={links || ((manifest as any) || {}).homepage || {}} />
+            <Links
+              links={links || ((manifest as any) || {}).homepage || {}}
+              bugs={bugs || ((manifest as any) || {}).url || {}}
+            />
           </div>
         </div>
 


### PR DESCRIPTION
This button aims to redirect users to the **bugs** URL provided in the package manifest, in order to move support from dappnode to upstream projects.

UIX

![image](https://user-images.githubusercontent.com/41727368/130053972-1400125a-a4f6-4c42-bfe8-9d1cdcc3ec86.png)
