### PR TITLE
Add Besu as official EL and as Main Repo Client

### DIFF
--- a/packages/admin-ui/src/common/types.ts
+++ b/packages/admin-ui/src/common/types.ts
@@ -1000,13 +1000,14 @@ export enum IpfsClientTarget {
  * Eth provider / client types
  * Manage the Ethereum multi-client setup
  */
-export type EthClientTargetPackage = "geth-light" | "geth" | "nethermind";
+export type EthClientTargetPackage = "geth-light" | "geth" | "nethermind" | "besu";
 export type EthClientTarget = EthClientTargetPackage | "remote";
 export const ethClientTargets: EthClientTarget[] = [
   "remote",
   "geth-light",
   "geth",
-  "nethermind"
+  "nethermind",
+  "besu"
 ];
 
 /**

--- a/packages/admin-ui/src/components/EthMultiClient.tsx
+++ b/packages/admin-ui/src/components/EthMultiClient.tsx
@@ -29,6 +29,8 @@ export function getEthClientPrettyName(target: EthClientTarget): string {
       return "Geth";
     case "nethermind":
       return "Nethermind";
+    case "besu":
+      return "Besu";
   }
 }
 
@@ -43,6 +45,7 @@ export function getEthClientType(target: EthClientTarget): string {
       return "Light client";
     case "geth":
     case "nethermind":
+    case "besu":
       return "Full node";
   }
 }
@@ -122,7 +125,7 @@ const clients: EthClientData[] = [
   {
     title: "Full node",
     description: "Your own Ethereum node w/out 3rd parties",
-    options: ["geth", "nethermind"],
+    options: ["geth", "nethermind", "besu"],
     stats: {
       syncTime: "Slow sync",
       requirements: "High requirements",

--- a/packages/dappmanager/src/params.ts
+++ b/packages/dappmanager/src/params.ts
@@ -337,7 +337,8 @@ export const ethClientData: {
     }
   },
   geth: { dnpName: "geth.dnp.dappnode.eth" },
-  nethermind: { dnpName: "nethermind.public.dappnode.eth" }
+  nethermind: { dnpName: "nethermind.public.dappnode.eth" },
+  besu: { dnpName: "besu.dnp.dappnode.eth" }
 };
 
 // Naming


### PR DESCRIPTION
added Besu


## Context

With the upcoming merge around the corner, we finally got multi-client implemented on all chains, solving the consensus layer diversification issue.  This aims to solve the new execution layer diversification issue created by the following:
- Deprecation of OpenEthereum
- Instability of Erigon
- Recent major bug in Geth, the majority client which made Nethermind the only option for a short time.
- Nethermind's resource hogging issue is still in the code AFAIK, but is being effectively mitigated by the ulimits now imposed by Docker for nethermind containers; this solution is not sufficient for very low RAM machines, Besu is touted to and has shown in testing to be more resource friendly than Nethermind.

## Approach

Will be adding Besu as an option alongside Nethermind and Geth as global ENVs for EL and CL client matching.
Also adding Besu as an option to be an official Repo client.

## Test instructions

Testing instructions on Notion.


## Before merging must complete testing of Besu with all published CLs!

