### PR TITLE
add security_opt

### DIFF
--- a/packages/admin-ui/src/common/types.ts
+++ b/packages/admin-ui/src/common/types.ts
@@ -665,7 +665,7 @@ export interface ComposeService {
   user?: string;
   volumes?: string[]; // ["dappmanagerdnpdappnodeeth_data:/usr/src/app/dnp_repo/"];
   working_dir?: string;
-  security_opt: string[];
+  security_opt?: string[];
 }
 
 export interface ComposeServiceNetwork {

--- a/packages/admin-ui/src/common/types.ts
+++ b/packages/admin-ui/src/common/types.ts
@@ -665,6 +665,7 @@ export interface ComposeService {
   user?: string;
   volumes?: string[]; // ["dappmanagerdnpdappnodeeth_data:/usr/src/app/dnp_repo/"];
   working_dir?: string;
+  security_opt: string[];
 }
 
 export interface ComposeServiceNetwork {

--- a/packages/dappmanager/src/modules/compose/unsafeCompose.ts
+++ b/packages/dappmanager/src/modules/compose/unsafeCompose.ts
@@ -53,7 +53,8 @@ const serviceSafeKeys: (keyof ComposeService)[] = [
   "stop_signal",
   "user",
   "volumes",
-  "working_dir"
+  "working_dir",
+  "security_opt"
 ];
 
 // Disallow external volumes to prevent packages accessing sensitive data of others


### PR DESCRIPTION
<!-- For DAppNode core members, once the Pull Request is created, do not forget to:
1.  Link issues to the PR if available
2.  Mention dappnode core members
3.  Add proper labels
-->

## Context

Add the `security_opt` to the docker compose safe keys. See https://docs.docker.com/compose/compose-file/#security_opt

This is necessary to install the web3signer package which has included this key to avoid an environment error

## Approach

Add the key

## Test instructions

<!-- MANDATORY: please, do not skip this step, it is very importand for DAppNode team to have simple and well defined instructions on how to test this PR.
-->

Test installation package works as expected
