### PR TITLE
Add  whitelist channel to telegram bot (ON HOLD)

### DIFF
--- a/packages/admin-ui/src/__mock-backend__/telegram.ts
+++ b/packages/admin-ui/src/__mock-backend__/telegram.ts
@@ -9,6 +9,9 @@ export const telegram: Pick<
   | "telegramStatusSet"
   | "telegramTokenGet"
   | "telegramTokenSet"
+  | "telegramChannelIdWhitelistGet"
+  | "telegramChannelIdWhitelistSet"
+  | "telegramChannelIdWhitelistRemove"
 > = {
   telegramStatusGet: async () => isEnabled,
   telegramStatusSet: async ({ telegramStatus }) => {
@@ -17,5 +20,11 @@ export const telegram: Pick<
   telegramTokenGet: async () => token,
   telegramTokenSet: async ({ telegramToken }) => {
     token = telegramToken;
-  }
+  },
+  telegramChannelIdWhitelistGet: async () => [
+    "h4dk49dk3nnckd8",
+    "dj3jsd93jdhcy3k"
+  ],
+  telegramChannelIdWhitelistSet: async ({ channelId }) => {},
+  telegramChannelIdWhitelistRemove: async ({ channelId }) => {}
 };

--- a/packages/admin-ui/src/common/routes.ts
+++ b/packages/admin-ui/src/common/routes.ts
@@ -578,6 +578,25 @@ export interface Routes {
   telegramTokenSet: (kwarg: { telegramToken: string }) => Promise<void>;
 
   /**
+   * Gets telegram whitelist channel IDs
+   */
+  telegramChannelIdWhitelistGet: () => Promise<string[]>;
+
+  /**
+   * Set a new telegram channel ID in the whitelist
+   */
+  telegramChannelIdWhitelistSet: (kwargs: {
+    channelId: string;
+  }) => Promise<void>;
+
+  /**
+   * Removes a telegram channel ID from the whitelist
+   */
+  telegramChannelIdWhitelistRemove: (kwargs: {
+    channelId: string;
+  }) => Promise<void>;
+
+  /**
    * Return the current SSH port from sshd
    */
   sshPortGet: () => Promise<number>;
@@ -743,6 +762,9 @@ export const routesData: { [P in keyof Routes]: RouteData } = {
   telegramStatusSet: { log: true },
   telegramTokenGet: {},
   telegramTokenSet: { log: true },
+  telegramChannelIdWhitelistGet: {},
+  telegramChannelIdWhitelistSet: { log: true },
+  telegramChannelIdWhitelistRemove: { log: true },
   natRenewalEnable: {},
   natRenewalIsEnabled: {},
   volumeRemove: { log: true },

--- a/packages/admin-ui/src/pages/system/components/Notifications/Telegram.tsx
+++ b/packages/admin-ui/src/pages/system/components/Notifications/Telegram.tsx
@@ -9,20 +9,51 @@ import ErrorView from "components/ErrorView";
 import Ok from "components/Ok";
 import { withToast } from "components/toast/Toast";
 import { InputSecret } from "components/InputSecret";
+import Input from "components/Input";
 import { forumUrl } from "params";
+import { BsTrash } from "react-icons/bs";
 
 export function TelegramNotifications() {
   const telegramStatus = useApi.telegramStatusGet();
   const telegramToken = useApi.telegramTokenGet();
+  const telegramWhitelistChannelId = useApi.telegramChannelIdWhitelistGet();
 
   const [reqStatusToken, setReqStatusToken] = useState<ReqStatus>({});
-  const [reqStatusStatus, setReqStatusStatus] = useState<ReqStatus>({});
+  const [reqTelegramStatus, setReqTelegramStatus] = useState<ReqStatus>({});
+  const [
+    reqStatusWhitelistChannelId,
+    setReqStatusWhitelistChannelId
+  ] = useState<ReqStatus>({});
+  const [newChannelId, setNewChannelId] = useState("");
+  const [channelIds, setChannelIds] = useState<string[]>([]);
   const [token, setToken] = useState("");
 
   // Update local `token` input with the token stored in the DAPPMANAGER DB `telegramToken`
   useEffect(() => {
     if (telegramToken.data) setToken(telegramToken.data);
   }, [telegramToken.data]);
+
+  // Update local `channelId` input with the channelId stored in the DAPPMANAGER DB `telegramWhitelistChannelId`
+  useEffect(() => {
+    if (telegramWhitelistChannelId.data)
+      setChannelIds(telegramWhitelistChannelId.data);
+  }, [telegramWhitelistChannelId.data]);
+
+  async function updateTelegramWhitelistChannelId() {
+    setReqStatusWhitelistChannelId({ loading: true });
+    try {
+      await withToast(
+        () => api.telegramChannelIdWhitelistSet({ channelId: newChannelId }),
+        {
+          message: `Setting channel ID...`,
+          onSuccess: `Updated telegram channel ID whitelist`
+        }
+      );
+      setReqStatusWhitelistChannelId({ result: true });
+    } catch (err) {
+      setReqStatusWhitelistChannelId({ error: err });
+    }
+  }
 
   async function updateTelegramToken() {
     try {
@@ -44,7 +75,7 @@ export function TelegramNotifications() {
 
   async function updateTelegramStatus(newStatus: boolean) {
     try {
-      setReqStatusStatus({ loading: true });
+      setReqTelegramStatus({ loading: true });
       await withToast(
         () => api.telegramStatusSet({ telegramStatus: newStatus }),
         {
@@ -53,9 +84,9 @@ export function TelegramNotifications() {
         }
       );
       telegramStatus.revalidate();
-      setReqStatusStatus({ result: true });
+      setReqTelegramStatus({ result: true });
     } catch (e) {
-      setReqStatusStatus({ error: e });
+      setReqTelegramStatus({ error: e });
       console.error("Error on telegramStatusSet", e);
     }
   }
@@ -115,6 +146,62 @@ export function TelegramNotifications() {
         />
       </Form.Group>
 
+      <Form.Group>
+        <Form.Label>Telegram channel ID</Form.Label>
+        <Input
+          placeholder="Telegram channel ID"
+          value={newChannelId}
+          onValueChange={setNewChannelId}
+          onEnterPress={updateTelegramWhitelistChannelId}
+          append={
+            <Button
+              type="submit"
+              className="register-button"
+              disabled={!newChannelId || !token}
+              onClick={updateTelegramWhitelistChannelId}
+              variant="dappnode"
+            >
+              Submit
+            </Button>
+          }
+        />
+        <br />
+        {/** Create a list of removable channel ids */}
+
+        {channelIds.length > 0 ? (
+          <div>
+            <div>
+              <strong>Telegram channel ID whitelist</strong>
+            </div>
+            <div>
+              <ul>
+                {channelIds.map(channelId => (
+                  <li key={channelId}>
+                    <BsTrash
+                      onClick={() =>
+                        withToast(
+                          () =>
+                            api.telegramChannelIdWhitelistRemove({
+                              channelId
+                            }),
+                          {
+                            message: `Removing channel ID ${channelId}...`,
+                            onSuccess: `Removed channel ID ${channelId} from the whitelist`
+                          }
+                        )
+                      }
+                    />
+                    {" " + channelId}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        ) : (
+          <div>No channels added</div>
+        )}
+      </Form.Group>
+
       {telegramStatus.data !== undefined ? (
         <Form.Group>
           <div>
@@ -138,8 +225,11 @@ export function TelegramNotifications() {
       {reqStatusToken.error && (
         <ErrorView error={reqStatusToken.error} hideIcon red />
       )}
-      {reqStatusStatus.error && (
-        <ErrorView error={reqStatusStatus.error} hideIcon red />
+      {reqStatusWhitelistChannelId.error && (
+        <ErrorView error={reqStatusWhitelistChannelId.error} hideIcon red />
+      )}
+      {reqTelegramStatus.error && (
+        <ErrorView error={reqTelegramStatus.error} hideIcon red />
       )}
 
       <hr />

--- a/packages/dappmanager/src/calls/telegram.ts
+++ b/packages/dappmanager/src/calls/telegram.ts
@@ -1,3 +1,8 @@
+import {
+  addChannelId,
+  channelIdExists,
+  removeChannelId
+} from "../daemons/telegramBot/commands";
 import * as db from "../db";
 import { eventBus } from "../eventBus";
 
@@ -39,4 +44,33 @@ export async function telegramTokenSet({
 }): Promise<void> {
   db.telegramToken.set(telegramToken);
   eventBus.telegramStatusChanged.emit();
+}
+
+/**
+ * Sets a new telegram channel id into the whitelist
+ */
+export async function telegramChannelIdWhitelistSet({
+  telegramChannelId
+}: {
+  telegramChannelId: string;
+}): Promise<void> {
+  if (!channelIdExists(telegramChannelId)) addChannelId(telegramChannelId);
+}
+
+/**
+ * Gets the telegram channel id whitelist
+ */
+export async function telegramChannelIdWhitelistGet(): Promise<string[]> {
+  return db.telegramChannelIds.get();
+}
+
+/**
+ * Removes a telegram channel id from the whitelist
+ */
+export async function telegramChannelIdWhitelistRemove({
+  telegramChannelId
+}: {
+  telegramChannelId: string;
+}): Promise<void> {
+  removeChannelId(telegramChannelId);
 }

--- a/packages/dappmanager/src/calls/telegram.ts
+++ b/packages/dappmanager/src/calls/telegram.ts
@@ -50,11 +50,11 @@ export async function telegramTokenSet({
  * Sets a new telegram channel id into the whitelist
  */
 export async function telegramChannelIdWhitelistSet({
-  telegramChannelId
+  channelId
 }: {
-  telegramChannelId: string;
+  channelId: string;
 }): Promise<void> {
-  if (!channelIdExists(telegramChannelId)) addChannelId(telegramChannelId);
+  if (!channelIdExists(channelId)) addChannelId(channelId);
 }
 
 /**


### PR DESCRIPTION
As a user from the forum pointed out (see https://forum.dappnode.io/t/set-up-your-dappnode-telegram-bot/816) anyone can add a bot to their own telegram channel. This is a security issue and dappnode is already warning users to do not allow telegram bot to be added to any group. 

In order to have a better implementation related to security concerns, add a whitelist channel ID that can be edited from the dappnode UI. If the message comes from a non-whitelisted channel ID then exit the chat.

### Test instructions
- Crete a telegram bot and add it to the dappnode notifications
- Add the telegram bot to a channel ID, add the channel ID to the whitelist. Make sure you are able to send/receive messages
- Remove the channel ID and check the telegram bot has exited the chat when trying to send commands