### PR TITLE
Remove properties from knownChains

### DIFF
--- a/packages/dappmanager/src/modules/chains/getChainDriverName.ts
+++ b/packages/dappmanager/src/modules/chains/getChainDriverName.ts
@@ -11,14 +11,11 @@ export function getChainDriverName(
 }
 
 const knownChains: { [dnpName: string]: ChainDriver } = {
-  "openethereum.dnp.dappnode.eth": "ethereum",
-  "ropsten.dnp.dappnode.eth": "ethereum",
-  "rinkeby.dnp.dappnode.eth": "ethereum",
-  "kovan.dnp.dappnode.eth": "ethereum",
-  "bitcoin.dnp.dappnode.eth": "bitcoin",
-  "monero.dnp.dappnode.eth": "monero",
-  "prysm.dnp.dappnode.eth": "ethereum-beacon-chain",
-  "prysm-prater.dnp.dappnode.eth": "ethereum-beacon-chain",
-  "lighthouse-prater.dnp.dappnode.eth": "ethereum-beacon-chain",
-  "teku-prater.dnp.dappnode.eth": "ethereum-beacon-chain"
+  // Pending: https://github.com/dappnode/DAppNodePackage-prysm/pull/65
+  "prysm.dnp.dappnode.eth": "ethereum-beacon-chain"
+  // ===============================
+  // DO NOT ADD ANY NEW PACKAGE HERE
+  // ===============================
+  // Instead add "chain" property in your package, like https://github.com/dappnode/DAppNodePackage-prysm/pull/65
+  // Full docs: https://docs.dappnode.io/developers/manifest-reference#chain
 };


### PR DESCRIPTION
knownChains are a boostrap mechanism to enable the chains feature before we released versions for all packages. That's the only purpose of that file, not to add new packages that can just have the chain property in the manifest.

Instead add "chain" property in your package, like https://github.com/dappnode/DAppNodePackage-prysm/pull/65. Full docs: https://docs.dappnode.io/developers/manifest-reference#chain

I've checked every package manually to ensure all of them define the chain property. All are fine except https://github.com/dappnode/DAppNodePackage-prysm/pull/65

```ts
const knownChains: { [dnpName: string]: ChainDriver } = {
  // Has `"chain": "ethereum"` in v0.2.12
  "openethereum.dnp.dappnode.eth": "ethereum",
  // Has `chain "ethereum"` in v0.3.14
  "ropsten.dnp.dappnode.eth": "ethereum",
  // Has `chain: "ethereum"` in v0.4.20
  "rinkeby.dnp.dappnode.eth": "ethereum",
  // Has `chain: "ethereum"` in v0.2.0
  "kovan.dnp.dappnode.eth": "ethereum",
  // Has `chain: "bitcoin"` in v0.1.8
  "bitcoin.dnp.dappnode.eth": "bitcoin",
  // Has `chain: "monero"` in v0.2.5
  "monero.dnp.dappnode.eth": "monero",
  // Pending: https://github.com/dappnode/DAppNodePackage-prysm/pull/65
  "prysm.dnp.dappnode.eth": "ethereum-beacon-chain",
  // Has `chain: "ethereum-beacon-chain"` in v1.0.4
  "prysm-prater.dnp.dappnode.eth": "ethereum-beacon-chain",
  // Has `chain: "ethereum-beacon-chain"` in v0.1.1
  "lighthouse-prater.dnp.dappnode.eth": "ethereum-beacon-chain",
  // Has `chain: "ethereum-beacon-chain"` in v0.1.2
  "teku-prater.dnp.dappnode.eth": "ethereum-beacon-chain"
};
```