### PR TITLE
Ensure not installing legacy validators

### DIFF
--- a/packages/dappmanager/src/calls/packageInstall.ts
+++ b/packages/dappmanager/src/calls/packageInstall.ts
@@ -17,6 +17,7 @@ import {
   afterInstall
 } from "../modules/installer";
 import { logs } from "../logs";
+import { ensureIsNotValidatorLegacyPackage } from "../modules/installer/ensureIsNotValidatorLegacyPackage";
 
 /**
  * Installs a DAppNode Package.
@@ -81,6 +82,9 @@ export async function packageInstall({
     const dnpNames = packagesData.map(({ dnpName }) => dnpName);
     for (const dnpName of dnpNames)
       if (packageIsInstalling(dnpName)) throw Error(`${dnpName} is installing`);
+
+    // Ensure is not a validator client legacy package
+    await ensureIsNotValidatorLegacyPackage(packagesData);
 
     try {
       flagPackagesAreInstalling(dnpNames);

--- a/packages/dappmanager/src/modules/installer/ensureIsNotValidatorLegacyPackage.ts
+++ b/packages/dappmanager/src/modules/installer/ensureIsNotValidatorLegacyPackage.ts
@@ -2,7 +2,7 @@ import { InstallPackageData } from "../../types";
 import semver from "semver";
 
 /**
- * Prevent from installing legacy version (previous to remote signer support) for packages:
+ * From dappmanager v0.2.46 prevent from installing legacy version (previous to remote signer support) for packages:
  * - Prysm
  * - Prysm-Prater
  * - Gnosis-Beacon-Chain-Prysm

--- a/packages/dappmanager/src/modules/installer/ensureIsNotValidatorLegacyPackage.ts
+++ b/packages/dappmanager/src/modules/installer/ensureIsNotValidatorLegacyPackage.ts
@@ -1,0 +1,39 @@
+import { InstallPackageData } from "../../types";
+import semver from "semver";
+
+/**
+ * Prevent from installing legacy version (previous to remote signer support) for packages:
+ * - Prysm
+ * - Prysm-Prater
+ * - Gnosis-Beacon-Chain-Prysm
+ */
+export async function ensureIsNotValidatorLegacyPackage(
+  packagesData: InstallPackageData[]
+): Promise<void> {
+  for (const pkg of packagesData) {
+    switch (pkg.dnpName) {
+      case "prysm-prater.dnp.dappnode.eth":
+        if (semver.lte(pkg.semVersion, "1.0.7"))
+          throw Error(
+            `${pkg.dnpName}:${pkg.semVersion} is a legacy validator client, install a more recent version with remote signer support`
+          );
+        continue;
+
+      // To be included once after prysm-prater
+      /*       case "gnosis-beacon-chain-prysm.dnp.dappnode.eth":
+        if (semver.lte(pkg.semVersion, "1.0.0"))
+          throw Error(
+            `${pkg.dnpName}:${pkg.semVersion} is a legacy validator client, install a more recent version with remote signer support`
+          );
+        continue;
+      case "prysm.dnp.dappnode.eth":
+        if (semver.lte(pkg.semVersion, "1.0.0"))
+          throw Error(
+            `${pkg.dnpName}:${pkg.semVersion} is a legacy validator client, install a more recent version with remote signer support`
+          );
+        continue; */
+      default:
+        continue;
+    }
+  }
+}

--- a/packages/dappmanager/src/modules/installer/ensureIsNotValidatorLegacyPackage.ts
+++ b/packages/dappmanager/src/modules/installer/ensureIsNotValidatorLegacyPackage.ts
@@ -1,5 +1,6 @@
 import { InstallPackageData } from "../../types";
 import semver from "semver";
+import params from "../../params";
 
 /**
  * From dappmanager v0.2.46 prevent from installing legacy version (previous to remote signer support) for packages:
@@ -11,29 +12,11 @@ export async function ensureIsNotValidatorLegacyPackage(
   packagesData: InstallPackageData[]
 ): Promise<void> {
   for (const pkg of packagesData) {
-    switch (pkg.dnpName) {
-      case "prysm-prater.dnp.dappnode.eth":
-        if (semver.lte(pkg.semVersion, "1.0.7"))
-          throw Error(
-            `${pkg.dnpName}:${pkg.semVersion} is a legacy validator client, install a more recent version with remote signer support`
-          );
-        continue;
-
-      // To be included once after prysm-prater
-      /*       case "gnosis-beacon-chain-prysm.dnp.dappnode.eth":
-        if (semver.lte(pkg.semVersion, "1.0.0"))
-          throw Error(
-            `${pkg.dnpName}:${pkg.semVersion} is a legacy validator client, install a more recent version with remote signer support`
-          );
-        continue;
-      case "prysm.dnp.dappnode.eth":
-        if (semver.lte(pkg.semVersion, "1.0.0"))
-          throw Error(
-            `${pkg.dnpName}:${pkg.semVersion} is a legacy validator client, install a more recent version with remote signer support`
-          );
-        continue; */
-      default:
-        continue;
-    }
+    params.minimumAllowedPackageVersions.map(({ dnpName, version }) => {
+      if (pkg.dnpName === dnpName && semver.lte(pkg.semVersion, version))
+        throw Error(
+          `${pkg.dnpName}:${pkg.semVersion} is a legacy validator client, install a more recent version with remote signer support`
+        );
+    });
   }
 }

--- a/packages/dappmanager/src/params.ts
+++ b/packages/dappmanager/src/params.ts
@@ -151,6 +151,14 @@ const params = {
   ETH_MAINNET_RPC_URL_REMOTE:
     process.env.ETH_MAINNET_RPC_URL_REMOTE || "https://web3.dappnode.net",
 
+  // Validators legacy versions
+  minimumAllowedPackageVersions: [
+    {
+      dnpName: "prysm-prater.dnp.dappnode.eth",
+      version: "1.0.7"
+    }
+  ],
+
   // DAPPMANAGER alias
   DAPPMANAGER_ALIASES: ["my.dappnode", "dappnode.local"],
 


### PR DESCRIPTION
The dappstore will not allow to install older versions of package however users still can use hashes to install validator package previous to the remote signer support.

This PR checks a hardcoded version for the Prysm prater to ensure it supports remote signer. Prysm mainnet and Gnosis is on the roadmap