### PR TITLE
Whitelist packages to use docker socket

### DIFF
--- a/packages/dappmanager/src/modules/docker/api/listImages.ts
+++ b/packages/dappmanager/src/modules/docker/api/listImages.ts
@@ -13,9 +13,7 @@ import { docker } from "./docker";
 export async function imagesList(
   options?: DockerApiListImagesOptions
 ): Promise<Dockerode.ImageInfo[]> {
-  return docker.listImages(options as Dockerode.ListImagesOptions) as Promise<
-    Dockerode.ImageInfo[]
-  >;
+  return docker.listImages(options);
 }
 
 export interface DockerApiListImagesOptions {

--- a/packages/dappmanager/src/modules/docker/api/listImages.ts
+++ b/packages/dappmanager/src/modules/docker/api/listImages.ts
@@ -13,7 +13,7 @@ import { docker } from "./docker";
 export async function imagesList(
   options?: DockerApiListImagesOptions
 ): Promise<Dockerode.ImageInfo[]> {
-  return docker.listImages(options);
+  return docker.listImages(options) as Promise<Dockerode.ImageInfo[]>;
 }
 
 export interface DockerApiListImagesOptions {

--- a/packages/dappmanager/src/modules/docker/api/listImages.ts
+++ b/packages/dappmanager/src/modules/docker/api/listImages.ts
@@ -13,7 +13,7 @@ import { docker } from "./docker";
 export async function imagesList(
   options?: DockerApiListImagesOptions
 ): Promise<Dockerode.ImageInfo[]> {
-  return docker.listImages(options) as Promise<Dockerode.ImageInfo[]>;
+  return docker.listImages(options || {}) as Promise<Dockerode.ImageInfo[]>;
 }
 
 export interface DockerApiListImagesOptions {

--- a/packages/dappmanager/src/modules/docker/api/listImages.ts
+++ b/packages/dappmanager/src/modules/docker/api/listImages.ts
@@ -10,42 +10,6 @@ import { docker } from "./docker";
  *   }
  * }
  */
-export async function imagesList(
-  options?: DockerApiListImagesOptions
-): Promise<Dockerode.ImageInfo[]> {
-  return docker.listImages(options || {}) as Promise<Dockerode.ImageInfo[]>;
-}
-
-export interface DockerApiListImagesOptions {
-  /**
-   * Show all images. Only images from a final layer (no children) are shown by default.
-   */
-  all?: boolean;
-  /**
-   * A JSON encoded value of the filters (a map[string][]string) to process on the images list. Available filters:
-   */
-  filters?: {
-    /**
-     * (<image-name>[:<tag>], <image id> or <image@digest>),
-     */
-    before?: string;
-    dangling?: Record<string, unknown>;
-    /**
-     * key or label="key=value" of an image label
-     */
-    label?: string[];
-    /**
-     * (<image-name>[:<tag>])
-     * Partial RepoTag, i.e. "dappmanager.dnp.dappnode.eth"
-     */
-    reference?: string[];
-    /**
-     * (<image-name>[:<tag>], <image id> or <image@digest>)
-     */
-    since?: string;
-  };
-  /**
-   * Show digest information as a RepoDigests field on each image
-   */
-  digests?: boolean;
+export async function imagesList(): Promise<Dockerode.ImageInfo[]> {
+  return docker.listImages();
 }

--- a/packages/dappmanager/src/params.ts
+++ b/packages/dappmanager/src/params.ts
@@ -129,6 +129,13 @@ const params = {
   CONTAINER_TOOL_NAME_PREFIX: "DAppNodeTool-",
   // Docker volume parameters
   MOUNTPOINT_DEVICE_PREFIX: "dappnode-volumes",
+  DOCKER_SOCKET: "/var/run/docker.sock",
+  WHITELISTED_DOCKER_SOCKET_VOLUME: [
+    "wifi.dnp.dappnode.eth",
+    "dappmanager.dnp.dappnode.eth",
+    "core.dnp.dappnode.eth",
+    "vpn.dnp.dappnode.eth"
+  ],
 
   // Auto-update parameters
   AUTO_UPDATE_DELAY: 1 * DAY,


### PR DESCRIPTION
## Context
Docker volumes are used by DAppNode packages in several different ways. There is a docker volume critical to be defined in the docker-compose, this is the docker socket volume: `/var/run/docker.sock`

## Solution
The docker socket volume is a critical volume that entails security vulnerabilities on the host. This docker socket volume should be only used by a well-known whitelist of packages:
- Dappmanager
- Core
- Vpn
- Wifi

## How to test it?
- Verify that installing the whitelist packages is allowed
- Verify that installing a package non-whitelisted with the docker socket volume result into an error