### PR TITLE
Do not remove orphan containers on `packageSetEnvironment`

### DIFF
--- a/packages/dappmanager/src/calls/packageSetEnvironment.ts
+++ b/packages/dappmanager/src/calls/packageSetEnvironment.ts
@@ -36,8 +36,7 @@ export async function packageSetEnvironment({
   // Packages sharing PID or must be recreated:
   // - Packages sharing PID must be recreated to ensure startup order
   await dockerComposeUpPackage({ dnpName }, containersStatus, {
-    forceRecreate: packageInstalledHasPid(compose.compose),
-    removeOrphans: true
+    forceRecreate: packageInstalledHasPid(compose.compose)
   });
 
   // Emit packages update

--- a/packages/dappmanager/src/modules/globalEnvs.ts
+++ b/packages/dappmanager/src/modules/globalEnvs.ts
@@ -78,7 +78,7 @@ export async function updatePkgsWithGlobalEnvs(
 
   if (pkgsWithGlobalEnv.length === 0) return;
 
-  for await (const pkg of pkgsWithGlobalEnv) {
+  for (const pkg of pkgsWithGlobalEnv) {
     if (pkg.dnpName === params.dappmanagerDnpName) continue;
     if (!pkg.defaultEnvironment) continue;
     const compose = new ComposeFileEditor(pkg.dnpName, pkg.isCore);
@@ -95,6 +95,8 @@ export async function updatePkgsWithGlobalEnvs(
     if (environmentsByService.length === 0) continue;
     const environmentByService: { [serviceName: string]: PackageEnvs } =
       environmentsByService.reduce((acc, curr) => ({ ...acc, ...curr }), {});
+
+    logs.info(`Setting environment: ${environmentByService}`);
 
     await packageSetEnvironment({
       dnpName: pkg.dnpName,


### PR DESCRIPTION
Do not remove orphan containers on `packageSetEnvironment`. This option may break docker functionality while calling `docker-compose up` with the option `force recreate` and `noStart: true`
