### PR TITLE
Forbid bind mounts

### DIFF
--- a/packages/dappmanager/src/modules/compose/unsafeCompose.ts
+++ b/packages/dappmanager/src/modules/compose/unsafeCompose.ts
@@ -201,10 +201,15 @@ function parseUnsafeVolumes(
 ): ComposeVolumes | undefined {
   if (!volumes) return undefined;
 
-  // External volumes are not allowed
+  // External volumes and bind mounts are not allowed
   for (const [volName, vol] of Object.entries(volumes)) {
-    if (vol && vol.external)
-      throw Error(`External volumes are not allowed '${volName}'`);
+    if (vol)
+    {
+      if(vol.external)
+        throw Error(`External volumes are not allowed '${volName}'`);
+      if (!vol.isNamed) // Volumes that are not named are bind mounts
+        throw Error(`Bind mounts are not allowed.`);
+    }
   }
 
   return mapValues(volumes, vol => pick(vol, volumeSafeKeys));

--- a/packages/dappmanager/src/modules/compose/volumes.ts
+++ b/packages/dappmanager/src/modules/compose/volumes.ts
@@ -27,7 +27,7 @@ export function parseVolumeMappings(volumesArray: string[]): VolumeMapping[] {
         const [host, container] = volString
           .split(/:(.*)/)
           .map(normalizeVolumePath);
-        const isNamed = !host.startsWith("/") && !host.startsWith("~");
+        const isNamed = !host.startsWith("/") && !host.startsWith("~") && !host.startsWith("./");
         return {
           host,
           container,


### PR DESCRIPTION
## Context

Bind mounts can be a security issue, especially when mounting important sockets like docker socket (see #983).

## Approach

 This PR would forbid all bind mounts since using bind mounts in dappnode packages have limited use.

## Test instructions

1) Go through all packages and see wheter bind mounts are used and research alternative if they are since this will break those packages
2) Try to install package with and without bind mount. Former should break, latter should go through.


For now, I will leave this as draft since after testing 1) we may have to add whitelist for some packages.