### PR TITLE
Expose https ports by default on installation

### DIFF
--- a/packages/admin-ui/src/common/types.ts
+++ b/packages/admin-ui/src/common/types.ts
@@ -30,6 +30,7 @@ export interface ExposableServiceManifestInfo {
   serviceName?: string;
   fromSubdomain?: string;
   port: number;
+  exposedByDefault?: boolean;
 }
 
 export interface ExposableServiceMapping extends ExposableServiceInfo {

--- a/packages/admin-ui/src/common/types.ts
+++ b/packages/admin-ui/src/common/types.ts
@@ -30,7 +30,7 @@ export interface ExposableServiceManifestInfo {
   serviceName?: string;
   fromSubdomain?: string;
   port: number;
-  exposedByDefault?: boolean;
+  exposeByDefault?: boolean;
 }
 
 export interface ExposableServiceMapping extends ExposableServiceInfo {

--- a/packages/dappmanager/src/calls/httpsPortal.ts
+++ b/packages/dappmanager/src/calls/httpsPortal.ts
@@ -10,7 +10,7 @@ const httpsPortalApiClient = new HttpsPortalApiClient(
   params.HTTPS_PORTAL_API_URL
 );
 
-const httpsPortal = new HttpsPortal(httpsPortalApiClient);
+export const httpsPortal = new HttpsPortal(httpsPortalApiClient);
 
 /**
  * HTTPs Portal: map a subdomain

--- a/packages/dappmanager/src/modules/installer/exposeByDefaultHttpsPorts.ts
+++ b/packages/dappmanager/src/modules/installer/exposeByDefaultHttpsPorts.ts
@@ -1,0 +1,78 @@
+import { listPackageNoThrow } from "../docker/list/listPackages";
+import { httpsPortal } from "../../calls/httpsPortal";
+import { prettyDnpName } from "../../utils/format";
+import params from "../../params";
+import { InstallPackageData } from "../../types";
+import { Log } from "../../utils/logUi";
+import { HttpsPortalMapping } from "../../common";
+
+/**
+ * Expose default HTTPS ports on installation defined in the manifest - exposable
+ */
+export async function exposeByDefaultHttpsPorts(
+  pkg: InstallPackageData,
+  log: Log
+): Promise<void> {
+  if (pkg.metadata.exposable) {
+    const portMappinRollback: HttpsPortalMapping[] = [];
+    for (const exposable of pkg.metadata.exposable) {
+      if (exposable.exposedByDefault) {
+        // Check HTTPS package exists
+        const httpsPackage = await listPackageNoThrow({
+          dnpName: params.HTTPS_PORTAL_DNPNAME
+        });
+        if (!httpsPackage)
+          throw Error(
+            `HTTPS package not found but required to expose HTTPS ports by default. Install HTTPS package first.`
+          );
+        // Check HTTPS package running
+        httpsPackage.containers.map(container => {
+          if (!container.running)
+            throw Error(
+              `HTTPS package not running but required to expose HTTPS ports by default.`
+            );
+        });
+
+        const portalMapping: HttpsPortalMapping = {
+          fromSubdomain: exposable.fromSubdomain || prettyDnpName(pkg.dnpName), // get dnpName by default
+          dnpName: pkg.dnpName,
+          serviceName:
+            exposable.serviceName || Object.keys(pkg.compose.services)[0], // get first service name by default (docs: https://docs.dappnode.io/es/developers/manifest-reference/#servicename)
+          port: exposable.port
+        };
+
+        try {
+          // Expose default HTTPS ports
+          log(
+            pkg.dnpName,
+            `Exposing ${prettyDnpName(pkg.dnpName)}:${
+              exposable.port
+            } to the external internet`
+          );
+          await httpsPortal.addMapping(portalMapping);
+          portMappinRollback.push(portalMapping);
+
+          log(
+            pkg.dnpName,
+            `Exposed ${prettyDnpName(pkg.dnpName)}:${
+              exposable.port
+            } to the external internet`
+          );
+        } catch (e) {
+          e.message = `${e.message} Error exposing default HTTPS ports, removing mappings`;
+          for (const mappingRollback of portMappinRollback) {
+            await httpsPortal.removeMapping(mappingRollback).catch(e => {
+              log(
+                pkg.dnpName,
+                `Error removing mapping ${JSON.stringify(mappingRollback)}, ${
+                  e.message
+                }`
+              );
+            });
+          }
+          throw e;
+        }
+      }
+    }
+  }
+}

--- a/packages/dappmanager/src/modules/installer/exposeByDefaultHttpsPorts.ts
+++ b/packages/dappmanager/src/modules/installer/exposeByDefaultHttpsPorts.ts
@@ -16,7 +16,7 @@ export async function exposeByDefaultHttpsPorts(
   if (pkg.metadata.exposable) {
     const portMappinRollback: HttpsPortalMapping[] = [];
     for (const exposable of pkg.metadata.exposable) {
-      if (exposable.exposedByDefault) {
+      if (exposable.exposeByDefault) {
         // Check HTTPS package exists
         const httpsPackage = await listPackageNoThrow({
           dnpName: params.HTTPS_PORTAL_DNPNAME

--- a/packages/dappmanager/src/modules/installer/runPackages.ts
+++ b/packages/dappmanager/src/modules/installer/runPackages.ts
@@ -8,6 +8,7 @@ import { InstallPackageData } from "../../types";
 import { logs } from "../../logs";
 import { dockerComposeUpPackage } from "../docker";
 import { packageToInstallHasPid } from "../../utils/pid";
+import { exposeByDefaultHttpsPorts } from "./exposeByDefaultHttpsPorts";
 
 /**
  * Create and run each package container in series
@@ -78,5 +79,7 @@ export async function runPackages(
     );
 
     log(pkg.dnpName, "Package started");
+
+    await exposeByDefaultHttpsPorts(pkg, log);
   }
 }


### PR DESCRIPTION
Expose HTTPS ports defined in the manifest with `exposedByDefault` as `true` 

e.g
``` 
exposable: {
    "name": "Geth JSON RPC",
    "description": "JSON RPC endpoint for Geth mainnet",
    "serviceName": "beacon_chain",
    "port":  8545,
    "exposedByDefault": true
}
``` 