### PR TITLE
Make ENS/DNP name the same for mainnet besu

### DIFF
--- a/packages/admin-ui/src/__mock-backend__/stakerConfig.ts
+++ b/packages/admin-ui/src/__mock-backend__/stakerConfig.ts
@@ -94,7 +94,7 @@ export const stakerConfig: Pick<
                 signedSafe: true,
 
                 metadata: {
-                  name: "besu.dnp.dappnode.eth",
+                  name: "besu.public.dappnode.eth",
                   description: "Besu execution client",
                   shortDescription: "Besu execution client",
                   version: "0.1.0"


### PR DESCRIPTION
ENS for the package is different than the metadata file.
Not sure if it matters at all but thought if its one way in the definition of the package it should stay consistent.

<!-- For DAppNode core members, once the Pull Request is created, do not forget to:
1.  Link issues to the PR if available
2.  Mention dappnode core members
3.  Add proper labels
-->

## Context

> Provide context of this PR: why it was created? what does it fixes? what new feature does it provides? ...

## Approach

> Define the solution for the issue or feature that this PR aims to fix

## Test instructions

<!-- MANDATORY: please, do not skip this step, it is very importand for DAppNode team to have simple and well defined instructions on how to test this PR.
-->
