### PR TITLE
Patch `any-observable` library

### DIFF
--- a/patches/any-observable+0.3.0.patch
+++ b/patches/any-observable+0.3.0.patch
@@ -1,0 +1,18 @@
+diff --git a/node_modules/any-observable/register.js b/node_modules/any-observable/register.js
+index 40b8d86..f0097a9 100644
+--- a/node_modules/any-observable/register.js
++++ b/node_modules/any-observable/register.js
+@@ -26,6 +26,13 @@ function loadImplementation(implementation) {
+ 	}
+ 
+ 	if (!impl) {
++		// Issue with webpack build and library listr (used by @dappnode/dappnodesdk) using any-observable sub-dependency
++		// https://github.com/SamVerschueren/listr/issues/146
++		// https://github.com/okonet/lint-staged/issues/416
++		return {
++			Observable: global.Observable,
++			implementation: 'global.Observable'
++		}
+ 		throw new Error('Cannot find any-observable implementation nor' +
+ 			' global.Observable. You must install polyfill or call' +
+ 			' require("any-observable/register") with your preferred' +


### PR DESCRIPTION
Due to the recent use of the `@dappnode/dappnodesdk` as a dependency in the dappmanager (see https://github.com/dappnode/DNP_DAPPMANAGER/pull/1049), the `webpack` build was failing when loading the subdependency: `#@dappnode#admin-ui#@dappnode#dappnodesdk#listr#@samverschueren#stream-to-observable#any-observable"` with the following error
```
Error: Cannot find any-observable implementation nor global.Observable. You must install polyfill or call require("any-observable/register") with your preferred implementation, e.g. require("any-observable/register")('rxjs') on application load prior to any require("any-observable").
    at loadImplementation (/usr/src/app/webpack:/node_modules/any-observable/register.js:29:1)
    at /usr/src/app/webpack:/node_modules/any-observable/loader.js:30:1
    at Object.66236 (/usr/src/app/webpack:/node_modules/any-observable/index.js:2:38)
    at __webpack_require__ (/usr/src/app/webpack:/@dappnode/dappmanager/webpack/bootstrap:19:1)
    at Object.70473 (/usr/src/app/webpack:/node_modules/@samverschueren/stream-to-observable/index.js:2:20)
    at __webpack_require__ (/usr/src/app/webpack:/@dappnode/dappmanager/webpack/bootstrap:19:1)
    at Object.78350 (/usr/src/app/webpack:/node_modules/listr/lib/task.js:3:28)
    at __webpack_require__ (/usr/src/app/webpack:/@dappnode/dappmanager/webpack/bootstrap:19:1)
    at Object.90869 (/usr/src/app/webpack:/node_modules/listr/index.js:3:14)
    at __webpack_require__ (/usr/src/app/webpack:/@dappnode/dappmanager/webpack/bootstrap:19:1)
```

This PR patches the subdependency `any-observable` to not throw an error but return an observable object

See upstream issues:
https://github.com/SamVerschueren/listr/issues/146
https://github.com/okonet/lint-staged/issues/416