### PR TITLE
Set dyndns on dappmanager startup faster

### DIFF
--- a/packages/dappmanager/src/daemons/dyndns/index.ts
+++ b/packages/dappmanager/src/daemons/dyndns/index.ts
@@ -76,7 +76,7 @@ async function shouldUpdate(): Promise<boolean> {
  * On any doubt, update the IP
  */
 
-async function checkIpAndUpdateIfNecessary(): Promise<void> {
+export async function checkIpAndUpdateIfNecessary(): Promise<void> {
   try {
     const isStaticIpSet = Boolean(db.staticIp.get());
     if (isStaticIpSet) return;


### PR DESCRIPTION
Dyndns is needed for other services to be exposed on the dappmanager API as soon as possible. This process may take a little time on dappmanager startup due to other processes such as getting IPs or other daemons.

- Get dynds on dappmanager startup
- Set dynds on db before start dappmanager api