### PR TITLE
Persist dappnode dynds domains to HTTPS container ip

### DIFF
--- a/packages/dappmanager/src/modules/nsupdate/utils.ts
+++ b/packages/dappmanager/src/modules/nsupdate/utils.ts
@@ -6,6 +6,7 @@ import {
   stripCharacters,
   ContainerNames
 } from "../../domains";
+import * as db from "../../db";
 
 const TTL = 60;
 const ethZone = "eth.";
@@ -147,6 +148,12 @@ export function getNsupdateTxts({
     // Add multilabel IPFS domains to the IPFS container IP
     if (container.dnpName === params.ipfsDnpName)
       dappnode[`*.${getDotDappnodeDomain(container)}`] = container.ip;
+    // Add multilabel dynds domains to the HTTPS container IP
+    if (container.dnpName === params.httpsDnpName) {
+      // f6e36f19e349b0dd.dyndns.dappnode.io
+      const domain = db.domain.get();
+      if (domain) dappnode[`*.${domain}`] = container.ip;
+    }
 
     // For multi-service DNPs, link the main container to the root URL
     if (container.isMain) {

--- a/packages/dappmanager/src/params.ts
+++ b/packages/dappmanager/src/params.ts
@@ -201,6 +201,8 @@ const params = {
   vpnContainerName: "DAppNodeCore-vpn.dnp.dappnode.eth",
   wifiDnpName: "wifi.dnp.dappnode.eth",
   wifiContainerName: "DAppNodeCore-wifi.dnp.dappnode.eth",
+  httpsDnpName: "https.dnp.dappnode.eth",
+  httpsContainerName: "DAppNodeCore-https.dnp.dappnode.eth",
   ipfsDnpName: "ipfs.dnp.dappnode.eth",
   ipfsContainerName: "DAppNodeCore-ipfs.dnp.dappnode.eth",
   vpnDataVolume: "dncore_vpndnpdappnodeeth_data",


### PR DESCRIPTION
<!-- For DAppNode core members, once the Pull Request is created, do not forget to:
1.  Link issues to the PR if available
2.  Mention dappnode core members
3.  Add proper labels
-->

## Approach

Set HTTPS portal mappings to the local dns. This will allow to use HTTPS portal mappings without having to expose it to the internet.

``` 
*.1234abc.dyndns.dappnode.io => httpsContainer.ip
```

## Test instructions

Expose a HTTPS portal mapping and make sure that it is available from inside and outside with dig command
