### PR TITLE
Limit resources feature

### DIFF
--- a/packages/admin-ui/src/common/types.ts
+++ b/packages/admin-ui/src/common/types.ts
@@ -1,5 +1,7 @@
 // Aliases
 
+import { ResourceLimits } from "worker_threads";
+
 export type DnpName = string;
 
 // AUTH, SESSION types
@@ -633,6 +635,13 @@ export interface ComposeService {
   container_name: string; // "DAppNodeCore-dappmanager.dnp.dappnode.eth";
   devices?: string[];
   depends_on?: string[];
+  deploy?: {
+    resources: {
+      limits: {
+        memory: string;
+      };
+    };
+  };
   dns?: string; // "172.33.1.2";
   entrypoint?: string;
   env_file?: string[];

--- a/packages/dappmanager/src/modules/compose/compose_v3x.schema.json
+++ b/packages/dappmanager/src/modules/compose/compose_v3x.schema.json
@@ -16,6 +16,22 @@
             "cap_add": { "$ref": "#/definitions/list_of_strings" },
             "cap_drop": { "$ref": "#/definitions/list_of_strings" },
             "devices": { "$ref": "#/definitions/list_of_strings" },
+            "deploy":{ 
+              "type": "object",
+              "properties":{ 
+                "resources":{
+                  "type": "object",
+                  "properties":{
+                    "limits":{
+                      "type": "object",
+                      "properties":{
+                        "memory":{ "type": "string" }
+                      }
+                    }
+                  }
+                }
+              }
+            },
             "environment": { "$ref": "#/definitions/list_or_dict" },
             "labels": { "$ref": "#/definitions/list_or_dict" },
             "mac_address": { "type": "string" },

--- a/packages/dappmanager/src/modules/compose/unsafeCompose.ts
+++ b/packages/dappmanager/src/modules/compose/unsafeCompose.ts
@@ -35,6 +35,7 @@ const serviceSafeKeys: (keyof ComposeService)[] = [
   "cap_drop",
   "command",
   "depends_on",
+  "deploy",
   "devices",
   "entrypoint",
   "environment",


### PR DESCRIPTION
## Context

If some package has a problem because of the usage of resources, nethermind-xdai client, it would be interesting to be able to limit the amount of resources a package can use in order to protect the performance of the dappnode.
The feature is to let the dappmanager accepts the deploy option of docker-compose.

## Approach

> Define the solution for the issue or feature that this PR aims to fix
This issue https://github.com/dappnode/DAppNode/issues/419

## Test instructions

<!-- MANDATORY: please, do not skip this step, it is very important for DAppNode team to have simple and well-defined instructions on how to test this PR.
-->
In order to test this feature you need to install a package where you add these lines to the docker-compose:
```
    deploy:
      resources:
        limits:
          memory: 5000M
```
Then, once you have installed the package you need to access to the machine cli and type the command `docker stats`
and check the memory limit of the package you have instaled.

