### PR TITLE
Remove https portal mapping when removing a package

### DIFF
--- a/packages/dappmanager/src/calls/packageRemove.ts
+++ b/packages/dappmanager/src/calls/packageRemove.ts
@@ -53,7 +53,10 @@ export async function packageRemove({
     }
   } catch (e) {
     // Bypass error to continue deleting the package
-    logs.error(`Error removing https mapping of ${dnp.dnpName}`, e);
+    logs.error(
+      `Error trying to remove https mappings from ${dnp.dnpName}. Continue with package remove`,
+      e
+    );
   }
 
   // Only no-cores reach this block

--- a/packages/dappmanager/src/calls/packageRemove.ts
+++ b/packages/dappmanager/src/calls/packageRemove.ts
@@ -74,7 +74,7 @@ export async function packageRemove({
   if (fs.existsSync(packageRepoDir)) await shell(`rm -r ${packageRepoDir}`);
 
   // Remove portal https portal mappings if any
-  if (await isRunningHttps()) {
+  if ((await isRunningHttps()) === true) {
     const mappings = await httpsPortal.getMappings(dnp.containers);
     for (const mapping of mappings) {
       if (mapping.dnpName === dnpName) {

--- a/packages/dappmanager/src/modules/https-portal/utils/isRunningHttps.ts
+++ b/packages/dappmanager/src/modules/https-portal/utils/isRunningHttps.ts
@@ -1,5 +1,5 @@
 import params from "../../../params";
-import { listPackageNoThrow } from "../../docker/list";
+import { listPackageNoThrow } from "../../docker/list/listPackages";
 
 /**
  * Returns true if HTTPS package installed and running, otherwise return false


### PR DESCRIPTION
<!-- For DAppNode core members, once the Pull Request is created, do not forget to:
1.  Link issues to the PR if available
2.  Mention dappnode core members
3.  Add proper labels
-->

## Context

HTTPS portal mappings were not removed when uninstalling a dappnode package. This is an unexpected behavior, that prevented from reinstalling a package with an existing portal mapping.

## Approach

Remove portal mappings when uninstalling a dappnode package

## Test instructions

Install a dappnode package with a portal mapping defined in the manifest. Remove the dappnode package and make sure the portal mapping was removed together with the package. Check the HTTPS volumes or use the HTTPS api to check the portal mappings
