### PR TITLE
read `ipfsClientTarget` on `initializeDb`

### DIFF
--- a/packages/dappmanager/src/index.ts
+++ b/packages/dappmanager/src/index.ts
@@ -55,7 +55,9 @@ switchEthClientIfOpenethereum().catch(e =>
 );
 
 // Initialize DB
-initializeDb().catch(e => logs.error("Error inititializing Database", e));
+initializeDb()
+  .then(() => logs.info("Initialized Database"))
+  .catch(e => logs.error("Error inititializing Database", e));
 
 // Start daemons
 startDaemons(controller.signal);

--- a/packages/dappmanager/src/index.ts
+++ b/packages/dappmanager/src/index.ts
@@ -54,18 +54,20 @@ switchEthClientIfOpenethereum().catch(e =>
   logs.error("Error switch client openethereum", e)
 );
 
+// Initialize DB
+initializeDb().catch(e => logs.error("Error inititializing Database", e));
+
 // Start daemons
 startDaemons(controller.signal);
 
-// Copy host services
-copyHostServices().catch(e => logs.error("Error copying host services", e));
-
 Promise.all([
-  initializeDb().catch(e => logs.error("Error copying host scripts", e)), // Generate keypair, network stats, and run dyndns loop
+  // Copy host services
+  copyHostServices().catch(e => logs.error("Error copying host services", e)),
   copyHostScripts().catch(e => logs.error("Error copying host scripts", e)) // Copy hostScripts
 ]).then(() =>
+  // avahiDaemon uses a host script that must be copied before been initialized
   startAvahiDaemon().catch(e => logs.error("Error starting avahi daemon", e))
-); // avahiDaemon uses a host script that must be copied before been initialized
+);
 
 // Create the global env file
 createGlobalEnvsEnvFile();

--- a/packages/dappmanager/src/modules/globalEnvs.ts
+++ b/packages/dappmanager/src/modules/globalEnvs.ts
@@ -4,7 +4,7 @@ import * as db from "../db";
 import params from "../params";
 import { stringifyEnvironment } from "../modules/compose";
 import { PackageEnvs } from "@dappnode/dappnodesdk";
-import { packageSetEnvironment } from "../calls";
+import { packageSetEnvironment } from "../calls/packageSetEnvironment";
 import { logs } from "../logs";
 import { ComposeFileEditor } from "./compose/editor";
 import { listContainers } from "./docker/list";


### PR DESCRIPTION
<!-- For DAppNode core members, once the Pull Request is created, do not forget to:
1.  Link issues to the PR if available
2.  Mention dappnode core members
3.  Add proper labels
-->

## Context

The function `interceptGlobalEnvsOnSet` is used by `globalEnvs` as a middleware. This function uses IPFS.

The IPFS instance requires some setting from the db to be read before being initialized

## Approach

In the startup function `initializeDb` read this value and set a default value of `local` if not set

## Test instructions

Make sure the ipfsClientTarget value is read and set propertly if required on startup