### PR TITLE
Fix cookie error unhandled

### DIFF
--- a/packages/dappmanager/src/api/utils.ts
+++ b/packages/dappmanager/src/api/utils.ts
@@ -1,5 +1,6 @@
 import express from "express";
 import { Server } from "socket.io";
+import { logs } from "../logs";
 
 export class HttpError extends Error {
   name: string;
@@ -25,6 +26,9 @@ export function wrapHandler<
     try {
       await handler(req, res, next);
     } catch (e) {
+      logs.info("req: ", req);
+      logs.info("res: ", res);
+      logs.info("next: ", next);
       if (res.headersSent) {
         next(e);
       } else if (e instanceof HttpError) {

--- a/packages/dappmanager/src/api/utils.ts
+++ b/packages/dappmanager/src/api/utils.ts
@@ -33,6 +33,7 @@ export function wrapHandler<
             error: { name: e.name, message: e.message }
           });
         } else {
+          // TODO: Find a proper way to end the session and redirect the user to a beauty UI
           // End session due to a probably cookie change
           // req.session = null;
         }


### PR DESCRIPTION
<!-- For DAppNode core members, once the Pull Request is created, do not forget to:
1.  Link issues to the PR if available
2.  Mention dappnode core members
3.  Add proper labels
-->

## Context

Having multiple dappnode and switching from one to another with the vpn credentials result in an uncaught error in the dappmanager (probably because of a wrong cookie cached on the browser) that makes the container restart

## Approach

Caught this error and end the session with `req.sesion = null`. This is not the ideal solution and must be researched the concrete error thrown when this cookie is wrong and show a beauty page saying something like "wrong cookie, try refreshing the browser".

This will result into a better user experience and dappmanager container not restarting

## Test instructions

Having this dappmanager and more than 1 dappnode configured with VPN credentials, switch from one to another an make sure the dappmanager container does not restart
