### PR TITLE
Set proper `globalEnv` key prefix to `globalEnvs` used iby `interceptGlobalEnvOnSet`

### DIFF
--- a/packages/dappmanager/src/db/dyndns.ts
+++ b/packages/dappmanager/src/db/dyndns.ts
@@ -9,12 +9,12 @@ const STATIC_IP = "static-ip";
 
 export const publicIp = interceptGlobalEnvOnSet({
   ...dbMain.staticKey<string>(PUBLIC_IP, ""),
-  globEnvKey: PUBLIC_IP
+  globEnvKey: Object.keys({ PUBLIC_IP })[0]
 });
 
 export const domain = interceptGlobalEnvOnSet({
   ...dbMain.staticKey<string>(DOMAIN, ""),
-  globEnvKey: DOMAIN
+  globEnvKey: Object.keys({ DOMAIN })[0]
 });
 
 export const dyndnsIdentity = dbMain.staticKey<IdentityInterface>(
@@ -24,5 +24,5 @@ export const dyndnsIdentity = dbMain.staticKey<IdentityInterface>(
 
 export const staticIp = interceptGlobalEnvOnSet({
   ...dbMain.staticKey<string>(STATIC_IP, ""),
-  globEnvKey: STATIC_IP
+  globEnvKey: Object.keys({ STATIC_IP })[0]
 });

--- a/packages/dappmanager/src/db/network.ts
+++ b/packages/dappmanager/src/db/network.ts
@@ -9,7 +9,7 @@ const AVAHI_SHOULD_BE_DISABLED = "avahi-should-be-disabled";
 
 export const noNatLoopback = interceptGlobalEnvOnSet({
   ...dbMain.staticKey<boolean>(NO_NAT_LOOPBACK, false),
-  globEnvKey: NO_NAT_LOOPBACK
+  globEnvKey: Object.keys({ NO_NAT_LOOPBACK })[0]
 });
 export const doubleNat = dbMain.staticKey<boolean>(DOUBLE_NAT, false);
 export const alertToOpenPorts = dbMain.staticKey<boolean>(
@@ -18,7 +18,7 @@ export const alertToOpenPorts = dbMain.staticKey<boolean>(
 );
 export const internalIp = interceptGlobalEnvOnSet({
   ...dbMain.staticKey<string>(INTERNAL_IP, ""),
-  globEnvKey: INTERNAL_IP
+  globEnvKey: Object.keys({ INTERNAL_IP })[0]
 });
 
 export const avahiPublishCmdShouldNotRun = dbMain.staticKey<boolean>(

--- a/packages/dappmanager/src/db/stakerConfig.ts
+++ b/packages/dappmanager/src/db/stakerConfig.ts
@@ -20,7 +20,7 @@ export const consensusClientMainnet = interceptGlobalEnvOnSet({
     CONSENSUS_CLIENT_MAINNET,
     null
   ),
-  globEnvKey: CONSENSUS_CLIENT_MAINNET
+  globEnvKey: Object.keys({ CONSENSUS_CLIENT_MAINNET })[0]
 });
 
 export const executionClientMainnet = interceptGlobalEnvOnSet({
@@ -28,12 +28,12 @@ export const executionClientMainnet = interceptGlobalEnvOnSet({
     EXECUTION_CLIENT_MAINNET,
     null
   ),
-  globEnvKey: EXECUTION_CLIENT_MAINNET
+  globEnvKey: Object.keys({ EXECUTION_CLIENT_MAINNET })[0]
 });
 
 export const mevBoostMainnet = interceptGlobalEnvOnSet({
   ...dbMain.staticKey<boolean>(MEVBOOST_MAINNET, false),
-  globEnvKey: MEVBOOST_MAINNET
+  globEnvKey: Object.keys({ MEVBOOST_MAINNET })[0]
 });
 
 // Gnosis
@@ -47,7 +47,7 @@ export const consensusClientGnosis = interceptGlobalEnvOnSet({
     CONSENSUS_CLIENT_GNOSIS,
     null
   ),
-  globEnvKey: CONSENSUS_CLIENT_GNOSIS
+  globEnvKey: Object.keys({ CONSENSUS_CLIENT_GNOSIS })[0]
 });
 
 export const executionClientGnosis = interceptGlobalEnvOnSet({
@@ -55,12 +55,12 @@ export const executionClientGnosis = interceptGlobalEnvOnSet({
     EXECUTION_CLIENT_GNOSIS,
     null
   ),
-  globEnvKey: EXECUTION_CLIENT_GNOSIS
+  globEnvKey: Object.keys({ EXECUTION_CLIENT_GNOSIS })[0]
 });
 
 export const mevBoostGnosis = interceptGlobalEnvOnSet({
   ...dbMain.staticKey<boolean>(MEVBOOST_GNOSIS, false),
-  globEnvKey: MEVBOOST_GNOSIS
+  globEnvKey: Object.keys({ MEVBOOST_GNOSIS })[0]
 });
 
 // Prater
@@ -74,7 +74,7 @@ export const consensusClientPrater = interceptGlobalEnvOnSet({
     CONENSUS_CLIENT_PRATER,
     null
   ),
-  globEnvKey: CONENSUS_CLIENT_PRATER
+  globEnvKey: Object.keys({ CONENSUS_CLIENT_PRATER })[0]
 });
 
 export const executionClientPrater = interceptGlobalEnvOnSet({
@@ -82,10 +82,10 @@ export const executionClientPrater = interceptGlobalEnvOnSet({
     EXECUTION_CLIENT_PRATER,
     null
   ),
-  globEnvKey: EXECUTION_CLIENT_PRATER
+  globEnvKey: Object.keys({ EXECUTION_CLIENT_PRATER })[0]
 });
 
 export const mevBoostPrater = interceptGlobalEnvOnSet({
   ...dbMain.staticKey<boolean>(MEVBOOST_PRATER, false),
-  globEnvKey: MEVBOOST_PRATER
+  globEnvKey: Object.keys({ MEVBOOST_PRATER })[0]
 });

--- a/packages/dappmanager/src/db/system.ts
+++ b/packages/dappmanager/src/db/system.ts
@@ -14,7 +14,7 @@ const DAPPNODE_WEB_NAME = "dappnode-web-name";
 
 export const serverName = interceptGlobalEnvOnSet({
   ...dbMain.staticKey<string>(SERVER_NAME, ""),
-  globEnvKey: SERVER_NAME
+  globEnvKey: Object.keys({ SERVER_NAME })[0]
 });
 
 // Domains

--- a/packages/dappmanager/src/db/upnp.ts
+++ b/packages/dappmanager/src/db/upnp.ts
@@ -10,7 +10,7 @@ const IS_NAT_RENEWAL_DISABLED = "is-nat-renewal-disabled";
 
 export const upnpAvailable = interceptGlobalEnvOnSet({
   ...dbCache.staticKey<boolean>(UPNP_AVAILABLE, false),
-  globEnvKey: UPNP_AVAILABLE
+  globEnvKey: Object.keys({ UPNP_AVAILABLE })[0]
 });
 
 export const upnpPortMappings = dbCache.staticKey<UpnpPortMapping[]>(


### PR DESCRIPTION
Instead of `_DAPPNODE_GLOBAL_consensus-client-prater` use `_DAPPNODE_GLOBAL_CONSENUS_CLIENT_PRATER`