### PR TITLE
Render link in package sent data

### DIFF
--- a/packages/admin-ui/src/__mock-backend__/data/dnps/lightningNetwork.ts
+++ b/packages/admin-ui/src/__mock-backend__/data/dnps/lightningNetwork.ts
@@ -168,7 +168,9 @@ Content in the first column | Content in the second column
     },
     packageSentData: {
       apiKey: "AAXXAAXXAAXXAAXXAAXXAAXXAAXXAAXXAAXXAAXX",
-      secretKey: "ZZXXZZXXZZXXZZXXZZXXZZXXZZXXZZXXZZXXZZXX"
+      secretKey: "ZZXXZZXXZZXXZZXXZZXXZZXXZZXXZZXXZZXXZZXX",
+      link:
+        "http://lightningNetwork.dappnode.eth/initialize?token=geagehTEGEgeg36eb.NIGE43"
     }
   },
   installedContainers: {

--- a/packages/admin-ui/src/pages/packages/components/Info/PackageSentData.tsx
+++ b/packages/admin-ui/src/pages/packages/components/Info/PackageSentData.tsx
@@ -72,7 +72,7 @@ function SentDataRow({
   isSecret
 }: {
   value: string;
-  isLink: boolean;
+  isLink?: boolean;
   isSecret?: boolean;
 }) {
   const [show, setShow] = useState(false);
@@ -85,7 +85,9 @@ function SentDataRow({
   return (
     <InputGroup>
       {isLink ? (
-        <Link to={value}>{value}</Link>
+        <Link className="form-control link-box" to={value}>
+          {value}
+        </Link>
       ) : (
         <input
           className="form-control copiable-input"

--- a/packages/admin-ui/src/pages/packages/components/Info/PackageSentData.tsx
+++ b/packages/admin-ui/src/pages/packages/components/Info/PackageSentData.tsx
@@ -8,6 +8,8 @@ import { api } from "api";
 import { withToastNoThrow } from "components/toast/Toast";
 import { confirm } from "components/ConfirmDialog";
 import "./packageSentData.scss";
+import { isLink } from "utils/isLink";
+import { Link } from "react-router-dom";
 
 export function RenderPackageSentData({
   dnpName,
@@ -45,7 +47,12 @@ export function RenderPackageSentData({
         <React.Fragment key={key}>
           <div>{key}</div>
           <div>
-            <SentDataRow key={key} value={value} isSecret={isSecret(key)} />
+            <SentDataRow
+              key={key}
+              value={value}
+              isLink={isLink(value)}
+              isSecret={isSecret(key)}
+            />
           </div>
         </React.Fragment>
       ))}
@@ -61,9 +68,11 @@ export function RenderPackageSentData({
 
 function SentDataRow({
   value,
+  isLink,
   isSecret
 }: {
   value: string;
+  isLink: boolean;
   isSecret?: boolean;
 }) {
   const [show, setShow] = useState(false);
@@ -75,30 +84,36 @@ function SentDataRow({
 
   return (
     <InputGroup>
-      <input
-        className="form-control copiable-input"
-        type={!isSecret || show ? "text" : "password"}
-        value={value}
-        readOnly={true}
-      />
+      {isLink ? (
+        <Link to={value}>{value}</Link>
+      ) : (
+        <input
+          className="form-control copiable-input"
+          type={!isSecret || show ? "text" : "password"}
+          value={value}
+          readOnly={true}
+        />
+      )}
 
-      <InputGroup.Append>
-        {isSecret && (
+      {!isLink && (
+        <InputGroup.Append>
+          {isSecret && (
+            <Button
+              onClick={() => setShow(x => !x)}
+              className="input-append-button"
+            >
+              {show ? <GoEyeClosed /> : <GoEye />}
+            </Button>
+          )}
+
           <Button
-            onClick={() => setShow(x => !x)}
-            className="input-append-button"
+            className="input-append-button copy-input-copy"
+            data-clipboard-text={value}
           >
-            {show ? <GoEyeClosed /> : <GoEye />}
+            <GoClippy />
           </Button>
-        )}
-
-        <Button
-          className="input-append-button copy-input-copy"
-          data-clipboard-text={value}
-        >
-          <GoClippy />
-        </Button>
-      </InputGroup.Append>
+        </InputGroup.Append>
+      )}
     </InputGroup>
   );
 }

--- a/packages/admin-ui/src/pages/packages/components/Info/packageSentData.scss
+++ b/packages/admin-ui/src/pages/packages/components/Info/packageSentData.scss
@@ -7,7 +7,13 @@
     );
   grid-gap: 0.5rem 1rem;
 
-  .copiable-input {
+  .link-box {
+    color: var(--dappnode-links-color);
+    transition: color ease 150ms;
+  }
+
+  .copiable-input,
+  .link-box {
     background-color: var(--color-background) !important;
   }
 

--- a/packages/admin-ui/src/utils/isLink.ts
+++ b/packages/admin-ui/src/utils/isLink.ts
@@ -1,0 +1,3 @@
+export function isLink(value: string): boolean {
+  return value.startsWith("http");
+}

--- a/packages/admin-ui/src/utils/isLink.ts
+++ b/packages/admin-ui/src/utils/isLink.ts
@@ -1,3 +1,3 @@
 export function isLink(value: string): boolean {
-  return value.startsWith("http");
+  return value.startsWith("http://") || value.startsWith("https://");
 }


### PR DESCRIPTION
If the data sent from the container to the dappmanager starts with **http** then render it as a Link. Related to https://github.com/dappnode/DAppNodePackage-prysm-prater/issues/19

Consider having a hardcoded key instead for links/URLs