### PR TITLE
Attemp to expose HTTPS ports by default only when are

### DIFF
--- a/packages/dappmanager/src/modules/https-portal/utils/exposeByDefaultHttpsPorts.ts
+++ b/packages/dappmanager/src/modules/https-portal/utils/exposeByDefaultHttpsPorts.ts
@@ -11,72 +11,73 @@ export async function exposeByDefaultHttpsPorts(
   pkg: InstallPackageData,
   log: Log
 ): Promise<void> {
-  if (pkg.metadata.exposable) {
-    const currentMappings = await httpsPortal.getMappings();
-    const portMappinRollback: HttpsPortalMapping[] = [];
+  const exposables = pkg.metadata.exposable;
 
-    for (const exposable of pkg.metadata.exposable) {
-      if (exposable.exposeByDefault) {
-        // Requires that https package exists and it is running
-        if (!(await isRunningHttps()))
-          throw Error(
-            `HTTPS package not running but required to expose HTTPS ports by default.`
-          );
-        const portalMapping: HttpsPortalMapping = {
-          fromSubdomain: exposable.fromSubdomain || prettyDnpName(pkg.dnpName), // get dnpName by default
-          dnpName: pkg.dnpName,
-          serviceName:
-            exposable.serviceName || Object.keys(pkg.compose.services)[0], // get first service name by default (docs: https://docs.dappnode.io/es/developers/manifest-reference/#servicename)
-          port: exposable.port
-        };
+  // Return if no exposable or not exposeByDefault
+  if (!exposables || !exposables.some(exp => exp.exposeByDefault)) return;
 
-        if (
-          currentMappings.length > 0 &&
-          currentMappings.includes(portalMapping)
-        )
-          continue;
+  // Requires that https package exists and it is running
+  if (!(await isRunningHttps()))
+    throw Error(
+      `HTTPS package not running but required to expose HTTPS ports by default.`
+    );
 
-        try {
-          // Expose default HTTPS ports
+  const currentMappings = await httpsPortal.getMappings();
+  const portMappinRollback: HttpsPortalMapping[] = [];
+
+  for (const exposable of exposables) {
+    if (exposable.exposeByDefault) {
+      const portalMapping: HttpsPortalMapping = {
+        fromSubdomain: exposable.fromSubdomain || prettyDnpName(pkg.dnpName), // get dnpName by default
+        dnpName: pkg.dnpName,
+        serviceName:
+          exposable.serviceName || Object.keys(pkg.compose.services)[0], // get first service name by default (docs: https://docs.dappnode.io/es/developers/manifest-reference/#servicename)
+        port: exposable.port
+      };
+
+      if (currentMappings.length > 0 && currentMappings.includes(portalMapping))
+        continue;
+
+      try {
+        // Expose default HTTPS ports
+        log(
+          pkg.dnpName,
+          `Exposing ${prettyDnpName(pkg.dnpName)}:${
+            exposable.port
+          } to the external internet`
+        );
+        await httpsPortal.addMapping(portalMapping);
+        portMappinRollback.push(portalMapping);
+
+        log(
+          pkg.dnpName,
+          `Exposed ${prettyDnpName(pkg.dnpName)}:${
+            exposable.port
+          } to the external internet`
+        );
+      } catch (e) {
+        if (e.message.includes("External endpoint already exists")) {
+          // Bypass error if already exposed: 400 Bad Request {"error":"External endpoint already exists"}
           log(
             pkg.dnpName,
-            `Exposing ${prettyDnpName(pkg.dnpName)}:${
-              exposable.port
-            } to the external internet`
+            `External endpoint already exists for ${prettyDnpName(
+              pkg.dnpName
+            )}:${exposable.port}`
           );
-          await httpsPortal.addMapping(portalMapping);
-          portMappinRollback.push(portalMapping);
-
-          log(
-            pkg.dnpName,
-            `Exposed ${prettyDnpName(pkg.dnpName)}:${
-              exposable.port
-            } to the external internet`
-          );
-        } catch (e) {
-          if (e.message.includes("External endpoint already exists")) {
-            // Bypass error if already exposed: 400 Bad Request {"error":"External endpoint already exists"}
-            log(
-              pkg.dnpName,
-              `External endpoint already exists for ${prettyDnpName(
-                pkg.dnpName
-              )}:${exposable.port}`
-            );
-          } else {
-            // Remove all mappings and throw error to trigger package install rollback
-            e.message = `${e.message} Error exposing default HTTPS ports, removing mappings`;
-            for (const mappingRollback of portMappinRollback) {
-              await httpsPortal.removeMapping(mappingRollback).catch(e => {
-                log(
-                  pkg.dnpName,
-                  `Error removing mapping ${JSON.stringify(mappingRollback)}, ${
-                    e.message
-                  }`
-                );
-              });
-            }
-            throw e;
+        } else {
+          // Remove all mappings and throw error to trigger package install rollback
+          e.message = `${e.message} Error exposing default HTTPS ports, removing mappings`;
+          for (const mappingRollback of portMappinRollback) {
+            await httpsPortal.removeMapping(mappingRollback).catch(e => {
+              log(
+                pkg.dnpName,
+                `Error removing mapping ${JSON.stringify(mappingRollback)}, ${
+                  e.message
+                }`
+              );
+            });
           }
+          throw e;
         }
       }
     }


### PR DESCRIPTION
<!-- For DAppNode core members, once the Pull Request is created, do not forget to:
1.  Link issues to the PR if available
2.  Mention dappnode core members
3.  Add proper labels
-->

## Context

When installing packages with the `exposable` feature and the `exposeByDefault` not defined, the dappmanager was throwing an error if the HTTPS package was not installed. This is unexpected behavior and there should be only thrown errors when the `exposeByDefault` is set to true and the HTTPS package is not installed

## Test instructions

<!-- MANDATORY: please, do not skip this step, it is very importand for DAppNode team to have simple and well defined instructions on how to test this PR.
-->

Install a dappnode package with the exposable defined and the `exposaByDefault` not defined or set to false and make sure its get installed.

