### PR TITLE
Update packages global envs

### DIFF
--- a/packages/dappmanager/src/api/routes/globalEnvs.ts
+++ b/packages/dappmanager/src/api/routes/globalEnvs.ts
@@ -10,7 +10,7 @@ interface Params {
  */
 export const globalEnvs = wrapHandler<Params>(async (req, res) => {
   const name = req.params.name as keyof GlobalEnvs | undefined;
-  const globalEnvs = computeGlobalEnvsFromDb();
+  const globalEnvs = computeGlobalEnvsFromDb(false);
 
   if (name) {
     // Accept both "INTERNAL_IP" and "internal_ip"

--- a/packages/dappmanager/src/db/dyndns.ts
+++ b/packages/dappmanager/src/db/dyndns.ts
@@ -1,18 +1,28 @@
 import { dbMain } from "./dbFactory";
 import { IdentityInterface } from "../types";
+import { interceptGlobalEnvOnSet } from "./interceptGlobalEnvOnSet";
 
 const PUBLIC_IP = "public-ip";
 const DOMAIN = "domain";
 const DYNDNS_IDENTITY = "dyndns-identity";
 const STATIC_IP = "static-ip";
 
-export const publicIp = dbMain.staticKey<string>(PUBLIC_IP, "");
+export const publicIp = interceptGlobalEnvOnSet({
+  ...dbMain.staticKey<string>(PUBLIC_IP, ""),
+  globEnvKey: PUBLIC_IP
+});
 
-export const domain = dbMain.staticKey<string>(DOMAIN, "");
+export const domain = interceptGlobalEnvOnSet({
+  ...dbMain.staticKey<string>(DOMAIN, ""),
+  globEnvKey: DOMAIN
+});
 
 export const dyndnsIdentity = dbMain.staticKey<IdentityInterface>(
   DYNDNS_IDENTITY,
   { address: "", privateKey: "", publicKey: "" }
 );
 
-export const staticIp = dbMain.staticKey<string>(STATIC_IP, "");
+export const staticIp = interceptGlobalEnvOnSet({
+  ...dbMain.staticKey<string>(STATIC_IP, ""),
+  globEnvKey: STATIC_IP
+});

--- a/packages/dappmanager/src/db/index.ts
+++ b/packages/dappmanager/src/db/index.ts
@@ -15,6 +15,7 @@ export * from "./systemFlags";
 export * from "./ui";
 export * from "./upnp";
 export * from "./vpn";
+export * from "./interceptGlobalEnvOnSet";
 // Aditional low levels methods
 import { dbCache, dbMain } from "./dbFactory";
 

--- a/packages/dappmanager/src/db/index.ts
+++ b/packages/dappmanager/src/db/index.ts
@@ -15,7 +15,6 @@ export * from "./systemFlags";
 export * from "./ui";
 export * from "./upnp";
 export * from "./vpn";
-export * from "./interceptGlobalEnvOnSet";
 // Aditional low levels methods
 import { dbCache, dbMain } from "./dbFactory";
 

--- a/packages/dappmanager/src/db/interceptGlobalEnvOnSet.ts
+++ b/packages/dappmanager/src/db/interceptGlobalEnvOnSet.ts
@@ -1,6 +1,3 @@
-// GLOBAL ENVS
-// ACTIVE: string, INTERNAL_IP: string, STATIC_IP: string, HOSTNAME: string, UPNP_AVAILABLE: boolean, NO_NAT_LOOPBACK: boolean, DOMAIN: string, PUBKEY: string, ADDRESS: string, PUBLIC_IP: string, SERVER_NAME: string
-
 import { logs } from "../logs";
 import {
   updatePkgsWithGlobalEnvs,
@@ -14,6 +11,9 @@ import params from "../params";
  * - Update the .env file
  * - Update the compose file of all dappnode packages using this global env
  * - Restart all dappnode packages using this global env
+ *
+ * Global ENVs that must be tracked:
+ * ACTIVE: string, INTERNAL_IP: string, STATIC_IP: string, HOSTNAME: string, UPNP_AVAILABLE: boolean, NO_NAT_LOOPBACK: boolean, DOMAIN: string, PUBKEY: string, ADDRESS: string, PUBLIC_IP: string, SERVER_NAME: string
  * @param dbSetter
  */
 export function interceptGlobalEnvOnSet({
@@ -21,12 +21,16 @@ export function interceptGlobalEnvOnSet({
   set,
   globEnvKey
 }: {
-  get: () => string;
-  set: (globEnvValue: string) => void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  get: () => any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  set: (globEnvValue: any) => void;
   globEnvKey: string;
 }): {
-  get: () => string;
-  set: (globEnvValue: string) => void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  get: () => any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  set: (globEnvValue: any) => void;
 } {
   return {
     get,

--- a/packages/dappmanager/src/db/interceptGlobalEnvOnSet.ts
+++ b/packages/dappmanager/src/db/interceptGlobalEnvOnSet.ts
@@ -1,0 +1,56 @@
+// GLOBAL ENVS
+// ACTIVE: string, INTERNAL_IP: string, STATIC_IP: string, HOSTNAME: string, UPNP_AVAILABLE: boolean, NO_NAT_LOOPBACK: boolean, DOMAIN: string, PUBKEY: string, ADDRESS: string, PUBLIC_IP: string, SERVER_NAME: string
+
+import { logs } from "../logs";
+import {
+  updatePkgsWithGlobalEnvs,
+  writeGlobalEnvsToEnvFile
+} from "../modules/globalEnvs";
+import params from "../params";
+
+/**
+ * Intercept all on set methods when any global env is set. When updating a global env there must be done:
+ * - Set the new value in the DB
+ * - Update the .env file
+ * - Update the compose file of all dappnode packages using this global env
+ * - Restart all dappnode packages using this global env
+ * @param dbSetter
+ */
+export function interceptGlobalEnvOnSet({
+  get,
+  set,
+  globEnvKey
+}: {
+  get: () => string;
+  set: (globEnvValue: string) => void;
+  globEnvKey: string;
+}): {
+  get: () => string;
+  set: (globEnvValue: string) => void;
+} {
+  return {
+    get,
+
+    set: function (globEnvValue: string): void {
+      // Must be with prefix _DAPPNODE_GLOBAL_
+      if (!globEnvKey.includes(params.GLOBAL_ENVS_PREFIX))
+        globEnvKey = `${params.GLOBAL_ENVS_PREFIX}${globEnvKey}`;
+
+      set(globEnvValue);
+      // Update the global env file
+      writeGlobalEnvsToEnvFile();
+      // List packages using the global env and update the global envs in composes files
+      updatePkgsWithGlobalEnvs(globEnvKey, globEnvValue)
+        .then(() => {
+          logs.info(
+            `Updated global env ${globEnvKey} to ${globEnvValue} in all dappnode packages`
+          );
+        })
+        .catch(err => {
+          logs.error(
+            `Error updating global env ${globEnvKey} to ${globEnvValue} in all dappnode packages: ${err}`
+          );
+        });
+    }
+  };
+}

--- a/packages/dappmanager/src/db/network.ts
+++ b/packages/dappmanager/src/db/network.ts
@@ -1,4 +1,5 @@
 import { dbMain } from "./dbFactory";
+import { interceptGlobalEnvOnSet } from "./interceptGlobalEnvOnSet";
 
 const NO_NAT_LOOPBACK = "no-nat-loopback";
 const DOUBLE_NAT = "double-nat";
@@ -6,13 +7,19 @@ const ALERT_TO_OPEN_PORTS = "alert-to-open-ports";
 const INTERNAL_IP = "internal-ip";
 const AVAHI_SHOULD_BE_DISABLED = "avahi-should-be-disabled";
 
-export const noNatLoopback = dbMain.staticKey<boolean>(NO_NAT_LOOPBACK, false);
+export const noNatLoopback = interceptGlobalEnvOnSet({
+  ...dbMain.staticKey<boolean>(NO_NAT_LOOPBACK, false),
+  globEnvKey: NO_NAT_LOOPBACK
+});
 export const doubleNat = dbMain.staticKey<boolean>(DOUBLE_NAT, false);
 export const alertToOpenPorts = dbMain.staticKey<boolean>(
   ALERT_TO_OPEN_PORTS,
   false
 );
-export const internalIp = dbMain.staticKey<string>(INTERNAL_IP, "");
+export const internalIp = interceptGlobalEnvOnSet({
+  ...dbMain.staticKey<string>(INTERNAL_IP, ""),
+  globEnvKey: INTERNAL_IP
+});
 
 export const avahiPublishCmdShouldNotRun = dbMain.staticKey<boolean>(
   AVAHI_SHOULD_BE_DISABLED,

--- a/packages/dappmanager/src/db/system.ts
+++ b/packages/dappmanager/src/db/system.ts
@@ -1,5 +1,6 @@
 import { dbCache, dbMain } from "./dbFactory";
 import { PackageVersionData } from "../types";
+import { interceptGlobalEnvOnSet } from "./interceptGlobalEnvOnSet";
 
 const SERVER_NAME = "server-name";
 const FULLNODE_DOMAIN_TARGET = "fullnode-domain-target";
@@ -11,7 +12,10 @@ const TELEGRAM_CHANNEL_ID = "telegram-channel-id";
 const DISK_USAGE_THRESHOLD = "disk-usage-threshold";
 const DAPPNODE_WEB_NAME = "dappnode-web-name";
 
-export const serverName = dbMain.staticKey<string>(SERVER_NAME, "");
+export const serverName = interceptGlobalEnvOnSet({
+  ...dbMain.staticKey<string>(SERVER_NAME, ""),
+  globEnvKey: SERVER_NAME
+});
 
 // Domains
 

--- a/packages/dappmanager/src/db/upnp.ts
+++ b/packages/dappmanager/src/db/upnp.ts
@@ -1,13 +1,17 @@
 import { dbCache } from "./dbFactory";
 import { UpnpPortMapping } from "../modules/upnpc/types";
 import { PackagePort } from "../types";
+import { interceptGlobalEnvOnSet } from "./interceptGlobalEnvOnSet";
 
 const UPNP_AVAILABLE = "upnp-available";
 const UPNP_PORT_MAPPINGS = "upnp-port-mappings";
 const PORTS_TO_OPEN = "ports-to-ppen";
 const IS_NAT_RENEWAL_DISABLED = "is-nat-renewal-disabled";
 
-export const upnpAvailable = dbCache.staticKey<boolean>(UPNP_AVAILABLE, false);
+export const upnpAvailable = interceptGlobalEnvOnSet({
+  ...dbCache.staticKey<boolean>(UPNP_AVAILABLE, false),
+  globEnvKey: UPNP_AVAILABLE
+});
 
 export const upnpPortMappings = dbCache.staticKey<UpnpPortMapping[]>(
   UPNP_PORT_MAPPINGS,

--- a/packages/dappmanager/src/modules/ipfs/Ipfs.ts
+++ b/packages/dappmanager/src/modules/ipfs/Ipfs.ts
@@ -27,7 +27,8 @@ export class Ipfs {
       url: ipfsHost,
       timeout: this.timeout
     });
-    this.ipfsClientTarget = db.ipfsClientTarget.get();
+    if (process.env.TEST) this.ipfsClientTarget = IpfsClientTarget.local;
+    else this.ipfsClientTarget = db.ipfsClientTarget.get();
   }
 
   /**

--- a/packages/dappmanager/src/params.ts
+++ b/packages/dappmanager/src/params.ts
@@ -258,6 +258,8 @@ const params = {
     PUBLIC_IP: "_DAPPNODE_GLOBAL_PUBLIC_IP", // "138.68.106.96"
     SERVER_NAME: "_DAPPNODE_GLOBAL_SERVER_NAME" // "MyDAppNode"
   },
+  // Global ENVs dappnode prefix
+  GLOBAL_ENVS_PREFIX: "_DAPPNODE_GLOBAL_",
 
   // nsenter line to run commands on host
   NSENTER_COMMAND:

--- a/packages/dappmanager/test/modules/compose/editor/composeAliases.test.ts
+++ b/packages/dappmanager/test/modules/compose/editor/composeAliases.test.ts
@@ -258,8 +258,8 @@ services:
     dns: 172.33.1.2
     environment:
       - 'EXTRA_OPTIONS=--http.api eth,net,web3,txpool'
-      - ACTIVE=true
-      - NO_NAT_LOOPBACK=false
+      - _DAPPNODE_GLOBAL_ACTIVE=true
+      - _DAPPNODE_GLOBAL_NO_NAT_LOOPBACK=false
     image: 'goerli-geth.dnp.dappnode.eth:0.4.12'
     logging:
       driver: json-file

--- a/packages/dappmanager/test/modules/globalEnvs.test.ts
+++ b/packages/dappmanager/test/modules/globalEnvs.test.ts
@@ -9,14 +9,14 @@ import {
   writeGlobalEnvsToEnvFile
 } from "../../src/modules/globalEnvs";
 
-describe("Module > globalEnvs", function() {
+describe("Module > globalEnvs", function () {
   beforeEach(async () => {
     await cleanTestDir();
     await createTestDir();
   });
 
   it("Should compute global ENVs from an empty DB", () => {
-    const globalEnvs = computeGlobalEnvsFromDb();
+    const globalEnvs = computeGlobalEnvsFromDb(false);
     expect(globalEnvs).to.deep.include({ ACTIVE: "true", INTERNAL_IP: "" });
   });
 


### PR DESCRIPTION
<!-- For DAppNode core members, once the Pull Request is created, do not forget to:
1.  Link issues to the PR if available
2.  Mention dappnode core members
3.  Add proper labels
-->

## Context

When a given pkg has in its manifest the `globalEnv` configured, and any of this `globalEnv` changes, the package must update its globalEnv.

- Pkgs with  `globalEnv: { all: true}` uses in the compose `env_file:`
- Pkgs with `globalEnv: [{ services: [ ], envs: [ ] }]` defines the given global env in the compose under `environment` section

## Approach

- If the option is `globalEnv: { all: true}` then write the new global env file and restart the pkgs that have this option in the manifest
- If the option is `globalEnv: [{ services: ["one", "two"], envs: ["FIRST_ENV", "SECOND_ENV"]}` then update this env in all the 

## Test instructions

<!-- MANDATORY: please, do not skip this step, it is very importand for DAppNode team to have simple and well defined instructions on how to test this PR.
-->

Install pkgs with `globalEnvs` in the manifest with both options.  Make sure that in both cases the global env is updated in the container