### PR TITLE
Add check for volume sizes

### DIFF
--- a/packages/admin-ui/src/pages/packages/components/Info/VolumesList.tsx
+++ b/packages/admin-ui/src/pages/packages/components/Info/VolumesList.tsx
@@ -79,6 +79,8 @@ export const VolumesList = ({ dnp }: { dnp: InstalledPackageDetailData }) => {
     return null;
   }
 
+  const isTotalVolumeSizeIllDefined = volumes.map(v => v.size).includes(undefined);
+
   const totalVolumeSize = volumes.reduce(
     (total, vol) => total + (vol.size || 0),
     0
@@ -101,7 +103,7 @@ export const VolumesList = ({ dnp }: { dnp: InstalledPackageDetailData }) => {
             {showAll ? <BsChevronContract /> : <BsChevronExpand />}
           </span>
         </span>
-        <span>{prettyBytes(totalVolumeSize)}</span>
+        <span>{isTotalVolumeSizeIllDefined ? "-" : prettyBytes(totalVolumeSize)}</span>
 
         <BsTrash
           className="trash-icon"

--- a/packages/admin-ui/src/pages/packages/components/Info/VolumesList.tsx
+++ b/packages/admin-ui/src/pages/packages/components/Info/VolumesList.tsx
@@ -79,7 +79,7 @@ export const VolumesList = ({ dnp }: { dnp: InstalledPackageDetailData }) => {
     return null;
   }
 
-  const isTotalVolumeSizeIllDefined = volumes.map(v => v.size).includes(undefined);
+  const isTotalVolumeSizeIllDefined = volumes.some(v => !v.size);
 
   const totalVolumeSize = volumes.reduce(
     (total, vol) => total + (vol.size || 0),


### PR DESCRIPTION
 ## Context

Connected with this: https://github.com/dappnode/DAppNode/issues/417

## Approach

Since showing volume size for bind volumes is not feasible since it has to be calculated, we don't show that. However, total volume size is shown, but counting as 0 volume size of bind mount volumes. This PR removes total volume size in those cases since that is obviously wrong information.

## Test instructions

In the volumes section of package check whether:
1) total volume size is shown for packages that don't have bind mounts (custom location for volumes)
2) total volume size is not show for packages that have bind mounts