### PR TITLE
Set HTTPS mappings to local dns

### DIFF
--- a/packages/dappmanager/src/modules/https-portal/index.ts
+++ b/packages/dappmanager/src/modules/https-portal/index.ts
@@ -126,7 +126,10 @@ export class HttpsPortal {
     removeNetworkAliasCompose(container, externalNetworkName);
 
     // Removes from the bind the domain:https-IP
-    eventBus.packagesModified.emit({ dnpNames: [container.dnpName] });
+    eventBus.packagesModified.emit({
+      dnpNames: [container.dnpName],
+      removed: true
+    });
   }
 
   async getMappings(

--- a/packages/dappmanager/src/modules/https-portal/index.ts
+++ b/packages/dappmanager/src/modules/https-portal/index.ts
@@ -12,6 +12,7 @@ import { HttpsPortalApiClient } from "./apiClient";
 import { ComposeEditor } from "../compose/editor";
 import { addNetworkAliasCompose } from "./utils/addNetworkAliasCompose";
 import { removeNetworkAliasCompose } from "./utils/removeNetworkAliasCompose";
+import { eventBus } from "../../eventBus";
 export { addAliasToRunningContainersMigration } from "./migration";
 export { HttpsPortalApiClient };
 export { getExposableServices } from "./exposable";
@@ -83,6 +84,9 @@ export class HttpsPortal {
         httpsExternalAlias
       ]);
     }
+
+    // Adds to the bind the domain:https-IP
+    eventBus.packagesModified.emit({ dnpNames: [container.dnpName] });
   }
 
   /**
@@ -120,6 +124,9 @@ export class HttpsPortal {
 
     // Edit compose to persist the setting
     removeNetworkAliasCompose(container, externalNetworkName);
+
+    // Removes from the bind the domain:https-IP
+    eventBus.packagesModified.emit({ dnpNames: [container.dnpName] });
   }
 
   async getMappings(

--- a/packages/dappmanager/src/modules/https-portal/index.ts
+++ b/packages/dappmanager/src/modules/https-portal/index.ts
@@ -96,6 +96,12 @@ export class HttpsPortal {
     const containers = await listContainers();
     const container = await this.getContainerForMapping(mapping, containers);
 
+    // Removes from the bind the domain:https-IP
+    eventBus.packagesModified.emit({
+      dnpNames: [container.dnpName],
+      removed: true
+    });
+
     const externalNetworkAlias = getExternalNetworkAlias(container);
 
     // Call Http Portal API to remove the mapping
@@ -124,12 +130,6 @@ export class HttpsPortal {
 
     // Edit compose to persist the setting
     removeNetworkAliasCompose(container, externalNetworkName);
-
-    // Removes from the bind the domain:https-IP
-    eventBus.packagesModified.emit({
-      dnpNames: [container.dnpName],
-      removed: true
-    });
   }
 
   async getMappings(

--- a/packages/dappmanager/src/modules/https-portal/utils/getHttpsIpMappings.ts
+++ b/packages/dappmanager/src/modules/https-portal/utils/getHttpsIpMappings.ts
@@ -1,0 +1,31 @@
+import { httpsPortal } from "../../../calls";
+import params from "../../../params";
+import { PackageContainer } from "../../../types";
+import { dockerContainerInspect } from "../../docker";
+import { isRunningHttps } from "./isRunningHttps";
+
+/**
+ * Returns an array of tuples with the format
+ * [ [httpsMapping, httpsContainer.ip], ... ]
+ */
+export async function getHttpsIpMappings(
+  containersToUpdate: PackageContainer[]
+): Promise<[string, string][]> {
+  if (await isRunningHttps()) {
+    // Get the HTTPS container IP
+    const httpsNetworkSettings = (
+      await dockerContainerInspect(params.httpsContainerName)
+    ).NetworkSettings.Networks[params.DNP_PRIVATE_NETWORK_NAME];
+    if (!httpsNetworkSettings)
+      throw Error(`No network settings for ${params.httpsContainerName}`);
+    const httpsIp = httpsNetworkSettings.IPAddress;
+    if (!httpsIp) throw Error(`No IP for ${params.httpsContainerName}`);
+
+    // Get the HTTPS mappings fo the containersToUpdate
+    const mappings = await httpsPortal.getMappings(containersToUpdate);
+    if (!mappings) return [];
+
+    return mappings.map(mapping => [mapping.fromSubdomain, httpsIp]);
+  }
+  return [];
+}

--- a/packages/dappmanager/src/modules/https-portal/utils/getHttpsIpMappings.ts
+++ b/packages/dappmanager/src/modules/https-portal/utils/getHttpsIpMappings.ts
@@ -22,16 +22,16 @@ export async function getHttpsIpMappings(
     const httpsIp = httpsNetworkSettings.IPAddress;
     if (!httpsIp) throw Error(`No IP for ${params.httpsContainerName}`);
 
-    // Get the dyndns identity
-    const dyndnsIdentity = db.dyndnsIdentity.get();
-    if (!dyndnsIdentity) throw Error(`No dyndns identity available`);
+    // Get the dyndns address
+    const domain = db.domain.get();
+    if (!domain) throw Error("No domain set");
 
     // Get the HTTPS mappings fo the containersToUpdate
     const mappings = await httpsPortal.getMappings(containersToUpdate);
     if (!mappings) return [];
 
     return mappings.map(mapping => [
-      `${mapping.fromSubdomain}.${dyndnsIdentity}`,
+      `${mapping.fromSubdomain}.${domain}`,
       httpsIp
     ]);
   }

--- a/packages/dappmanager/src/modules/nsupdate/utils.ts
+++ b/packages/dappmanager/src/modules/nsupdate/utils.ts
@@ -6,6 +6,8 @@ import {
   stripCharacters,
   ContainerNames
 } from "../../domains";
+import { logs } from "../../logs";
+import { getHttpsIpMappings } from "../https-portal/utils/getHttpsIpMappings";
 
 const TTL = 60;
 const ethZone = "eth.";
@@ -158,6 +160,18 @@ export function getNsupdateTxts({
       dappnode[getDotDappnodeDomain(rootNames)] = container.ip;
     }
   }
+
+  // Set the containers HTTPS mappings to the HTTPS container IP (from the dncore_network)
+  //    dappnode[httpsMapping] = container.ip
+  // This would allow to use HTTPS locally without having to expose it to the internet
+  getHttpsIpMappings(containersToUpdate)
+    .then(mappings => {
+      if (mappings.length)
+        for (const mapping of mappings) dappnode[mapping[0]] = mapping[1];
+    })
+    .catch(e => {
+      logs.error(e);
+    });
 
   // Add dappnode domain alias from installed packages
   for (const container of containersToUpdate)

--- a/packages/dappmanager/src/params.ts
+++ b/packages/dappmanager/src/params.ts
@@ -196,6 +196,8 @@ const params = {
   coreDnpName: "core.dnp.dappnode.eth",
   dappmanagerDnpName: "dappmanager.dnp.dappnode.eth",
   dappmanagerContainerName: "DAppNodeCore-dappmanager.dnp.dappnode.eth",
+  httpsDnpName: "https.dnp.dappnode.eth",
+  httpsContainerName: "DAppNodeCore-https.dnp.dappnode.eth",
   restartDnpName: "restart.dnp.dappnode.eth",
   vpnDnpName: "vpn.dnp.dappnode.eth",
   vpnContainerName: "DAppNodeCore-vpn.dnp.dappnode.eth",


### PR DESCRIPTION
<!-- For DAppNode core members, once the Pull Request is created, do not forget to:
1.  Link issues to the PR if available
2.  Mention dappnode core members
3.  Add proper labels
-->

## Context

Set HTTPS portal mappings to the local dns. This will allow to use HTTPS portal mappings without having to expose it to the internet

## Test instructions

Expose a HTTPS portal mapping and make sure that it is available from inside and outside with `dig` command
