### PR TITLE
Check for rest of the packages for HTTPS portal

### DIFF
--- a/packages/dappmanager/src/domains.ts
+++ b/packages/dappmanager/src/domains.ts
@@ -58,12 +58,6 @@ export function getExternalNetworkAlias(container: ContainerNames): string {
   return `${shortUniqueDappnodeEns(fullEns)}.external`;
 }
 
-
-export function getExternalNetworkAliasFromPackage(dnpName: string, serviceName: string): string {
-  const fullEns = getContainerDomain({dnpName, serviceName});
-  return `${shortUniqueDappnodeEns(fullEns)}.external`;
-}
-
 export function getPublicSubdomain(container: ContainerNames): string {
   const fullEns = getContainerDomain(container);
   return stripBadDomainChars(shortUniqueDappnodeEns(fullEns));

--- a/packages/dappmanager/src/domains.ts
+++ b/packages/dappmanager/src/domains.ts
@@ -58,6 +58,12 @@ export function getExternalNetworkAlias(container: ContainerNames): string {
   return `${shortUniqueDappnodeEns(fullEns)}.external`;
 }
 
+
+export function getExternalNetworkAliasFromPackage(dnpName: string, serviceName: string): string {
+  const fullEns = getContainerDomain({dnpName, serviceName});
+  return `${shortUniqueDappnodeEns(fullEns)}.external`;
+}
+
 export function getPublicSubdomain(container: ContainerNames): string {
   const fullEns = getContainerDomain(container);
   return stripBadDomainChars(shortUniqueDappnodeEns(fullEns));

--- a/packages/dappmanager/src/modules/https-portal/index.ts
+++ b/packages/dappmanager/src/modules/https-portal/index.ts
@@ -74,7 +74,7 @@ export class HttpsPortal {
     const httpsComposePath = ComposeEditor.getComposePath(params.HTTPS_PORTAL_DNPNAME, true)
     const editor = new ComposeEditor(ComposeEditor.readFrom(httpsComposePath))
 
-    if(editor.getComposeNetwork(externalNetworkName) === null) {
+    if (editor.getComposeNetwork(externalNetworkName) === null) {
       const httpsExternalAlias = getExternalNetworkAlias(httpsPortalContainer)
       addNetworkAliasCompose(httpsPortalContainer, externalNetworkName, [httpsExternalAlias])
     }
@@ -146,13 +146,13 @@ export class HttpsPortal {
     return mappings;
   }
 
-  async hasMapping(dnpName: string, serviceName: string) : Promise<boolean> {
+  async hasMapping(dnpName: string, serviceName: string): Promise<boolean> {
 
     const entries = await this.httpsPortalApiClient.list();
     const mappingAlias = getExternalNetworkAliasFromPackage(dnpName, serviceName);
     for (const { fromSubdomain, toHost } of entries) {
       const [alias, port] = toHost.split(":");
-      if(alias === mappingAlias) {
+      if (alias === mappingAlias) {
         return true;
       }
     }

--- a/packages/dappmanager/src/modules/https-portal/index.ts
+++ b/packages/dappmanager/src/modules/https-portal/index.ts
@@ -6,7 +6,7 @@ import {
 } from "../docker";
 import { listContainers } from "../docker/list";
 import params from "../../params";
-import { getExternalNetworkAlias } from "../../domains";
+import { getExternalNetworkAlias, getExternalNetworkAliasFromPackage } from "../../domains";
 import { PackageContainer, HttpsPortalMapping } from "../../types";
 import { HttpsPortalApiClient } from "./apiClient";
 import { addNetworkAliasCompose, removeNetworkAliasCompose } from "./utils";
@@ -144,6 +144,19 @@ export class HttpsPortal {
       }
     }
     return mappings;
+  }
+
+  async hasMapping(dnpName: string, serviceName: string) : Promise<boolean> {
+
+    const entries = await this.httpsPortalApiClient.list();
+    const mappingAlias = getExternalNetworkAliasFromPackage(dnpName, serviceName);
+    for (const { fromSubdomain, toHost } of entries) {
+      const [alias, port] = toHost.split(":");
+      if(alias === mappingAlias) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private async getContainerForMapping(

--- a/packages/dappmanager/src/modules/https-portal/index.ts
+++ b/packages/dappmanager/src/modules/https-portal/index.ts
@@ -6,7 +6,7 @@ import {
 } from "../docker";
 import { listContainers } from "../docker/list";
 import params from "../../params";
-import { getExternalNetworkAlias, getExternalNetworkAliasFromPackage } from "../../domains";
+import { getExternalNetworkAlias } from "../../domains";
 import { PackageContainer, HttpsPortalMapping } from "../../types";
 import { HttpsPortalApiClient } from "./apiClient";
 import { addNetworkAliasCompose, removeNetworkAliasCompose } from "./utils";
@@ -69,14 +69,18 @@ export class HttpsPortal {
     // Edit compose to persist the setting
     addNetworkAliasCompose(container, externalNetworkName, aliases);
 
-
     // Check whether DNP_HTTPS compose has external network persisted
-    const httpsComposePath = ComposeEditor.getComposePath(params.HTTPS_PORTAL_DNPNAME, true)
-    const editor = new ComposeEditor(ComposeEditor.readFrom(httpsComposePath))
+    const httpsComposePath = ComposeEditor.getComposePath(
+      params.HTTPS_PORTAL_DNPNAME,
+      true
+    );
+    const editor = new ComposeEditor(ComposeEditor.readFrom(httpsComposePath));
 
     if (editor.getComposeNetwork(externalNetworkName) === null) {
-      const httpsExternalAlias = getExternalNetworkAlias(httpsPortalContainer)
-      addNetworkAliasCompose(httpsPortalContainer, externalNetworkName, [httpsExternalAlias])
+      const httpsExternalAlias = getExternalNetworkAlias(httpsPortalContainer);
+      addNetworkAliasCompose(httpsPortalContainer, externalNetworkName, [
+        httpsExternalAlias
+      ]);
     }
   }
 
@@ -146,15 +150,16 @@ export class HttpsPortal {
     return mappings;
   }
 
+  /**
+   * Returns true if the container has assigned a mapping to the https-portal
+   */
   async hasMapping(dnpName: string, serviceName: string): Promise<boolean> {
-
     const entries = await this.httpsPortalApiClient.list();
-    const mappingAlias = getExternalNetworkAliasFromPackage(dnpName, serviceName);
-    for (const { fromSubdomain, toHost } of entries) {
-      const [alias, port] = toHost.split(":");
-      if (alias === mappingAlias) {
-        return true;
-      }
+    const mappingAlias = getExternalNetworkAlias({ serviceName, dnpName });
+    for (const { toHost } of entries) {
+      // toHost format: someDomain:80
+      const alias = toHost.split(":")[0];
+      if (alias === mappingAlias) return true;
     }
     return false;
   }

--- a/packages/dappmanager/src/modules/installer/https.ts
+++ b/packages/dappmanager/src/modules/installer/https.ts
@@ -1,0 +1,142 @@
+import { listPackageNoThrow } from "../docker/list/listPackages";
+import { httpsPortal } from "../../calls/httpsPortal";
+import { prettyDnpName } from "../../utils/format";
+import params from "../../params";
+import { InstallPackageData } from "../../types";
+import { Log } from "../../utils/logUi";
+import { HttpsPortalMapping } from "../../common";
+import { getExternalNetworkAliasFromPackage } from "../../domains";
+import { ComposeFileEditor } from "../compose/editor";
+import { dockerListNetworks, dockerCreateNetwork } from "../docker";
+
+/**
+ * Recreate HTTPs portal mapping if installing or updating HTTPs package
+ */
+export async function httpsEnsureNetworkExists(
+  pkg: InstallPackageData,
+  externalNetworkName: string
+): Promise<void> {
+  const networks = await dockerListNetworks();
+  if (!networks.find(network => network.Name === externalNetworkName)) {
+    await dockerCreateNetwork(externalNetworkName);
+  }
+
+  // Check whether DNP_HTTPS compose has external network persisted
+  const compose = new ComposeFileEditor(pkg.dnpName, true);
+  if (compose.getComposeNetwork(externalNetworkName) === null) {
+    const composeService = compose.firstService();
+    const alias = getExternalNetworkAliasFromPackage(
+      pkg.dnpName,
+      composeService.serviceName
+    );
+    const aliases = [alias];
+    composeService.addNetwork(externalNetworkName, { aliases });
+    compose.write();
+  }
+}
+
+/**
+ * Persist external network on packages compose files
+ */
+export async function httpsPersistPackagesExternalNetwork(
+  pkg: InstallPackageData,
+  externalNetworkName: string
+): Promise<void> {
+  const compose = new ComposeFileEditor(pkg.dnpName, true);
+  const services = Object.entries(compose.services());
+
+  for (const [serviceName, composeServiceEditor] of services) {
+    if (await httpsPortal.hasMapping(pkg.dnpName, serviceName)) {
+      const networks = await dockerListNetworks();
+      if (!networks.find(network => network.Name === externalNetworkName)) {
+        await dockerCreateNetwork(externalNetworkName);
+      }
+
+      const alias = getExternalNetworkAliasFromPackage(
+        pkg.dnpName,
+        serviceName
+      );
+      const aliases = [alias];
+      composeServiceEditor.addNetwork(externalNetworkName, { aliases });
+      compose.write();
+    }
+  }
+}
+
+/**
+ * Expose default HTTPS ports on installation defined in the manifest - exposable
+ */
+export async function httpsExposeByDefaultPorts(
+  pkg: InstallPackageData,
+  log: Log
+): Promise<void> {
+  if (pkg.metadata.exposable) {
+    // Check HTTPS package exists
+    const httpsPackage = await listPackageNoThrow({
+      dnpName: params.HTTPS_PORTAL_DNPNAME
+    });
+    if (!httpsPackage)
+      throw Error(
+        `HTTPS package not found but required to expose HTTPS ports by default. Install HTTPS package first.`
+      );
+    // Check HTTPS package running
+    httpsPackage.containers.map(container => {
+      if (!container.running)
+        throw Error(
+          `HTTPS package not running but required to expose HTTPS ports by default.`
+        );
+    });
+    const currentMappings = await httpsPortal.getMappings();
+    const portMappinRollback: HttpsPortalMapping[] = [];
+
+    for (const exposable of pkg.metadata.exposable) {
+      if (exposable.exposeByDefault) {
+        const portalMapping: HttpsPortalMapping = {
+          fromSubdomain: exposable.fromSubdomain || prettyDnpName(pkg.dnpName), // get dnpName by default
+          dnpName: pkg.dnpName,
+          serviceName:
+            exposable.serviceName || Object.keys(pkg.compose.services)[0], // get first service name by default (docs: https://docs.dappnode.io/es/developers/manifest-reference/#servicename)
+          port: exposable.port
+        };
+
+        if (
+          currentMappings.length > 0 &&
+          currentMappings.includes(portalMapping)
+        )
+          continue;
+
+        try {
+          // Expose default HTTPS ports
+          log(
+            pkg.dnpName,
+            `Exposing ${prettyDnpName(pkg.dnpName)}:${
+              exposable.port
+            } to the external internet`
+          );
+          await httpsPortal.addMapping(portalMapping);
+          portMappinRollback.push(portalMapping);
+
+          log(
+            pkg.dnpName,
+            `Exposed ${prettyDnpName(pkg.dnpName)}:${
+              exposable.port
+            } to the external internet`
+          );
+        } catch (e) {
+          e.message = `${e.message} Error exposing default HTTPS ports, removing mappings`;
+          for (const mappingRollback of portMappinRollback) {
+            await httpsPortal.removeMapping(mappingRollback).catch(e => {
+              log(
+                pkg.dnpName,
+                `Error removing mapping ${JSON.stringify(mappingRollback)}, ${
+                  e.message
+                }`
+              );
+            });
+          }
+          throw e;
+        }
+      }
+    }
+  }
+}

--- a/packages/dappmanager/src/modules/installer/https.ts
+++ b/packages/dappmanager/src/modules/installer/https.ts
@@ -59,6 +59,7 @@ export async function httpsPersistPackagesExternalNetwork(
       const aliases = [alias];
       composeServiceEditor.addNetwork(externalNetworkName, { aliases });
       compose.write();
+      break;
     }
   }
 }

--- a/packages/dappmanager/src/modules/installer/https.ts
+++ b/packages/dappmanager/src/modules/installer/https.ts
@@ -135,13 +135,13 @@ export async function httpsExposeByDefaultPorts(
   }
 }
 
-async function hasRunningHTTPS(require: boolean = false) {
+async function hasRunningHTTPS(required: boolean = false) {
 
   const httpsPackage = await listPackageNoThrow({
     dnpName: params.HTTPS_PORTAL_DNPNAME
   });
   if (!httpsPackage) {
-    if(!require) {
+    if(!required) {
       return false;
     }
 
@@ -153,7 +153,7 @@ async function hasRunningHTTPS(require: boolean = false) {
   // Check HTTPS package running
   httpsPackage.containers.forEach(container => {
     if (!container.running){
-      if(!require) {
+      if(!required) {
         return false;
       }
       throw Error(

--- a/packages/dappmanager/src/modules/installer/https.ts
+++ b/packages/dappmanager/src/modules/installer/https.ts
@@ -42,7 +42,7 @@ export async function httpsPersistPackagesExternalNetwork(
   pkg: InstallPackageData,
   externalNetworkName: string
 ): Promise<void> {
-  const compose = new ComposeFileEditor(pkg.dnpName, true);
+  const compose = new ComposeFileEditor(pkg.dnpName, pkg.isCore);
   const services = Object.entries(compose.services());
 
   for (const [serviceName, composeServiceEditor] of services) {

--- a/packages/dappmanager/src/modules/installer/https.ts
+++ b/packages/dappmanager/src/modules/installer/https.ts
@@ -43,7 +43,7 @@ export async function httpsPersistPackagesExternalNetwork(
   externalNetworkName: string
 ): Promise<void> {
 
-  if(!hasRunningHTTPS()) { // if there is no https, checks aren't needed
+  if(!(await hasRunningHTTPS())) { // if there is no https, checks aren't needed
     return;
   }
   const compose = new ComposeFileEditor(pkg.dnpName, pkg.isCore);
@@ -78,7 +78,7 @@ export async function httpsExposeByDefaultPorts(
   if (pkg.metadata.exposable) {
     // Check HTTPS package exists
 
-    hasRunningHTTPS(true); // require that https package exists and it is running
+    await hasRunningHTTPS(true); // require that https package exists and it is running
 
     const currentMappings = await httpsPortal.getMappings();
     const portMappinRollback: HttpsPortalMapping[] = [];
@@ -141,7 +141,7 @@ async function hasRunningHTTPS(require: boolean = false) {
     dnpName: params.HTTPS_PORTAL_DNPNAME
   });
   if (!httpsPackage) {
-    if(require) {
+    if(!require) {
       return false;
     }
 
@@ -153,7 +153,7 @@ async function hasRunningHTTPS(require: boolean = false) {
   // Check HTTPS package running
   httpsPackage.containers.forEach(container => {
     if (!container.running){
-      if(require) {
+      if(!require) {
         return false;
       }
       throw Error(

--- a/packages/dappmanager/src/modules/installer/runPackages.ts
+++ b/packages/dappmanager/src/modules/installer/runPackages.ts
@@ -8,10 +8,7 @@ import { InstallPackageData } from "../../types";
 import { logs } from "../../logs";
 import { dockerComposeUpPackage } from "../docker";
 import { packageToInstallHasPid } from "../../utils/pid";
-import {
-  connectToPublicNetwork,
-  httpsExposeByDefaultPorts,
-} from "./https";
+import { connectToPublicNetwork, exposeByDefaultHttpsPorts } from "./https";
 
 const externalNetworkName = params.DNP_EXTERNAL_NETWORK_NAME;
 
@@ -85,9 +82,8 @@ export async function runPackages(
     log(pkg.dnpName, "Package started");
 
     // Expose default HTTPs ports if required
-    
+
     await connectToPublicNetwork(pkg, externalNetworkName);
-    await httpsExposeByDefaultPorts(pkg, log);
-  
+    await exposeByDefaultHttpsPorts(pkg, log);
   }
 }

--- a/packages/dappmanager/src/modules/installer/runPackages.ts
+++ b/packages/dappmanager/src/modules/installer/runPackages.ts
@@ -45,11 +45,6 @@ export async function runPackages(
     // - Allow copying files without duplicating logic
     // - Allow conditionally starting containers latter if were previously running
     log(pkg.dnpName, "Preparing package...");
-
-    if (pkg.dnpName === params.HTTPS_PORTAL_DNPNAME)
-      await httpsEnsureNetworkExists(pkg, externalNetworkName);
-    else await httpsPersistPackagesExternalNetwork(pkg, externalNetworkName);
-
     await dockerComposeUp(pkg.composePath, {
       // To clean-up changing multi-service packages, remove orphans
       // but NOT for core packages, which always have orphans
@@ -91,6 +86,15 @@ export async function runPackages(
     log(pkg.dnpName, "Package started");
 
     // Expose default HTTPs ports if required
-    await httpsExposeByDefaultPorts(pkg, log);
+    
+    if (pkg.dnpName === params.HTTPS_PORTAL_DNPNAME) {
+      await httpsEnsureNetworkExists(externalNetworkName);
+    }
+      
+    else {
+      await httpsExposeByDefaultPorts(pkg, log);
+      await httpsPersistPackagesExternalNetwork(pkg, externalNetworkName);
+    }
+
   }
 }

--- a/packages/dappmanager/src/modules/installer/runPackages.ts
+++ b/packages/dappmanager/src/modules/installer/runPackages.ts
@@ -9,9 +9,8 @@ import { logs } from "../../logs";
 import { dockerComposeUpPackage } from "../docker";
 import { packageToInstallHasPid } from "../../utils/pid";
 import {
-  httpsEnsureNetworkExists,
+  connectToPublicNetwork,
   httpsExposeByDefaultPorts,
-  httpsPersistPackagesExternalNetwork
 } from "./https";
 
 const externalNetworkName = params.DNP_EXTERNAL_NETWORK_NAME;
@@ -87,14 +86,8 @@ export async function runPackages(
 
     // Expose default HTTPs ports if required
     
-    if (pkg.dnpName === params.HTTPS_PORTAL_DNPNAME) {
-      await httpsEnsureNetworkExists(externalNetworkName);
-    }
-      
-    else {
-      await httpsExposeByDefaultPorts(pkg, log);
-      await httpsPersistPackagesExternalNetwork(pkg, externalNetworkName);
-    }
-
+    await connectToPublicNetwork(pkg, externalNetworkName);
+    await httpsExposeByDefaultPorts(pkg, log);
+  
   }
 }


### PR DESCRIPTION
## Context

Packages which have HTTPS mappings on update inject docker-compose which doesn't necessarily have external network specified

## Approach

During installation process, DNP_HTTPS is queried whether mapping exists, and if it does it adds external network to the compose. 

## Test instructions

- Do HTTPS mapping on a package
- Update that same package
- Check if mapping is broken after update
- Test specially when package === DNP_HTTPS and when it is not