### PR TITLE
Prune`userActionLogs`

### DIFF
--- a/packages/admin-ui/src/common/routes.ts
+++ b/packages/admin-ui/src/common/routes.ts
@@ -674,7 +674,7 @@ export const routesData: { [P in keyof Routes]: RouteData } = {
   cleanCache: {},
   cleanDb: {},
   copyFileTo: { log: true },
-  stakerConfigGet: { log: true },
+  stakerConfigGet: {},
   stakerConfigSet: { log: true },
   dappnodeWebNameSet: { log: true },
   deviceAdd: { log: true },

--- a/packages/dappmanager/src/logUserAction.ts
+++ b/packages/dappmanager/src/logUserAction.ts
@@ -26,8 +26,10 @@ type UserActionLogPartial = Omit<UserActionLog, "level" | "timestamp">;
  * Specific RPCs will have a ```userAction``` flag to indicate that the result
  * should be logged by this module.
  */
-function push(log: UserActionLogPartial, level: UserActionLog["level"]): void {
-  const maxLogSize = 3072; // 3072 Bytes = 3KB
+export function push(
+  log: UserActionLogPartial,
+  level: UserActionLog["level"]
+): void {
   const userActionLog: UserActionLog = {
     level,
     timestamp: Date.now(),
@@ -37,10 +39,9 @@ function push(log: UserActionLogPartial, level: UserActionLog["level"]): void {
   };
 
   // Skip for logs greater than 3 KB
-  const logSize = Buffer.byteLength(JSON.stringify(userActionLog), "utf8");
-  if (logSize > maxLogSize) {
+  if (isLogTooBig(userActionLog)) {
     logs.warn(
-      `The log ${userActionLog.event} is too big (>${maxLogSize} bytes). It will not be stored in ${params.USER_ACTION_LOGS_DB_PATH}`
+      `The log ${userActionLog.event} is too big. It will not be stored in ${params.USER_ACTION_LOGS_DB_PATH}`
     );
     return;
   }
@@ -50,6 +51,12 @@ function push(log: UserActionLogPartial, level: UserActionLog["level"]): void {
 
   // Store the log in disk
   set([userActionLog, ...get()]);
+}
+
+export function isLogTooBig(log: UserActionLog): boolean {
+  const maxLogSize = 3072; // 3072 Bytes = 3KB
+  const logSize = Buffer.byteLength(JSON.stringify(log), "utf8");
+  return logSize > maxLogSize;
 }
 
 export function info(log: UserActionLogPartial): void {

--- a/packages/dappmanager/src/modules/migrations/index.ts
+++ b/packages/dappmanager/src/modules/migrations/index.ts
@@ -4,6 +4,7 @@ import { migrateUserActionLogs } from "./migrateUserActionLogs";
 import { removeLegacyDockerAssets } from "./removeLegacyDockerAssets";
 import { addAliasToRunningContainers } from "./addAliasToRunningContainers";
 import { switchEthClientIfOpenethereumOrGethLight } from "./switchEthClientIfOpenethereumOrGethLight";
+import { pruneUserActionLogs } from "./pruneUserActionLogs";
 
 export class MigrationError extends Error {
   migration: string;
@@ -69,6 +70,16 @@ export async function executeMigrations(): Promise<void> {
       migration:
         "switch client if the current selected is geth-light or openethereum",
       coreVersion: "0.2.58",
+      name: "MIGRATION_ERROR",
+      message: e.message,
+      stack: e.stack
+    })
+  );
+
+  pruneUserActionLogs().catch(e =>
+    migrationErrors.push({
+      migration: "prune user action logs if the size is greater than 4 MB",
+      coreVersion: "0.2.59",
       name: "MIGRATION_ERROR",
       message: e.message,
       stack: e.stack

--- a/packages/dappmanager/src/modules/migrations/pruneUserActionLogs.ts
+++ b/packages/dappmanager/src/modules/migrations/pruneUserActionLogs.ts
@@ -1,0 +1,17 @@
+import fs from "fs";
+import params from "../../params";
+
+/**
+ * Prune the userActionLogs.json file if the current size
+ * is greater than 4 MB
+ */
+export async function pruneUserActionLogs(): Promise<void> {
+  const maxFileSizeBytes = 4194304; // Bytes = 4MB
+  const currentFileSizeBytes = fs.statSync(
+    params.USER_ACTION_LOGS_DB_PATH
+  ).size;
+  if (currentFileSizeBytes > maxFileSizeBytes)
+    fs.truncate("/path/to/file", 0, function () {
+      console.log("done");
+    });
+}

--- a/packages/dappmanager/test/utils/logUserAction.test.ts
+++ b/packages/dappmanager/test/utils/logUserAction.test.ts
@@ -1,0 +1,24 @@
+import * as logUserAction from "../../src/logUserAction";
+import { UserActionLog } from "../../src/types";
+import "mocha";
+import { expect } from "chai";
+
+describe("Util: logUserAction", () => {
+  it("Should return true due to a big log", () => {
+    const bigBuffer = Buffer.alloc(3073, "a");
+    const bigString: UserActionLog = bigBuffer.toString(
+      "utf8"
+    ) as unknown as UserActionLog;
+
+    expect(logUserAction.isLogTooBig(bigString)).to.be.true;
+  });
+
+  it("Should return false due to a small log", () => {
+    const bigBuffer = Buffer.alloc(3069, "a");
+    const bigString: UserActionLog = bigBuffer.toString(
+      "utf8"
+    ) as unknown as UserActionLog;
+
+    expect(logUserAction.isLogTooBig(bigString)).to.be.false;
+  });
+});


### PR DESCRIPTION
- Truncate the file `userActionLogs.json` to 0 if the size is greater than 4MB. Files with size higher are dangerous to parse and may result into unexpected behaviours.
- Do not allow to write new logs to the file if the size of the log exceeds 3KB.