### PR TITLE
Fix chain driver

### DIFF
--- a/packages/admin-ui/src/common/types.ts
+++ b/packages/admin-ui/src/common/types.ts
@@ -429,7 +429,7 @@ export type ContainerState =
 export type ChainDriver = ChainDriverType | ChainDriverSpecs;
 
 export type ChainDriverSpecs = {
-  driver: ChainDriverType;
+  chain: ChainDriverType;
   serviceName?: string;
   portNumber?: number;
 };

--- a/packages/admin-ui/src/common/types.ts
+++ b/packages/admin-ui/src/common/types.ts
@@ -429,7 +429,7 @@ export type ContainerState =
 export type ChainDriver = ChainDriverType | ChainDriverSpecs;
 
 export type ChainDriverSpecs = {
-  chain: ChainDriverType;
+  driver: ChainDriverType;
   serviceName?: string;
   portNumber?: number;
 };

--- a/packages/dappmanager/src/modules/chains/drivers/index.ts
+++ b/packages/dappmanager/src/modules/chains/drivers/index.ts
@@ -20,12 +20,12 @@ export async function runWithChainDriver(
 ): Promise<ChainDataResult | null> {
   let chainDriverSpecs: ChainDriverSpecs;
   if (typeof chainDriver === "string") {
-    chainDriverSpecs = { driver: chainDriver };
+    chainDriverSpecs = { chain: chainDriver };
   } else {
     chainDriverSpecs = chainDriver;
   }
 
-  switch (chainDriverSpecs.driver) {
+  switch (chainDriverSpecs.chain) {
     case "bitcoin":
       return bitcoin(dnp);
     case "ethereum":
@@ -36,6 +36,6 @@ export async function runWithChainDriver(
     case "monero":
       return monero(dnp);
     default:
-      throw Error(`Unsupported driver: ${chainDriverSpecs.driver}`);
+      throw Error(`Unsupported chain: ${chainDriverSpecs.chain}`);
   }
 }

--- a/packages/dappmanager/src/modules/chains/drivers/index.ts
+++ b/packages/dappmanager/src/modules/chains/drivers/index.ts
@@ -1,5 +1,8 @@
-import { ChainDriverSpecs, InstalledPackageData } from "../../../common";
-import { ChainDriver } from "../../../types";
+import {
+  ChainDriver,
+  ChainDriverSpecs,
+  InstalledPackageData
+} from "../../../common";
 import { ChainDataResult } from "../types";
 // Drivers
 import { bitcoin } from "./bitcoin";
@@ -20,12 +23,14 @@ export async function runWithChainDriver(
 ): Promise<ChainDataResult | null> {
   let chainDriverSpecs: ChainDriverSpecs;
   if (typeof chainDriver === "string") {
-    chainDriverSpecs = { chain: chainDriver };
+    chainDriverSpecs = {
+      driver: chainDriver
+    };
   } else {
     chainDriverSpecs = chainDriver;
   }
 
-  switch (chainDriverSpecs.chain) {
+  switch (chainDriverSpecs.driver) {
     case "bitcoin":
       return bitcoin(dnp);
     case "ethereum":
@@ -36,6 +41,6 @@ export async function runWithChainDriver(
     case "monero":
       return monero(dnp);
     default:
-      throw Error(`Unsupported chain: ${chainDriverSpecs.chain}`);
+      throw Error(`Unsupported chain: ${chainDriverSpecs.driver}`);
   }
 }

--- a/packages/dappmanager/src/modules/chains/getChainDriverName.ts
+++ b/packages/dappmanager/src/modules/chains/getChainDriverName.ts
@@ -17,6 +17,8 @@ const knownChains: { [dnpName: string]: ChainDriver } = {
   "kovan.dnp.dappnode.eth": "ethereum",
   "bitcoin.dnp.dappnode.eth": "bitcoin",
   "monero.dnp.dappnode.eth": "monero",
-  "prysm.dnp.dappnode.eth": "ethereum2-beacon-chain-prysm",
-  "prysm-prater.dnp.dappnode.eth": "ethereum2-beacon-chain-prysm"
+  "prysm.dnp.dappnode.eth": "ethereum-beacon-chain",
+  "prysm-prater.dnp.dappnode.eth": "ethereum-beacon-chain",
+  "lighthouse-prater.dnp.dappnode.eth": "ethereum-beacon-chain",
+  "teku-prater.dnp.dappnode.eth": "ethereum-beacon-chain"
 };

--- a/packages/dappmanager/src/modules/compose/labelsDb.ts
+++ b/packages/dappmanager/src/modules/compose/labelsDb.ts
@@ -58,7 +58,7 @@ const labelParseFns: {
     if (
       valueParsed &&
       chainDriversTypes.includes(
-        (valueParsed as ChainDriverSpecs).driver as ChainDriverType
+        (valueParsed as ChainDriverSpecs).chain as ChainDriverType
       )
     )
       return value as ChainDriver;

--- a/packages/dappmanager/src/modules/compose/labelsDb.ts
+++ b/packages/dappmanager/src/modules/compose/labelsDb.ts
@@ -52,16 +52,17 @@ const labelParseFns: {
   "dappnode.dnp.avatar": parseString,
   "dappnode.dnp.origin": parseString,
   "dappnode.dnp.chain": value => {
-    if (chainDriversTypes.includes(value as ChainDriverType))
-      return value as ChainDriver;
+    if (chainDriversTypes.includes(value as ChainDriverType)) {
+      return value as ChainDriverType ;
+    }
     const valueParsed = parseJsonSafe(value);
     if (
       valueParsed &&
       chainDriversTypes.includes(
-        (valueParsed as ChainDriverSpecs).chain as ChainDriverType
+        (valueParsed as ChainDriverSpecs).driver as ChainDriverType
       )
     )
-      return value as ChainDriver;
+      return valueParsed as ChainDriver;
     return undefined;
   },
   "dappnode.dnp.isCore": parseBool,

--- a/packages/dappmanager/test/modules/compose/labelDb.test.ts
+++ b/packages/dappmanager/test/modules/compose/labelDb.test.ts
@@ -4,7 +4,7 @@ import { ContainerLabelsRaw } from "../../../src/types";
 import { readContainerLabels } from "../../../src/modules/compose";
 
 describe("Parse and validate manifest labels to be used in the compose", () => {
-  it("should parse and validate chain as a string", () => {
+  it("should parse and validate driver as a string", () => {
     const expectedLabels = {
       dnpName: "dnp-name",
       version: "1.0.0",
@@ -44,7 +44,7 @@ describe("Parse and validate manifest labels to be used in the compose", () => {
     expect(labelValues).to.deep.equal(expectedLabels);
   });
 
-  it("should parse and validate chain as an object", () => {
+  it("should parse and validate driver as an object", () => {
     const expectedLabels = {
       dnpName: "dnp-name",
       version: "1.0.0",
@@ -53,7 +53,9 @@ describe("Parse and validate manifest labels to be used in the compose", () => {
       dependencies: { oneDependency: "dependency-name" },
       avatar: "avatar-url",
       origin: "origin-url",
-      chain: '{"driver": "ethereum2-beacon-chain-prysm"}',
+      chain: {
+        driver: "ethereum2-beacon-chain-prysm"
+      },
       isCore: true,
       isMain: true,
       dockerTimeout: 10,
@@ -84,7 +86,7 @@ describe("Parse and validate manifest labels to be used in the compose", () => {
     expect(labelValues).to.deep.equal(expectedLabels);
   });
 
-  it("should parse and validate chain as undefined", () => {
+  it("should parse and validate driver as undefined", () => {
     const expectedLabels = {
       dnpName: "dnp-name",
       version: "1.0.0",
@@ -109,7 +111,7 @@ describe("Parse and validate manifest labels to be used in the compose", () => {
       "dappnode.dnp.dependencies": '{"oneDependency": "dependency-name"}',
       "dappnode.dnp.avatar": "avatar-url",
       "dappnode.dnp.origin": "origin-url",
-      "dappnode.dnp.chain": '{"driverd": "ethereum2-beacon-chain-prysm"}',
+      "dappnode.dnp.chain": '{"driverd": "ethereudm2-beacon-chain-prysm"}',
       "dappnode.dnp.isCore": "true",
       "dappnode.dnp.isMain": "true",
       "dappnode.dnp.dockerTimeout": "10",

--- a/packages/dappmanager/test/modules/docker/parseContainerInfo.test.ts
+++ b/packages/dappmanager/test/modules/docker/parseContainerInfo.test.ts
@@ -398,7 +398,7 @@ describe("modules / docker / parseContainerInfo", function () {
         dependencies: {},
         avatarUrl: "/ipfs/QmQnHxr4YAVdtqzHnsDYvmXizxptSYyaj3YwTjoiLshVwF",
         origin: "/ipfs/QmeBfnwgsNcEmbmxENBWtgkv5YZsAhiaDsoYd7nMTV1wKV",
-        chain: "ethereum",
+        chain: "ethereum" ,
         canBeFullnode: false,
         defaultEnvironment: {
           EXTRA_OPTS: "--warp-barrier 8540000",
@@ -699,7 +699,7 @@ describe("modules / docker / parseContainerInfo", function () {
         exitCode: null,
         dependencies: {},
         avatarUrl: "",
-        chain: "ethereum",
+        chain: "ethereum" ,
         canBeFullnode: false
       },
       {


### PR DESCRIPTION

<!-- For DAppNode core members, once the Pull Request is created, do not forget to:
1.  Link issues to the PR if available
2.  Mention dappnode core members
3.  Add proper labels
-->

## Context

The changes implemented to get dynamically the chain driver based on port and service name was breaking the old hardcoded way of defining the chain.

## Approach

Fix chain driver. There was referring to `.driver` instead of `.chain`. This should be compatible with both methods:
```
"chain" : "ethereum2-beacon-chain"
```
and 
```
  "chain": {
    "driver": "ethereum-beacon-chain",
    "serviceName": "beacon-chain",
    "portNumber": 3500
  }
```

## Test instructions

<!-- MANDATORY: please, do not skip this step, it is very important for DAppNode team to have simple and well defined instructions on how to test this PR.
-->
Install valid dappnode packages with both options in the manifest and maks sure that the chain is shown in the dashboard
