### PR TITLE
New API endpoint to send notifications from packages to the dappmanager to be shown in the UI

### DIFF
--- a/packages/admin-ui/server-mock/index.ts
+++ b/packages/admin-ui/server-mock/index.ts
@@ -49,6 +49,7 @@ startDappmanager({
     downloadUserActionLogs: () => {},
     fileDownload: () => {},
     globalEnvs: () => {},
+    notificationSend: () => {},
     packageManifest: () => {},
     publicPackagesData: () => {},
     sign: () => {},

--- a/packages/admin-ui/src/__mock-backend__/notifications.ts
+++ b/packages/admin-ui/src/__mock-backend__/notifications.ts
@@ -11,6 +11,15 @@ export const notifications: Pick<
 
 const sampleNotifications: PackageNotificationDb[] = [
   {
+    id: "notification-web3signer-gnosis.dnp.dappnode.eth",
+    type: "danger",
+    title: "Web3signer eth2 client selected is not available",
+    body:
+      "Make sure you hace selected an available client at packages > web3signer > config > eth2 client",
+    timestamp: 153834826,
+    viewed: false
+  },
+  {
     id: "diskSpaceRanOut-stoppedPackages",
     type: "danger",
     title: "Disk space ran out, stopped packages",

--- a/packages/dappmanager/src/api/routes/index.ts
+++ b/packages/dappmanager/src/api/routes/index.ts
@@ -9,3 +9,4 @@ export * from "./publicPackagesData";
 export * from "./sign";
 export * from "./upload";
 export * from "./downloadWireguardConfig";
+export * from "./notificationSend";

--- a/packages/dappmanager/src/api/routes/notificationSend.ts
+++ b/packages/dappmanager/src/api/routes/notificationSend.ts
@@ -1,0 +1,48 @@
+import { getDnpFromIp } from "./sign";
+import { eventBus } from "../../eventBus";
+import { HttpError, wrapHandler } from "../utils";
+
+/**
+ * Receive arbitrary notifications from packages to be shown in the UI
+ */
+export const notificationSend = wrapHandler(async (req, res) => {
+  const type = req.query.type;
+  const title = req.query.title; // "Some notification"
+  const body = req.query.body; // "Some text about notification"
+
+  try {
+    if (typeof type === undefined) throw Error("missing");
+    if (typeof type !== "string") throw Error("must be a string");
+    if (type !== ("danger" || "warning" || "success" || "info"))
+      throw Error("must be danger, warning, success or info");
+  } catch (e) {
+    throw new HttpError({ statusCode: 400, name: `Arg type ${e.message}` });
+  }
+
+  try {
+    if (typeof title === undefined) throw Error("missing");
+    if (typeof title !== "string") throw Error("must be a string");
+    if (!title) throw Error("must not be empty");
+  } catch (e) {
+    throw new HttpError({ statusCode: 400, name: `Arg title ${e.message}` });
+  }
+
+  try {
+    if (typeof body === undefined) throw Error("missing");
+    if (typeof body !== "string") throw Error("must be a string");
+    if (!body) throw Error("must not be empty");
+  } catch (e) {
+    throw new HttpError({ statusCode: 400, name: `Arg body ${e.message}` });
+  }
+
+  const { dnpName } = await getDnpFromIp(req.ip);
+
+  eventBus.notification.emit({
+    id: `notification-${dnpName}`,
+    type,
+    title,
+    body
+  });
+
+  return res.status(200).send();
+});

--- a/packages/dappmanager/src/api/startHttpApi.ts
+++ b/packages/dappmanager/src/api/startHttpApi.ts
@@ -40,6 +40,7 @@ export interface HttpRoutes {
   downloadWireguardConfig: RequestHandler<{ device: string }>;
   fileDownload: RequestHandler<{ containerName: string }>;
   globalEnvs: RequestHandler<{ name: string }>;
+  notificationSend: RequestHandler;
   packageManifest: RequestHandler<{ dnpName: string }>;
   publicPackagesData: RequestHandler<{ containerName: string }>;
   sign: RequestHandler;
@@ -162,6 +163,7 @@ export function startHttpApi({
   app.get("/package-manifest/:dnpName", routes.packageManifest);
   app.post("/sign", routes.sign);
   app.post("/data-send", routes.dataSend);
+  app.post("/notification-send", routes.notificationSend);
 
   // Rest of RPC methods
   app.post(


### PR DESCRIPTION
<!-- For DAppNode core members, once the Pull Request is created, do not forget to:
1.  Link issues to the PR if available
2.  Mention dappnode core members
3.  Add proper labels
-->

## Context

Select a non-available client in the web3signer is allowed, this behavior is hard to restrict due to the client been syncing, the API not available, etc.

## Approach

Implement a notification API endpoint in the dappmanager to allow packages to send notifications to be rendered in the UI

## Test instructions

Install this dappmanager branch, perform a notification post to the dappmanager API (from another docker container) and make sure it is shown in the dappmanager bell on the top right corner

```
 curl -X POST "http://my.dappnode/data-send?type=danger&title='web3signer client selected not available'&body='Make sure to select an available client'"
```

The request keys must contains the following:
```
{
  type:  "danger" | "warning" | "success" | "info";
  title: string; // "Some notification"
  body: string; // "Some text about notification"
}
``` 

