### PR TITLE
Fix get manifest from IPFS remote

### DIFF
--- a/packages/dappmanager/src/modules/release/getManifest.ts
+++ b/packages/dappmanager/src/modules/release/getManifest.ts
@@ -1,7 +1,9 @@
-import { ipfs } from "../ipfs";
+import { ipfs, IPFSEntry } from "../ipfs";
 import { parseManifest, validateManifestBasic } from "../manifest";
 import { Manifest } from "../../types";
 import { isDirectoryRelease } from "./ipfs/isDirectoryRelease";
+import { IpfsClientTarget } from "../../common";
+import { releaseFiles } from "../../params";
 
 export async function getManifest(contentUri: string): Promise<Manifest> {
   let data: string;
@@ -9,9 +11,7 @@ export async function getManifest(contentUri: string): Promise<Manifest> {
     const ipfsEntries = await ipfs.list(contentUri);
     const isDirectory = await isDirectoryRelease(ipfsEntries);
     if (isDirectory) {
-      data = await ipfs.writeFileToMemory(
-        `${contentUri}/dappnode_package.json`
-      );
+      data = await getManifestFromDir(ipfsEntries, contentUri);
     } else {
       data = await ipfs.writeFileToMemory(contentUri);
     }
@@ -20,4 +20,21 @@ export async function getManifest(contentUri: string): Promise<Manifest> {
   }
 
   return validateManifestBasic(parseManifest(data));
+}
+
+async function getManifestFromDir(
+  ipfsEntries: IPFSEntry[],
+  contentUri: string
+): Promise<string> {
+  if (ipfs.ipfsClientTarget === IpfsClientTarget.remote) {
+    const manifestPath = ipfsEntries.find(file =>
+      releaseFiles.manifest.regex.test(file.name)
+    );
+    if (!manifestPath) throw Error("Manifest not found using IPFS gateway");
+    // The ipfs dag.export method does not allow hash using "path" format
+    return await ipfs.writeFileToMemory(manifestPath.cid.toString());
+  } else {
+    // The ipfs cat method does allow to use hash using "path" format
+    return await ipfs.writeFileToMemory(`${contentUri}/dappnode_package.json`);
+  }
 }

--- a/packages/dappmanager/test/integration/ipfs/ipfsGateway.test.int.ts
+++ b/packages/dappmanager/test/integration/ipfs/ipfsGateway.test.int.ts
@@ -1,10 +1,12 @@
 import "mocha";
 import { expect } from "chai";
 import { mockManifestWithImage } from "../../testUtils";
-import { ManifestWithImage } from "../../../src/types";
+import { ManifestWithImage, IpfsClientTarget } from "../../../src/types";
 import { uploadManifestRelease } from "../../integrationSpecs/buildReleaseManifest";
-import { localIpfsGateway } from "../../testIpfsUtils";
-import { catCarReaderToMemory } from "../../../src/modules/ipfs/writeFileToMemory";
+import { uploadDirectoryRelease } from "../../integrationSpecs/buildReleaseDirectory";
+import { ipfs } from "../../../src/modules/ipfs";
+import { getManifest } from "../../../src/modules/release/getManifest";
+import { ipfsGatewayUrl } from "../../testIpfsUtils";
 
 describe("IPFS remote", function () {
   this.timeout(100000 * 5);
@@ -14,16 +16,41 @@ describe("IPFS remote", function () {
     ...mockManifestWithImage,
     name: dnpName
   };
-  let releaseHash: string;
+  let manifestHash: string;
+  let dnpReleaseHash: string;
 
   before(async () => {
-    releaseHash = await uploadManifestRelease(manifest);
+    // Set remote IPFS host
+    ipfs.changeHost(ipfsGatewayUrl, IpfsClientTarget.remote);
+    // Upload manifest and dnp directrory
+    manifestHash = await uploadManifestRelease(manifest);
+    dnpReleaseHash = await uploadDirectoryRelease({
+      manifest,
+      compose: {
+        version: "3.5",
+        services: {
+          [dnpName]: {
+            restart: "unless-stopped"
+          }
+        }
+      }
+    });
   });
 
-  it("Should get content from IPFS gateway", async function () {
+  it("Should get manifest from IPFS gateway", async function () {
     // If the content hashed does not match the CID there is thrown an error
-    const buff = await catCarReaderToMemory(localIpfsGateway, releaseHash);
+    const buff = await ipfs.writeFileToMemory(manifestHash);
     const contentParsed = JSON.parse(buff.toString());
     expect(contentParsed).to.be.ok;
+  });
+
+  it("Should get manifest from directory using IPFS gateway", async function () {
+    const manifest = await getManifest(dnpReleaseHash);
+    expect(manifest).to.be.ok;
+  });
+
+  after(async () => {
+    // Set remote IPFS host
+    ipfs.changeHost(ipfsGatewayUrl, IpfsClientTarget.local);
   });
 });

--- a/packages/dappmanager/test/integration/ipfs/ipfsGateway.test.int.ts
+++ b/packages/dappmanager/test/integration/ipfs/ipfsGateway.test.int.ts
@@ -21,7 +21,7 @@ describe("IPFS remote", function () {
 
   before(async () => {
     // Set remote IPFS host
-    ipfs.changeHost(ipfsGatewayUrl, IpfsClientTarget.remote);
+    ipfs.changeHost(ipfsGatewayUrl, IpfsClientTarget.local);
     // Upload manifest and dnp directrory
     manifestHash = await uploadManifestRelease(manifest);
     dnpReleaseHash = await uploadDirectoryRelease({
@@ -50,7 +50,7 @@ describe("IPFS remote", function () {
   });
 
   after(async () => {
-    // Set remote IPFS host
+    // Set remote IPFS host again
     ipfs.changeHost(ipfsGatewayUrl, IpfsClientTarget.local);
   });
 });

--- a/packages/dappmanager/test/integration/releaseFormat.test.int.ts
+++ b/packages/dappmanager/test/integration/releaseFormat.test.int.ts
@@ -13,7 +13,7 @@ import {
 } from "../integrationSpecs";
 import { mockImageEnvNAME } from "../integrationSpecs/mockImage";
 import { ipfs } from "../../src/modules/ipfs";
-import { ipfsApiUrl } from "../testIpfsUtils";
+import { ipfsApiUrl, ipfsGatewayUrl } from "../testIpfsUtils";
 
 /**
  * Generate mock releases in the different formats,
@@ -284,5 +284,8 @@ describe("Release format tests", () => {
   after("Remove DAppNode docker network", async () => {
     await shell(`docker network remove ${params.DNP_PRIVATE_NETWORK_NAME}`);
     await cleanTestDir();
+
+    // Set remote IPFS host again
+    ipfs.changeHost(ipfsGatewayUrl, IpfsClientTarget.local);
   });
 });

--- a/packages/dappmanager/test/integration/signedRelease.test.int.ts
+++ b/packages/dappmanager/test/integration/signedRelease.test.int.ts
@@ -4,15 +4,24 @@ import { ComposeEditor } from "../../src/modules/compose/editor";
 import { ipfs } from "../../src/modules/ipfs";
 import { ReleaseFetcher } from "../../src/modules/release";
 import { getContainerName, getImageTag } from "../../src/params";
-import { Manifest, ReleaseSignatureStatusCode } from "../../src/types";
+import {
+  IpfsClientTarget,
+  Manifest,
+  ReleaseSignatureStatusCode
+} from "../../src/types";
 import { uploadDirectoryRelease } from "../integrationSpecs";
 import { signRelease } from "../integrationSpecs/signRelease";
+import { ipfsApiUrl } from "../testIpfsUtils";
 
 // Sign the string message
 const privateKey =
   "0x0111111111111111111111111111111111111111111111111111111111111111";
 
 describe("Sign release", () => {
+  before("Change IPFS host", async () => {
+    ipfs.changeHost(ipfsApiUrl, IpfsClientTarget.local);
+  });
+
   it("Sign uploaded release", async () => {
     const dnpName = "test.dnp.dappnode.eth";
     const version = "1.0.0";

--- a/packages/dappmanager/test/modules/ipfs/index.test.int.ts
+++ b/packages/dappmanager/test/modules/ipfs/index.test.int.ts
@@ -3,7 +3,8 @@ import path from "path";
 import { expect } from "chai";
 import { ipfs } from "../../../src/modules/ipfs";
 import { cleanTestDir, testDir } from "../../testUtils";
-import { ipfsAddDirFromFs } from "../../testIpfsUtils";
+import { ipfsAddDirFromFs, ipfsApiUrl } from "../../testIpfsUtils";
+import { IpfsClientTarget } from "../../../src/common";
 
 describe("ipfs / integration test", function () {
   this.timeout(60 * 1000);
@@ -15,6 +16,10 @@ describe("ipfs / integration test", function () {
 
   let dirHash: string;
   let fileHash: string;
+
+  before("Change IPFS host", async () => {
+    ipfs.changeHost(ipfsApiUrl, IpfsClientTarget.local);
+  });
 
   before("Prepare directory", () => {
     fs.mkdirSync(dirPath, { recursive: true });


### PR DESCRIPTION
The IPFS method `dag/export/ does not allow to use IPFS hashes in path format, i.e:
`QmXcZnd6euc3wfQqwb8m9r2hWuefrS6cPic29k5VZz7S6d/dappnode_package.json`

There must be used the CID of the file