### PR TITLE
Set `globalEnvs` (as `string [ ]` and `all: true`) in the `docker-compose.yml`

### DIFF
--- a/packages/admin-ui/package.json
+++ b/packages/admin-ui/package.json
@@ -21,7 +21,7 @@
     "mock-standalone:build": "REACT_APP_MOCK=true yarn build"
   },
   "dependencies": {
-    "@dappnode/dappnodesdk": "^0.2.64",
+    "@dappnode/dappnodesdk": "^0.2.65",
     "@reduxjs/toolkit": "^1.3.5",
     "@types/clipboard": "^2.0.1",
     "@types/jest": "^24.9.1",

--- a/packages/dappmanager/package.json
+++ b/packages/dappmanager/package.json
@@ -19,7 +19,7 @@
   },
   "license": "GPL-3.0",
   "dependencies": {
-    "@dappnode/dappnodesdk": "^0.2.64",
+    "@dappnode/dappnodesdk": "^0.2.65",
     "@ipld/car": "^3.1.16",
     "@types/async": "^3.0.1",
     "@types/async-retry": "^1.4.2",

--- a/packages/dappmanager/src/modules/compose/editor.ts
+++ b/packages/dappmanager/src/modules/compose/editor.ts
@@ -83,11 +83,10 @@ export class ComposeServiceEditor {
     }));
   }
 
-  mergeEnvs(newEnvs: PackageEnvs | string[]): void {
-    const newEnvsParsed = parseEnvironment(newEnvs);
+  mergeEnvs(newEnvs: PackageEnvs): void {
     this.edit(service => ({
       environment: stringifyEnvironment(
-        mergeEnvs(newEnvsParsed, parseEnvironment(service.environment || []))
+        mergeEnvs(newEnvs, parseEnvironment(service.environment || []))
       )
     }));
   }
@@ -184,7 +183,7 @@ export class ComposeServiceEditor {
             )}. Got ${globEnv.envs.join(", ")}`
           );
 
-        this.mergeEnvs(globEnv.envs);
+        this.mergeEnvs(pick(globalEnvsFromDb, globEnv.envs));
       }
     } else if ((manifestGlobalEnvs || {}).all) {
       // Add global env_file on request

--- a/packages/dappmanager/src/modules/compose/editor.ts
+++ b/packages/dappmanager/src/modules/compose/editor.ts
@@ -81,10 +81,11 @@ export class ComposeServiceEditor {
     }));
   }
 
-  mergeEnvs(newEnvs: PackageEnvs): void {
+  mergeEnvs(newEnvs: PackageEnvs | string[]): void {
+    const newEnvsParsed = parseEnvironment(newEnvs);
     this.edit(service => ({
       environment: stringifyEnvironment(
-        mergeEnvs(newEnvs, parseEnvironment(service.environment || []))
+        mergeEnvs(newEnvsParsed, parseEnvironment(service.environment || []))
       )
     }));
   }

--- a/packages/dappmanager/src/modules/release/getRelease.ts
+++ b/packages/dappmanager/src/modules/release/getRelease.ts
@@ -8,7 +8,10 @@ import { setDappnodeComposeDefaults } from "../compose/setDappnodeComposeDefault
 import { ComposeEditor } from "../compose/editor";
 import { writeMetadataToLabels } from "../compose";
 import { fileToMultiaddress } from "../../utils/distributedFile";
-import { getGlobalEnvsFilePath } from "../../modules/globalEnvs";
+import {
+  computeGlobalEnvsFromDb,
+  getGlobalEnvsFilePath
+} from "../../modules/globalEnvs";
 import { sanitizeDependencies } from "../dappGet/utils/sanitizeDependencies";
 import { parseTimeoutSeconds } from "../../utils/timeout";
 import { ReleaseDownloadedContents } from "./types";
@@ -52,9 +55,24 @@ export async function getRelease({
 
   const services = Object.values(compose.services());
   for (const service of services) {
-    // Add global env_file on request
-    if ((manifest.globalEnvs || {}).all)
+    if (Array.isArray(manifest.globalEnvs)) {
+      // Add the defined global envs to the selected services
+      for (const globEnv of manifest.globalEnvs) {
+        if (!globEnv.services.includes(service.serviceName)) continue;
+        const globalEnvsFromDb = computeGlobalEnvsFromDb();
+        if (globEnv.envs.some(env => !(env in globalEnvsFromDb)))
+          throw Error(
+            `Global envs allowed are ${Object.keys(globalEnvsFromDb).join(
+              ", "
+            )}. Got ${globEnv.envs.join(", ")}`
+          );
+
+        service.mergeEnvs(globEnv.envs);
+      }
+    } else if ((manifest.globalEnvs || {}).all) {
+      // Add global env_file on request
       service.addEnvFile(getGlobalEnvsFilePath(isCore));
+    }
 
     service.mergeLabels(
       writeMetadataToLabels({

--- a/yarn.lock
+++ b/yarn.lock
@@ -1152,10 +1152,10 @@
   dependencies:
     postcss-value-parser "^4.2.0"
 
-"@dappnode/dappnodesdk@^0.2.64":
-  version "0.2.64"
-  resolved "https://registry.yarnpkg.com/@dappnode/dappnodesdk/-/dappnodesdk-0.2.64.tgz#9265a82e8e5402b84389bb6ba9a17d236c10b95c"
-  integrity sha512-U+unG6/mdjA7L0cZwfZWXlUydxb3oQjGwMnPjW72MofnKM7PF+DdAdXH49d5p2hMfRsk480uJQHiBZB8Fl7uOQ==
+"@dappnode/dappnodesdk@^0.2.65":
+  version "0.2.65"
+  resolved "https://registry.yarnpkg.com/@dappnode/dappnodesdk/-/dappnodesdk-0.2.65.tgz#40990677be35d2deee7a4afe1b25d050fe2e01c1"
+  integrity sha512-zlV5bE4+awcDss3tmCLbx0k6YP6S28QpM50s8N/Frqshjp69Kew5GZ87hSkpw9jBxav8p86P4ZZt1KMaY1Z6Nw==
   dependencies:
     "@octokit/rest" "^18.0.12"
     ajv "^8.11.0"


### PR DESCRIPTION

<!-- For DAppNode core members, once the Pull Request is created, do not forget to:
1.  Link issues to the PR if available
2.  Mention dappnode core members
3.  Add proper labels
-->

## Context

From https://github.com/dappnode/DAppNodeSDK/pull/266, the `globalEnvs` manifest feature allows defining which global envs add to which service. 

## Approach

Implement the addition of the global envs to the compose file based on this feature. There can be added two types of global envs:
- **all**: this is the current feature implemented, it injects the `.env` file into the `docker-compose`
- Defining envs and services to set those vars

## Test instructions

Install two packages:
1. Package with a manifest defining the `globalEnvs` like:
```
globalEnvs?: {
        all?: boolean;
    } 
``` 
2. Package with a manifest defining the `globalEnvs` like:
```
globalEnvs?: {
        envs: string[];
        services: string[];
    }[ ]
```

Make sure that in both cases the `docker-compose.yml` of the given package was edited and added the envs (env file for the 1 and env one by one to the 2)