### PR TITLE
Fix map order

### DIFF
--- a/packages/dappmanager/src/params.ts
+++ b/packages/dappmanager/src/params.ts
@@ -162,8 +162,8 @@ const params = {
   // Web3signer and clients dnpnames
   web3SignerClientsDnpNames: [
     {
-      web3SignerDnpName: "web3signer-prater.dnp.dappnode.eth",
-      clientDnpName: "prysm-prater.dnp.dappnode.eth"
+      clientDnpName: "prysm-prater.dnp.dappnode.eth",
+      web3SignerDnpName: "web3signer-prater.dnp.dappnode.eth"
     }
   ],
 


### PR DESCRIPTION
Reorder params from web3signer and client legacy:
```
  web3SignerClientsDnpNames: [
    {
      clientDnpName: "prysm-prater.dnp.dappnode.eth",
      web3SignerDnpName: "web3signer-prater.dnp.dappnode.eth"
    }
  ],
```