### PR TITLE
Fix wrong check when installing web3signer

### DIFF
--- a/packages/dappmanager/src/modules/installer/ensureEth2MigrationRequirements.ts
+++ b/packages/dappmanager/src/modules/installer/ensureEth2MigrationRequirements.ts
@@ -4,58 +4,51 @@ import params from "../../params";
 import { listPackageNoThrow } from "../docker/list";
 
 /**
- * Ensure the following requirements for Eth2 migration:
- * - From dappmanager v0.2.46 prevent from installing legacy version (previous to remote signer support) for packages: (Prysm, Prysm-prater and Gnosis-Beacon-Chain-Prysm)
- * - Ensure not to install web3signer if Prysm package legacy version is installed
+ * Check it is a legacy client package version
+ */
+export function isClientLegacy(dnpName: string, dnpVersion: string): boolean {
+  const dnpVersionParsed = semver.valid(dnpVersion);
+  if (!dnpVersionParsed) return false;
+  return params.minimumAllowedClientsLegacyVersions.some(
+    clientPkg =>
+      clientPkg.clientDnpName === dnpName &&
+      semver.lt(dnpVersionParsed, clientPkg.clientVersion)
+  );
+}
+
+/**
+ * Ensure the following requirements for Eth2 migration, from dappmanager v0.2.46 prevent the following:
+ * - Ensure not installing client legacy version (previous to remote signer support) for packages: (Prysm, Prysm-prater and Gnosis-Beacon-Chain-Prysm)
+ * - Ensure not installing web3signer if Prysm package legacy version is installed
  */
 export async function ensureEth2MigrationRequirements(
   packagesData: InstallPackageData[]
 ): Promise<void> {
-  const minimumAllowedPackageVersions = new Map(
-    params.minimumAllowedPackageVersions.map(({ dnpName, version }) => [
-      dnpName,
-      version
-    ])
-  );
-
-  const web3SignerClientsDnpNames = new Map(
-    params.web3SignerClientsDnpNames.map(
-      ({ web3SignerDnpName, clientDnpName }) => [
-        web3SignerDnpName,
-        clientDnpName
-      ]
+  const minimumAllowedClientVersions = new Map(
+    params.minimumAllowedClientsLegacyVersions.map(
+      ({ clientDnpName, clientVersion }) => [clientDnpName, clientVersion]
     )
   );
 
   for (const pkg of packagesData) {
-    // Ensure not to install a legacy version of a package
-    const pkgLegacyVersion = minimumAllowedPackageVersions.get(pkg.dnpName);
+    // Ensure not to install legacy client
+    const pkgLegacyVersion = minimumAllowedClientVersions.get(pkg.dnpName);
     if (pkgLegacyVersion && semver.lte(pkg.semVersion, pkgLegacyVersion))
       throw Error(
         `${pkg.dnpName}:${pkg.semVersion} is a legacy validator client, install a more recent version with remote signer support`
       );
 
     // Ensure not to install web3signer if client package legacy version is installed
-    const web3SignerClientDnpName = web3SignerClientsDnpNames.get(pkg.dnpName);
-    if (!web3SignerClientDnpName) continue;
-    const web3SignerClientPkg = await listPackageNoThrow({
-      dnpName: web3SignerClientDnpName
+    params.minimumAllowedClientsLegacyVersions.map(async item => {
+      if (pkg.dnpName === item.web3signerDnpName) {
+        const clientPkg = await listPackageNoThrow({
+          dnpName: item.clientDnpName
+        });
+        if (clientPkg && semver.lte(clientPkg.version, pkg.semVersion))
+          throw Error(
+            `Not allowed to install web3signer having a legacy client installed it ${pkg.dnpName}:${pkg.semVersion}. Update it or remove it`
+          );
+      }
     });
-    if (!web3SignerClientPkg) continue;
-    if (semver.lte(pkg.semVersion, web3SignerClientPkg.version)) {
-      throw Error(
-        `${pkg.dnpName}:${pkg.semVersion} is a legacy validator client, install a more recent version with remote signer support`
-      );
-    }
   }
-}
-
-export function isClientLegacy(dnpName: string, dnpVersion: string): boolean {
-  const dnpVersionParsed = semver.valid(dnpVersion);
-  if (!dnpVersionParsed) return false;
-  return params.minimumAllowedPackageVersions.some(
-    clientPkg =>
-      clientPkg.dnpName === dnpName &&
-      semver.lt(dnpVersionParsed, clientPkg.version)
-  );
 }

--- a/packages/dappmanager/src/params.ts
+++ b/packages/dappmanager/src/params.ts
@@ -152,18 +152,11 @@ const params = {
     process.env.ETH_MAINNET_RPC_URL_REMOTE || "https://web3.dappnode.net",
 
   // Validators legacy versions: Prysm, Prysm-prater, Prysm-gnosis
-  minimumAllowedPackageVersions: [
-    {
-      dnpName: "prysm-prater.dnp.dappnode.eth",
-      version: "0.1.7"
-    }
-  ],
-
-  // Web3signer and clients dnpnames
-  web3SignerClientsDnpNames: [
+  minimumAllowedClientsLegacyVersions: [
     {
       clientDnpName: "prysm-prater.dnp.dappnode.eth",
-      web3SignerDnpName: "web3signer-prater.dnp.dappnode.eth"
+      clientVersion: "0.1.7",
+      web3signerDnpName: "web3signer-prater.dnp.dappnode.eth"
     }
   ],
 


### PR DESCRIPTION
Fix a wrong check to not allow installing web3signer while having a legacy client installed in dappnode.