### PR TITLE
Only pin if is ipfs local

### DIFF
--- a/packages/dappmanager/src/modules/ipfs/Ipfs.ts
+++ b/packages/dappmanager/src/modules/ipfs/Ipfs.ts
@@ -105,8 +105,13 @@ export class Ipfs {
   }
 
   async pinAddNoThrow(hash: IPFSPath): Promise<void> {
-    await this.pinAdd(hash).catch((e: Error) =>
-      logs.error(`Error pinning hash ${hash}`, e)
-    );
+    // Pin release on visit
+    if (db.ipfsClientTarget.get() === "local") {
+      await this.pinAdd(hash).catch((e: Error) =>
+        logs.error(`Error pinning hash ${hash}`, e)
+      );
+    } else {
+      logs.info("Pinning hash not supported when using remote ipfs client");
+    }
   }
 }

--- a/packages/dappmanager/src/modules/release/ipfs/downloadRelease.ts
+++ b/packages/dappmanager/src/modules/release/ipfs/downloadRelease.ts
@@ -18,6 +18,7 @@ import { downloadAssetRequired } from "./downloadAssets";
 import { isDirectoryRelease } from "./isDirectoryRelease";
 import { serializeIpfsDirectory } from "../releaseSignature";
 import { ReleaseDownloadedContents } from "../types";
+import * as db from "../../../db";
 
 const source = "ipfs" as const;
 
@@ -73,7 +74,7 @@ async function downloadReleaseIpfsFn(
       );
 
       // Pin release on visit
-      ipfs.pinAddNoThrow(hash);
+      if (db.ipfsClientTarget.get() === "local") ipfs.pinAddNoThrow(hash);
 
       // Fetch image by arch, will throw if not available
       const imageEntry = getImageByArch(manifest, files, arch);

--- a/packages/dappmanager/src/modules/release/ipfs/downloadRelease.ts
+++ b/packages/dappmanager/src/modules/release/ipfs/downloadRelease.ts
@@ -18,7 +18,6 @@ import { downloadAssetRequired } from "./downloadAssets";
 import { isDirectoryRelease } from "./isDirectoryRelease";
 import { serializeIpfsDirectory } from "../releaseSignature";
 import { ReleaseDownloadedContents } from "../types";
-import * as db from "../../../db";
 
 const source = "ipfs" as const;
 
@@ -73,8 +72,7 @@ async function downloadReleaseIpfsFn(
         files
       );
 
-      // Pin release on visit
-      if (db.ipfsClientTarget.get() === "local") ipfs.pinAddNoThrow(hash);
+      ipfs.pinAddNoThrow(hash);
 
       // Fetch image by arch, will throw if not available
       const imageEntry = getImageByArch(manifest, files, arch);


### PR DESCRIPTION
<!-- For DAppNode core members, once the Pull Request is created, do not forget to:
1.  Link issues to the PR if available
2.  Mention dappnode core members
3.  Add proper labels
-->

## Context

Ipfs was pinning content on every visit to the dappstore by the user. This is fine when using IPFS local but not when using IPFS remote.

## Approach

Only pin when using IPFS local.
## Test instructions

<!-- MANDATORY: please, do not skip this step, it is very importand for DAppNode team to have simple and well defined instructions on how to test this PR.
-->

- Test that visiting the dappstore using IPFS local does pins the content
- Test that visiting the dappstore using IPFS remote does not pin the content
