### PR TITLE
Add compose `deploy: resources` keys

### DIFF
--- a/packages/admin-ui/src/common/types.ts
+++ b/packages/admin-ui/src/common/types.ts
@@ -636,6 +636,7 @@ export interface ComposeService {
   container_name: string; // "DAppNodeCore-dappmanager.dnp.dappnode.eth";
   devices?: string[];
   depends_on?: string[];
+  deploy?: ComposeServiceResources;
   dns?: string; // "172.33.1.2";
   entrypoint?: string;
   env_file?: string[];
@@ -665,11 +666,36 @@ export interface ComposeService {
   restart?: string; // "unless-stopped";
   stop_grace_period?: string;
   stop_signal?: string;
+  ulimits?: { nproc: number } | { nofile: { soft: number; hard: number } };
   user?: string;
   volumes?: string[]; // ["dappmanagerdnpdappnodeeth_data:/usr/src/app/dnp_repo/"];
   working_dir?: string;
   security_opt?: string[];
-  ulimits?: { nproc: number } | { nofile: { soft: number; hard: number } };
+}
+
+/**
+ * Docs: https://docs.docker.com/compose/compose-file/deploy/#resources
+ */
+export interface ComposeServiceResources {
+  resources: {
+    limits?: {
+      cpus?: number | string;
+      memory?: string;
+      pids?: number;
+    };
+    reservations?: {
+      cpus?: number | string;
+      memory?: string;
+      devices?: {
+        capabilities?: string[];
+        driver?: string;
+        count?: number;
+        device_ids?: string[];
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        options?: { [key: string]: any };
+      };
+    };
+  };
 }
 
 export interface ComposeServiceNetwork {

--- a/packages/dappmanager/src/modules/compose/unsafeCompose.ts
+++ b/packages/dappmanager/src/modules/compose/unsafeCompose.ts
@@ -55,7 +55,8 @@ const serviceSafeKeys: (keyof ComposeService)[] = [
   "volumes",
   "working_dir",
   "security_opt",
-  "ulimits"
+  "ulimits",
+  "deploy"
 ];
 
 // Disallow external volumes to prevent packages accessing sensitive data of others


### PR DESCRIPTION
<!-- For DAppNode core members, once the Pull Request is created, do not forget to:
1.  Link issues to the PR if available
2.  Mention dappnode core members
3.  Add proper labels
-->

## Context

DAppNode packages should be allowed to define the `deploy` compose service key to define resource restrictions. This would be especially useful to avoid dappnode crashing due to linux OOM killer.

## Approach

Add these key to the safe compose keys

## Test instructions

Using this dappmanager install any package with the resources defined in the compose and make sure that after the installation the compose file have this keys AND that the resource limit was applied to the docker container with `docker stats`
