### PR TITLE
Use empty string instead of `undefined` for none option in the stakers UI 

### DIFF
--- a/packages/admin-ui/src/common/types.ts
+++ b/packages/admin-ui/src/common/types.ts
@@ -1184,12 +1184,14 @@ export type ConsensusClientMainnet =
   | "prysm.dnp.dappnode.eth"
   | "lighthouse.dnp.dappnode.eth"
   | "teku.dnp.dappnode.eth"
-  | "nimbus.dnp.dappnode.eth";
+  | "nimbus.dnp.dappnode.eth"
+  | "";
 export type ExecutionClientMainnet =
   | "geth.dnp.dappnode.eth"
   | "besu.dnp.dappnode.eth"
   | "erigon.dnp.dappnode.eth"
-  | "nethermind.public.dappnode.eth";
+  | "nethermind.public.dappnode.eth"
+  | "";
 
 // Prater
 
@@ -1197,13 +1199,15 @@ export type ConsensusClientPrater =
   | "prysm-prater.dnp.dappnode.eth"
   | "lighthouse-prater.dnp.dappnode.eth"
   | "teku-prater.dnp.dappnode.eth"
-  | "nimbus-prater.dnp.dappnode.eth";
+  | "nimbus-prater.dnp.dappnode.eth"
+  | "";
 
 export type ExecutionClientPrater =
   | "goerli-geth.dnp.dappnode.eth"
   | "goerli-erigon.dnp.dappnode.eth"
   | "goerli-nethermind.dnp.dappnode.eth"
-  | "goerli-besu.dnp.dappnode.eth";
+  | "goerli-besu.dnp.dappnode.eth"
+  | "";
 
 // Gnosis
 
@@ -1211,8 +1215,9 @@ export type ConsensusClientGnosis =
   | "gnosis-beacon-chain-prysm.dnp.dappnode.eth"
   | "lighthouse-gnosis.dnp.dappnode.eth"
   | "teku-gnosis.dnp.dappnode.eth"
-  | "nimbus-gnosis.dnp.dappnode.eth";
-export type ExecutionClientGnosis = "nethermind-xdai.dnp.dappnode.eth";
+  | "nimbus-gnosis.dnp.dappnode.eth"
+  | "";
+export type ExecutionClientGnosis = "nethermind-xdai.dnp.dappnode.eth" | "";
 
 export type StakerItem = StakerItemOk | StakerItemError;
 

--- a/packages/dappmanager/src/daemons/stakerConfig/index.ts
+++ b/packages/dappmanager/src/daemons/stakerConfig/index.ts
@@ -14,11 +14,11 @@ function runStakerConfigUpdate({ dnpNames }: { dnpNames: string[] }): void {
       ) {
         switch (network) {
           case "mainnet":
-            db.executionClientMainnet.set(undefined);
+            db.executionClientMainnet.set("");
           case "gnosis":
-            db.executionClientGnosis.set(undefined);
+            db.executionClientGnosis.set("");
           case "prater":
-            db.executionClientPrater.set(undefined);
+            db.executionClientPrater.set("");
         }
       }
 
@@ -27,11 +27,11 @@ function runStakerConfigUpdate({ dnpNames }: { dnpNames: string[] }): void {
       ) {
         switch (network) {
           case "mainnet":
-            db.consensusClientMainnet.set(undefined);
+            db.consensusClientMainnet.set("");
           case "gnosis":
-            db.consensusClientGnosis.set(undefined);
+            db.consensusClientGnosis.set("");
           case "prater":
-            db.consensusClientPrater.set(undefined);
+            db.consensusClientPrater.set("");
         }
       }
 

--- a/packages/dappmanager/src/db/stakerConfig.ts
+++ b/packages/dappmanager/src/db/stakerConfig.ts
@@ -16,7 +16,7 @@ const EXECUTION_CLIENT_MAINNET = "execution-client-mainnet";
 const MEVBOOST_MAINNET = "mevboost-mainnet";
 
 export const consensusClientMainnet = interceptGlobalEnvOnSet(
-  dbMain.staticKey<ConsensusClientMainnet | null | undefined>(
+  dbMain.staticKey<ConsensusClientMainnet | null>(
     CONSENSUS_CLIENT_MAINNET,
     null
   ),
@@ -24,7 +24,7 @@ export const consensusClientMainnet = interceptGlobalEnvOnSet(
 );
 
 export const executionClientMainnet = interceptGlobalEnvOnSet(
-  dbMain.staticKey<ExecutionClientMainnet | null | undefined>(
+  dbMain.staticKey<ExecutionClientMainnet | null>(
     EXECUTION_CLIENT_MAINNET,
     null
   ),
@@ -43,18 +43,12 @@ const EXECUTION_CLIENT_GNOSIS = "execution-client-gnosis";
 const MEVBOOST_GNOSIS = "mevboost-gnosis";
 
 export const consensusClientGnosis = interceptGlobalEnvOnSet(
-  dbMain.staticKey<ConsensusClientGnosis | null | undefined>(
-    CONSENSUS_CLIENT_GNOSIS,
-    null
-  ),
+  dbMain.staticKey<ConsensusClientGnosis | null>(CONSENSUS_CLIENT_GNOSIS, null),
   Object.keys({ CONSENSUS_CLIENT_GNOSIS })[0]
 );
 
 export const executionClientGnosis = interceptGlobalEnvOnSet(
-  dbMain.staticKey<ExecutionClientGnosis | null | undefined>(
-    EXECUTION_CLIENT_GNOSIS,
-    null
-  ),
+  dbMain.staticKey<ExecutionClientGnosis | null>(EXECUTION_CLIENT_GNOSIS, null),
   Object.keys({ EXECUTION_CLIENT_GNOSIS })[0]
 );
 
@@ -70,18 +64,12 @@ const EXECUTION_CLIENT_PRATER = "execution-client-prater";
 const MEVBOOST_PRATER = "mevboost-prater";
 
 export const consensusClientPrater = interceptGlobalEnvOnSet(
-  dbMain.staticKey<ConsensusClientPrater | null | undefined>(
-    CONSENSUS_CLIENT_PRATER,
-    null
-  ),
+  dbMain.staticKey<ConsensusClientPrater | null>(CONSENSUS_CLIENT_PRATER, null),
   Object.keys({ CONSENSUS_CLIENT_PRATER })[0]
 );
 
 export const executionClientPrater = interceptGlobalEnvOnSet(
-  dbMain.staticKey<ExecutionClientPrater | null | undefined>(
-    EXECUTION_CLIENT_PRATER,
-    null
-  ),
+  dbMain.staticKey<ExecutionClientPrater | null>(EXECUTION_CLIENT_PRATER, null),
   Object.keys({ EXECUTION_CLIENT_PRATER })[0]
 );
 

--- a/packages/dappmanager/src/modules/stakerConfig/setDefaultStakerConfig.ts
+++ b/packages/dappmanager/src/modules/stakerConfig/setDefaultStakerConfig.ts
@@ -1,4 +1,12 @@
-import { Network } from "../../types";
+import {
+  ConsensusClientGnosis,
+  ConsensusClientMainnet,
+  ConsensusClientPrater,
+  ExecutionClientGnosis,
+  ExecutionClientMainnet,
+  ExecutionClientPrater,
+  Network
+} from "../../types";
 import { getNetworkStakerPkgs } from "./utils";
 import * as db from "../../db";
 import { packagesGet } from "../../calls";
@@ -25,7 +33,8 @@ export async function setDefaultStakerConfig(): Promise<void> {
     // If there is no repository full node option selected and there are execution client packages installed, choose one of them based on a given priority
     // If there is no repository full node option selected and there are no execution clients packages installed then set undefined
     if (stakerConfig.currentExecClient === null) {
-      let newExexClientValue: any;
+      // Set default empty string value
+      let newExexClientValue = "";
 
       for (const execClient of stakerConfig.execClients.map(
         exCl => exCl.dnpName
@@ -45,13 +54,19 @@ export async function setDefaultStakerConfig(): Promise<void> {
 
       switch (network) {
         case "mainnet":
-          db.executionClientMainnet.set(newExexClientValue);
+          db.executionClientMainnet.set(
+            newExexClientValue as ExecutionClientMainnet
+          );
           break;
         case "gnosis":
-          db.executionClientGnosis.set(newExexClientValue);
+          db.executionClientGnosis.set(
+            newExexClientValue as ExecutionClientGnosis
+          );
           break;
         case "prater":
-          db.executionClientPrater.set(newExexClientValue);
+          db.executionClientPrater.set(
+            newExexClientValue as ExecutionClientPrater
+          );
           break;
         default:
           break;
@@ -62,7 +77,8 @@ export async function setDefaultStakerConfig(): Promise<void> {
     // If the web3signer is installed then grab the value from its compose ENV value
     // If not web3signer then is undefined
     if (stakerConfig.currentConsClient === null) {
-      let newConsClientValue: any;
+      // Set default empty string value
+      let newConsClientValue = "";
 
       const web3signerPkg = pkgs.find(
         pkg => pkg.dnpName === stakerConfig.web3signer.dnpName
@@ -94,13 +110,19 @@ export async function setDefaultStakerConfig(): Promise<void> {
 
       switch (network) {
         case "mainnet":
-          db.consensusClientMainnet.set(newConsClientValue);
+          db.consensusClientMainnet.set(
+            newConsClientValue as ConsensusClientMainnet
+          );
           break;
         case "gnosis":
-          db.consensusClientGnosis.set(newConsClientValue);
+          db.consensusClientGnosis.set(
+            newConsClientValue as ConsensusClientGnosis
+          );
           break;
         case "prater":
-          db.consensusClientPrater.set(newConsClientValue);
+          db.consensusClientPrater.set(
+            newConsClientValue as ConsensusClientPrater
+          );
           break;
         default:
           break;

--- a/packages/dappmanager/src/modules/stakerConfig/utils.ts
+++ b/packages/dappmanager/src/modules/stakerConfig/utils.ts
@@ -1,4 +1,13 @@
-import { StakerConfigSet, Network } from "../../types";
+import {
+  StakerConfigSet,
+  Network,
+  ExecutionClientMainnet,
+  ConsensusClientMainnet,
+  ExecutionClientGnosis,
+  ConsensusClientGnosis,
+  ExecutionClientPrater,
+  ConsensusClientPrater
+} from "../../types";
 import * as db from "../../db";
 
 /**
@@ -7,25 +16,31 @@ import * as db from "../../db";
 export function setStakerConfigOnDb(stakerConfig: StakerConfigSet): void {
   switch (stakerConfig.network) {
     case "mainnet":
-      db.executionClientMainnet.set(stakerConfig.executionClient as any);
-      db.consensusClientMainnet.set(
-        stakerConfig.consensusClient?.dnpName as any
+      db.executionClientMainnet.set(
+        (stakerConfig.executionClient || "") as ExecutionClientMainnet
       );
-      db.mevBoostMainnet.set(stakerConfig.enableMevBoost as any);
+      db.consensusClientMainnet.set(
+        (stakerConfig.consensusClient?.dnpName || "") as ConsensusClientMainnet
+      );
+      db.mevBoostMainnet.set(stakerConfig.enableMevBoost || false);
       break;
     case "gnosis":
-      db.executionClientGnosis.set(stakerConfig.executionClient as any);
-      db.consensusClientGnosis.set(
-        stakerConfig.consensusClient?.dnpName as any
+      db.executionClientGnosis.set(
+        (stakerConfig.executionClient || "") as ExecutionClientGnosis
       );
-      db.mevBoostGnosis.set(stakerConfig.enableMevBoost as any);
+      db.consensusClientGnosis.set(
+        (stakerConfig.consensusClient?.dnpName || "") as ConsensusClientGnosis
+      );
+      db.mevBoostGnosis.set(stakerConfig.enableMevBoost || false);
       break;
     case "prater":
-      db.executionClientPrater.set(stakerConfig.executionClient as any);
-      db.consensusClientPrater.set(
-        stakerConfig.consensusClient?.dnpName as any
+      db.executionClientPrater.set(
+        (stakerConfig.executionClient || "") as ExecutionClientPrater
       );
-      db.mevBoostPrater.set(stakerConfig.enableMevBoost as any);
+      db.consensusClientPrater.set(
+        (stakerConfig.consensusClient?.dnpName || "") as ConsensusClientPrater
+      );
+      db.mevBoostPrater.set(stakerConfig.enableMevBoost || false);
       break;
     default:
       throw new Error(`Unsupported network: ${stakerConfig.network}`);


### PR DESCRIPTION
The dappmanager db for the stakers UI uses `null` values to express a non-definition value for every value in execution and consensus clients for networks mainnet prater and gnosis. After the first run, these values should have any string value but not `null`. Setting `undefined` results in a default value of `null` which is a false positive of the value not been set.