### PR TITLE
Migrate ipfs gateway endpoint 

### DIFF
--- a/packages/dappmanager/src/initializeDb.ts
+++ b/packages/dappmanager/src/initializeDb.ts
@@ -30,6 +30,11 @@ const getPublicIpFromUrlsSafe = returnNullIfError(getPublicIpFromUrls);
  */
 export default async function initializeDb(): Promise<void> {
   /**
+   * Migrate dappnode ipfs gateway endpoint
+   */
+  migrateIpfsGatewayEndpoint();
+
+  /**
    * Migrate data from the VPN db
    * - dyndns identity (including the domain)
    * - staticIp (if set)
@@ -137,6 +142,15 @@ export default async function initializeDb(): Promise<void> {
 }
 
 /**
+ * Migrate ipfs remote gateway endpoint from http://ipfs.dappnode.io:8081 to https://ipfs.gateway.dappnode.io
+ * The endpoint http://ipfs.dappnode.io:8081 is being deprecated
+ */
+function migrateIpfsGatewayEndpoint(): void {
+  if (db.ipfsGateway.get() === "http://ipfs.dappnode.io:8081")
+    db.ipfsGateway.set(params.IPFS_REMOTE);
+}
+
+/**
  * Migrate data from the VPN db
  * - dyndns identity (including the domain)
  * - staticIp (if set)
@@ -221,7 +235,7 @@ function returnNullIfError(
   fn: () => Promise<string>,
   silent?: boolean
 ): () => Promise<string | null> {
-  return async function(): Promise<string | null> {
+  return async function (): Promise<string | null> {
     try {
       return await fn();
     } catch (e) {

--- a/packages/dappmanager/src/initializeDb.ts
+++ b/packages/dappmanager/src/initializeDb.ts
@@ -32,7 +32,7 @@ export default async function initializeDb(): Promise<void> {
   /**
    * Migrate dappnode ipfs gateway endpoint
    */
-  migrateIpfsGatewayEndpoint();
+  migrateDappnodeIpfsGatewayEndpoint();
 
   /**
    * Migrate data from the VPN db
@@ -145,7 +145,7 @@ export default async function initializeDb(): Promise<void> {
  * Migrate ipfs remote gateway endpoint from http://ipfs.dappnode.io:8081 to https://ipfs.gateway.dappnode.io
  * The endpoint http://ipfs.dappnode.io:8081 is being deprecated
  */
-function migrateIpfsGatewayEndpoint(): void {
+function migrateDappnodeIpfsGatewayEndpoint(): void {
   if (db.ipfsGateway.get() === "http://ipfs.dappnode.io:8081")
     db.ipfsGateway.set(params.IPFS_REMOTE);
 }


### PR DESCRIPTION
<!-- For DAppNode core members, once the Pull Request is created, do not forget to:
1.  Link issues to the PR if available
2.  Mention dappnode core members
3.  Add proper labels
-->

## Context

The ipfs gateway endpoint http://ipfs.dappnode.io:8081 is being deprecated by https://gateway.ipfs.dappnode.io

## Approach

Migrate the old dappnode ipfs gateway with the new one ONLY if is set to such endpoint

## Test instructions

<!-- MANDATORY: please, do not skip this step, it is very important for DAppNode team to have simple and well-defined instructions on how to test this PR.
-->

- Having the old ipfs endpoint, after the update it should have been changed by the new one
- Having any other endpoint it should persist
- Ipfs remote should work as expected
