### PR TITLE
Set max WPA characters for passphrase

### DIFF
--- a/packages/admin-ui/src/utils/validation.ts
+++ b/packages/admin-ui/src/utils/validation.ts
@@ -42,7 +42,7 @@ export function validateStrongPassword(password: string): string | null {
     return `Password must be at least ${argMinLen} characters long`;
   }
    if (password.length > argMaxLen) {
-    return `Password must be less than ${argMaxLen} characters long`;
+    return `Password must not exeed ${argMaxLen} characters long`;
   }
   if (!/\d+/.test(password)) {
     return "Password must contain at least one number";

--- a/packages/admin-ui/src/utils/validation.ts
+++ b/packages/admin-ui/src/utils/validation.ts
@@ -1,4 +1,5 @@
 const argMinLen = 8;
+const argMaxLen = 63;
 
 export function validateDockerEnv(
   value: string,
@@ -26,9 +27,22 @@ export function validateMinLength(
   return null;
 }
 
+export function validateMiaxLength(
+  value: string,
+  argName: string
+): string | null {
+  if (value.length > argMiaxLen) {
+    return `${argName} must be at less than ${argMaxLen} characters long`;
+  }
+  return null;
+}
+
 export function validateStrongPassword(password: string): string | null {
   if (password.length < argMinLen) {
     return `Password must be at least ${argMinLen} characters long`;
+  }
+   if (password.length > argMaxLen) {
+    return `Password must be less than ${argMaxLen} characters long`;
   }
   if (!/\d+/.test(password)) {
     return "Password must contain at least one number";

--- a/packages/admin-ui/src/utils/validation.ts
+++ b/packages/admin-ui/src/utils/validation.ts
@@ -42,7 +42,7 @@ export function validateStrongPassword(password: string): string | null {
     return `Password must be at least ${argMinLen} characters long`;
   }
    if (password.length > argMaxLen) {
-    return `Password must not exeed ${argMaxLen} characters long`;
+    return `Password must not exceed ${argMaxLen} characters long`;
   }
   if (!/\d+/.test(password)) {
     return "Password must contain at least one number";

--- a/packages/admin-ui/src/utils/validation.ts
+++ b/packages/admin-ui/src/utils/validation.ts
@@ -31,7 +31,7 @@ export function validateMiaxLength(
   value: string,
   argName: string
 ): string | null {
-  if (value.length > argMiaxLen) {
+  if (value.length > argMaxLen) {
     return `${argName} must be at less than ${argMaxLen} characters long`;
   }
   return null;

--- a/packages/admin-ui/src/utils/validation.ts
+++ b/packages/admin-ui/src/utils/validation.ts
@@ -27,7 +27,7 @@ export function validateMinLength(
   return null;
 }
 
-export function validateMiaxLength(
+export function validateMaxLength(
   value: string,
   argName: string
 ): string | null {


### PR DESCRIPTION
fixes #1024

<!-- For DAppNode core members, once the Pull Request is created, do not forget to:
1.  Link issues to the PR if available
2.  Mention dappnode core members
3.  Add proper labels
-->

## Context
Fixes #1024 (by making the max WPA passphrase character length an argument in the validator implemented the same as the minimum is, makes it so that this endless loop from #1024 to not be a possible situation by properly setting the max length, a warning appears when it exceeds 63 characters as the WPA standard describes, and it is baked into the validation for password strength function keeping it so that the warning not just pops up over 63 characters, but even when the password is properly copied into the second field, it shows a match, but the change password button remains inactive until the passphrase meets the strong password requirements, which now include the max character length in addition to the minimum.

## Approach

Add new variable for the max length of 63 characters and implemented it alongside  and within the password strength validation functions with front end GUI warnings and making it not possible to set a password that is too long for the WPA standard. and warning the user as soon as they exceed 63 characters

## Test instructions

<!-- MANDATORY: please, do not skip this step, it is very importand for DAppNode team to have simple and well defined instructions on how to test this PR.
-->
Check Netlify and test.  IPFS hash will be uploaded by CI  for install too.
