### PR TITLE
Add prysm to `eth2MigrationRequirements`

### DIFF
--- a/packages/dappmanager/src/params.ts
+++ b/packages/dappmanager/src/params.ts
@@ -174,6 +174,17 @@ const params = {
         "lighthouse-gnosis.dnp.dappnode.eth",
         "nimbus-gnosis.dnp.dappnode.eth"
       ]
+    },
+    // v0.2.52
+    {
+      prysmDnpName: "prysm.dnp.dappnode.eth",
+      prysmVersion: "1.0.25",
+      web3signerDnpName: "web3signer.dnp.dappnode.eth",
+      incompatibleClientsDnpNames: [
+        "teku.dnp.dappnode.eth",
+        "lighthouse.dnp.dappnode.eth",
+        "nimbus.dnp.dappnode.eth"
+      ]
     }
   ],
 


### PR DESCRIPTION
<!-- For DAppNode core members, once the Pull Request is created, do not forget to:
1.  Link issues to the PR if available
2.  Mention dappnode core members
3.  Add proper labels
-->

## Context

The upcoming core release 0.2.56 will be mandatory for validating in mainnet chain with eth2 multiclient + web3signer.

## Approach

- Not allowed to installed legacy prsm  (<=1.0.24)
- Not allowed to install web3signer if legacy prysm installed


## Test instructions

- Install a legacy version of prysm , then install the dappmanager to have this PR code, and finally try to install the web3signer . It should not be allowed.
- Install the dappmanager to have this PR code, the try to install a legacy version of prysm. It should not be allowed.
