### PR TITLE
Add compose key ulimits

### DIFF
--- a/packages/admin-ui/src/common/types.ts
+++ b/packages/admin-ui/src/common/types.ts
@@ -669,6 +669,7 @@ export interface ComposeService {
   volumes?: string[]; // ["dappmanagerdnpdappnodeeth_data:/usr/src/app/dnp_repo/"];
   working_dir?: string;
   security_opt?: string[];
+  ulimits?: { nproc: number } | { nofile: { soft: number; hard: number } };
 }
 
 export interface ComposeServiceNetwork {

--- a/packages/dappmanager/src/modules/compose/unsafeCompose.ts
+++ b/packages/dappmanager/src/modules/compose/unsafeCompose.ts
@@ -54,7 +54,8 @@ const serviceSafeKeys: (keyof ComposeService)[] = [
   "user",
   "volumes",
   "working_dir",
-  "security_opt"
+  "security_opt",
+  "ulimits"
 ];
 
 // Disallow external volumes to prevent packages accessing sensitive data of others


### PR DESCRIPTION
<!-- For DAppNode core members, once the Pull Request is created, do not forget to:
1.  Link issues to the PR if available
2.  Mention dappnode core members
3.  Add proper labels
-->

## Context

Nethermind requires the `ulimits` compose feature to prevent from running out of memory 

## Approach

Add `ulimits` and its types to `unsafeCompose`

## Test instructions

Build and install Nethermind package with the ulimits configured. Make sure that the compose feature persists after installation
