### PR TITLE
Fix lvm.sh file

### DIFF
--- a/packages/dappmanager/hostScripts/lvm.sh
+++ b/packages/dappmanager/hostScripts/lvm.sh
@@ -46,7 +46,7 @@ function extend_disk () {
   # Logical volume
   lvs --noheadings -o lv_name | grep -q "$3" || { echo "Error: Logical volume ${3} not found" | tee -a "$LOG_FILE"; exit 1; }
   # 2. Create pv
-  pvcreate "/dev/${1}" &>> "$LOG_FILE"
+  pvcreate "/dev/${1}" -y &>> "$LOG_FILE"
   # 3. Extend vg
   vgextend "$2" "/dev/${1}" &>> "$LOG_FILE"
   # 4. Extend lv


### PR DESCRIPTION
It was required to add the -y flag when the pvcreate command is executed.

## Context

If you try to expand the hard disk of your dappnode and the disk you want to expand contains something, it appears a warning message and the script stop working.

## Approach

It's required to add the -y in the line where the command pvcreate is used.

## Test instructions

Use the expand disk function.
