### PR TITLE
Add prysm gnosis to `eth2MigrationRequirements`

### DIFF
--- a/packages/dappmanager/src/modules/installer/ensureEth2MigrationRequirements.ts
+++ b/packages/dappmanager/src/modules/installer/ensureEth2MigrationRequirements.ts
@@ -17,7 +17,7 @@ export function isClientLegacy(dnpName: string, dnpVersion: string): boolean {
 }
 
 /**
- * Ensure the following requirements for Eth2 migration, from dappmanager v0.2.46 prevent the following:
+ * Ensure the following requirements for Eth2 migration:
  * - Ensure not installing client legacy version (previous to remote signer support) for packages: (Prysm, Prysm-prater and Gnosis-Beacon-Chain-Prysm)
  * - Ensure not installing web3signer if Prysm package legacy version is installed
  */

--- a/packages/dappmanager/src/params.ts
+++ b/packages/dappmanager/src/params.ts
@@ -153,10 +153,17 @@ const params = {
 
   // Validators legacy versions: Prysm, Prysm-prater, Prysm-gnosis
   minimumAllowedClientsLegacyVersions: [
+    //  v0.2.46
     {
       clientDnpName: "prysm-prater.dnp.dappnode.eth",
       clientVersion: "0.1.7",
       web3signerDnpName: "web3signer-prater.dnp.dappnode.eth"
+    },
+    // v0.2.51
+    {
+      clientDnpName: "gnosis-beacon-chain-prysm.dnp.dappnode.eth",
+      clientVersion: "0.1.8",
+      web3signerDnpName: "web3signer-gnosis.dnp.dappnode.eth"
     }
   ],
 


### PR DESCRIPTION
<!-- For DAppNode core members, once the Pull Request is created, do not forget to:
1.  Link issues to the PR if available
2.  Mention dappnode core members
3.  Add proper labels
-->

## Context

The upcoming core release 0.2.56 will be mandatory for validating in gnosis chain with eth2 multiclient + web3signer.

## Approach

- Not allowed to installed legacy prsm gnosis (<=0.1.8)
- Not allowed to install web3signer gnosis if legacy prysm installed


## Test instructions

- Install a legacy version of prysm gnosis, then install the dappmanager to have this PR code, and finally try to install the web3signer gnosis. It should not be allowed.
- Install the dappmanager to have this PR code, the try to install a legacy version of prysm-gnosis. It should not be allowed.
