### PR TITLE
Add besu client option

### DIFF
--- a/packages/admin-ui/src/common/types.ts
+++ b/packages/admin-ui/src/common/types.ts
@@ -1311,13 +1311,14 @@ export enum IpfsClientTarget {
  * Eth provider / client types
  * Manage the Ethereum multi-client setup
  */
-export type EthClientTargetPackage = "geth-light" | "geth" | "nethermind";
+export type EthClientTargetPackage = "geth-light" | "geth" | "nethermind" | "besu";
 export type EthClientTarget = EthClientTargetPackage | "remote";
 export const ethClientTargets: EthClientTarget[] = [
   "remote",
   "geth-light",
   "geth",
-  "nethermind"
+  "nethermind",
+  "besu"
 ];
 
 /**

--- a/packages/admin-ui/src/components/EthMultiClient.tsx
+++ b/packages/admin-ui/src/components/EthMultiClient.tsx
@@ -29,6 +29,8 @@ export function getEthClientPrettyName(target: EthClientTarget): string {
       return "Geth";
     case "nethermind":
       return "Nethermind";
+    case "besu":
+      return "Besu";
   }
 }
 
@@ -43,6 +45,8 @@ export function getEthClientType(target: EthClientTarget): string {
       return "Light client";
     case "geth":
     case "nethermind":
+      return "Full node";
+    case "besu":
       return "Full node";
   }
 }

--- a/packages/admin-ui/src/components/EthMultiClient.tsx
+++ b/packages/admin-ui/src/components/EthMultiClient.tsx
@@ -45,7 +45,6 @@ export function getEthClientType(target: EthClientTarget): string {
       return "Light client";
     case "geth":
     case "nethermind":
-      return "Full node";
     case "besu":
       return "Full node";
   }

--- a/packages/admin-ui/src/components/EthMultiClient.tsx
+++ b/packages/admin-ui/src/components/EthMultiClient.tsx
@@ -126,7 +126,7 @@ const clients: EthClientData[] = [
   {
     title: "Full node",
     description: "Your own Ethereum node w/out 3rd parties",
-    options: ["geth", "nethermind"],
+    options: ["geth", "nethermind", "besu"],
     stats: {
       syncTime: "Slow sync",
       requirements: "High requirements",

--- a/packages/dappmanager/src/params.ts
+++ b/packages/dappmanager/src/params.ts
@@ -318,7 +318,8 @@ export const ethClientData: {
     }
   },
   geth: { dnpName: "geth.dnp.dappnode.eth" },
-  nethermind: { dnpName: "nethermind.public.dappnode.eth" }
+  nethermind: { dnpName: "nethermind.public.dappnode.eth" },
+  besu: { dnpName: "besu.public.dappnode.eth" }
 };
 
 // Naming


### PR DESCRIPTION
## Context

Enables the user to select the Ethereum EL client "Besu" as a fullnode client in the repository overview.

## Approach

I developed a Besu package, tested that for a good while and then implemented the change in this PR. Besu responds to fullnode.dappnode and gets used as repo source now.

## Test instructions

Choose "Besu" as EL full node in the repository settings, install besu and wait for it to sync. 