### PR TITLE
Fix link in dataSent feature

### DIFF
--- a/packages/admin-ui/src/pages/packages/components/Info/PackageSentData.tsx
+++ b/packages/admin-ui/src/pages/packages/components/Info/PackageSentData.tsx
@@ -9,7 +9,6 @@ import { withToastNoThrow } from "components/toast/Toast";
 import { confirm } from "components/ConfirmDialog";
 import "./packageSentData.scss";
 import { isLink } from "utils/isLink";
-import { Link } from "react-router-dom";
 
 export function RenderPackageSentData({
   dnpName,
@@ -85,9 +84,9 @@ function SentDataRow({
   return (
     <InputGroup>
       {isLink ? (
-        <Link className="form-control link-box" to={value}>
+        <a className="form-control link-box" href={value}>
           {value}
-        </Link>
+        </a>
       ) : (
         <input
           className="form-control copiable-input"


### PR DESCRIPTION
There was used a link with the full url path, instead it should be used only the package ENS domain