### PR TITLE
Update & install docker-compose in dappmanager

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,13 +59,13 @@ RUN apk add --no-cache bind-tools docker
 #####################################
 FROM node:16.15.0-alpine
 
-ENV DOCKER_COMPOSE_VERSION 1.25.5
+ENV DOCKER_COMPOSE_VERSION v2.5.0
 
 RUN apk add --no-cache curl bind-dev xz libltdl miniupnpc zip unzip dbus bind \
   # See https://github.com/dappnode/DNP_DAPPMANAGER/issues/669
   avahi-tools
 
-RUN curl -L https://github.com/dappnode/compose/releases/download/$DOCKER_COMPOSE_VERSION/docker-compose-Linux-$(uname -m) > /usr/local/bin/docker-compose \
+RUN curl -L https://github.com/docker/compose/releases/download/$DOCKER_COMPOSE_VERSION/docker-compose-linux-$(uname -m) > /usr/local/bin/docker-compose \
   && chmod +x /usr/local/bin/docker-compose
 
 WORKDIR /usr/src/app


### PR DESCRIPTION
With these changes, the dappmanager installs docker-compose using the official repo of docker-compose and install the v2.5.0 version

This pr is part of this https://github.com/dappnode/DNP_DAPPMANAGER/issues/1015

> Provide context of this PR: why it was created? what does it fix? what new feature does it provide? ...

## Approach

This PR install version v2.5.0 in the dappmanager and change how the docker-compose is installed. Modify the dappmanager dockerfile.

## Test instructions

There is 2 kind of tests here:
- Test to check the dappmanager is using this version.
- Test to check a different kind of operations works with this new version of docker-compose.

## Check docker-compose version
Go into the dappnode and go inside of the dappmanager container and check the version or execute the next command:
`docker exec -it DAppNodeCore-dappmanager.dnp.dappnode.eth docker-compose -v`

## Check if the next operations work while you checks the logs of the dappmanager
- Install a package
- Restart a package
- Stop a package
- Start a package
- Remove package


