### PR TITLE
Add warning onRemove

### DIFF
--- a/packages/admin-ui/src/__mock-backend__/data/dnps/bitcoin.ts
+++ b/packages/admin-ui/src/__mock-backend__/data/dnps/bitcoin.ts
@@ -25,6 +25,9 @@ export const bitcoin: MockDnp = {
       "Eduardo Antuña <eduadiez@gmail.com> (https://github.com/eduadiez)",
       "Loco del Bitcoin <ellocodelbitcoin@gmail.com>"
     ],
+    warnings: {
+      onRemove: "Make sure you have change the endpoint in your bitcoin miner"
+    },
     keywords: ["bitcoin", "btc"],
     // @ts-ignore
     homepage: {

--- a/packages/admin-ui/src/pages/packages/components/Info/RemovePackage.tsx
+++ b/packages/admin-ui/src/pages/packages/components/Info/RemovePackage.tsx
@@ -19,11 +19,36 @@ interface WarningItem {
 }
 
 export function RemovePackage({ dnp }: { dnp: InstalledPackageDetailData }) {
-  const { dnpName, areThereVolumesToRemove, dependantsOf, notRemovable } = dnp;
+  const {
+    dnpName,
+    areThereVolumesToRemove,
+    dependantsOf,
+    notRemovable,
+    manifest
+  } = dnp;
 
   const history = useHistory();
 
   async function packageRemove() {
+    // Dialog to confirm warning onRemove from manifest
+    const removeWarnings = manifest?.warnings?.onRemove;
+    if (removeWarnings) {
+      await new Promise(
+        (resolve: (confirmOnRemoveWarning: boolean) => void) => {
+          confirm({
+            title: `Removal warning`,
+            text: removeWarnings,
+            buttons: [
+              {
+                label: "Continue",
+                onClick: () => resolve(true)
+              }
+            ]
+          });
+        }
+      );
+    }
+
     // Dialog to confirm remove + USER INPUT for delete volumes
     const deleteVolumes = await new Promise(
       (resolve: (_deleteVolumes: boolean) => void) => {


### PR DESCRIPTION
<!-- For DAppNode core members, once the Pull Request is created, do not forget to:
1.  Link issues to the PR if available
2.  Mention dappnode core members
3.  Add proper labels
-->

## Context

Use of the avaialble manifest warning `onRemove` https://docs.dappnode.io/es/developers/manifest-reference/#onremove

## Approach

Set the warning on the UI when the user attemps to remove a package by calling the function call `onPackageRemove`

## Test instructions

Develop a package with a warnning `onRemove`. Install the package, and make sure the warning appears when trying to remove it
