### PR TITLE
`docker-compose up` core package always on `runPackage`

### DIFF
--- a/packages/dappmanager/src/modules/docker/dockerComposeUp.ts
+++ b/packages/dappmanager/src/modules/docker/dockerComposeUp.ts
@@ -48,8 +48,13 @@ export async function dockerComposeUpPackage(
     serviceName => containersStatus[serviceName]?.targetStatus !== "stopped"
   );
 
-  if (serviceNames.length === servicesToStart.length) {
-    // For new packages and all running run docker-compose up as is
+  if (
+    serviceNames.length === servicesToStart.length ||
+    dnpName === params.coreDnpName
+  ) {
+    // Run docker-compose up on all services for:
+    // - packages with all services running
+    // - core package, it must be executed always. No matter the previous status
     await dockerComposeUp(composePath, dockerComposeUpOptions);
   } else {
     // If some services are not running, first create the containers


### PR DESCRIPTION
<!-- For DAppNode core members, once the Pull Request is created, do not forget to:
1.  Link issues to the PR if available
2.  Mention dappnode core members
3.  Add proper labels
-->

## Context

The function `runPackage` called during the installation of packages runs packages with `docker-compose up` on containers with a previous state different than `stopped`. This is an expected behaviour, however, it is preventing from running the core package if the exit code is 0 OR the status is `created` (`created` status is parsed to `stopped`)

## Approach

Run `docker-compose up` for packages with all the services running previous to the update AND if it is the core package, no matter its previous state.

## Test instructions

With this dappmanager and having already the core container in any of the following status: `stopped` or `created`. Do a core update and make sure that the core package is executed during the update
