### PR TITLE
Set `StakerItem.data` type as optional

### DIFF
--- a/packages/admin-ui/src/common/types.ts
+++ b/packages/admin-ui/src/common/types.ts
@@ -1279,8 +1279,6 @@ export type StakerItemData = Pick<
   | "dnpName"
   | "reqVersion"
   | "semVersion"
-  | "imageFile"
-  | "avatarFile"
   | "metadata"
   | "warnings"
   | "origin"

--- a/packages/admin-ui/src/common/types.ts
+++ b/packages/admin-ui/src/common/types.ts
@@ -1279,6 +1279,8 @@ export type StakerItemData = Pick<
   | "dnpName"
   | "reqVersion"
   | "semVersion"
+  | "imageFile"
+  | "avatarFile"
   | "metadata"
   | "warnings"
   | "origin"
@@ -1291,7 +1293,7 @@ export type StakerItemOk<T extends Network, P extends StakerType> = {
   isInstalled: boolean;
   isUpdated: boolean;
   isRunning: boolean;
-  data: StakerItemData;
+  data?: StakerItemData;
   isSelected: boolean;
 } & StakerItemBasic<T, P>;
 

--- a/packages/admin-ui/src/pages/stakers/components/StakerNetwork.tsx
+++ b/packages/admin-ui/src/pages/stakers/components/StakerNetwork.tsx
@@ -34,7 +34,6 @@ import {
 } from "./utils";
 import { responseInterface } from "swr";
 import { Alert } from "react-bootstrap";
-import { omit } from "lodash";
 
 export default function StakerNetwork<T extends Network>({
   network,
@@ -214,12 +213,22 @@ export default function StakerNetwork<T extends Network>({
         setReqStatus({ loading: true });
         await withToast(
           () =>
+            // Omit metadata to be sent back to the backend
             api.stakerConfigSet({
               stakerConfig: {
                 network,
-                executionClient: omit(newExecClient, ["data"]),
-                consensusClient: omit(newConsClient, ["data"]),
-                mevBoost: omit(newMevBoost, ["data"]),
+                executionClient:
+                  newExecClient?.status === "ok"
+                    ? { ...newExecClient, data: undefined }
+                    : newExecClient,
+                consensusClient:
+                  newConsClient?.status === "ok"
+                    ? { ...newConsClient, data: undefined }
+                    : newConsClient,
+                mevBoost:
+                  newMevBoost?.status === "ok"
+                    ? { ...newMevBoost, data: undefined }
+                    : newMevBoost,
                 enableWeb3signer: newEnableWeb3signer
               }
             }),

--- a/packages/admin-ui/src/pages/stakers/components/StakerNetwork.tsx
+++ b/packages/admin-ui/src/pages/stakers/components/StakerNetwork.tsx
@@ -34,6 +34,7 @@ import {
 } from "./utils";
 import { responseInterface } from "swr";
 import { Alert } from "react-bootstrap";
+import { omit } from "lodash";
 
 export default function StakerNetwork<T extends Network>({
   network,
@@ -216,9 +217,9 @@ export default function StakerNetwork<T extends Network>({
             api.stakerConfigSet({
               stakerConfig: {
                 network,
-                executionClient: newExecClient,
-                consensusClient: newConsClient,
-                mevBoost: newMevBoost,
+                executionClient: omit(newExecClient, ["data"]),
+                consensusClient: omit(newConsClient, ["data"]),
+                mevBoost: omit(newMevBoost, ["data"]),
                 enableWeb3signer: newEnableWeb3signer
               }
             }),

--- a/packages/admin-ui/src/pages/stakers/components/columns/ConsensusClient.tsx
+++ b/packages/admin-ui/src/pages/stakers/components/columns/ConsensusClient.tsx
@@ -89,7 +89,9 @@ export default function ConsensusClient<T extends Network>({
 
       {consensusClient.status === "ok" && (
         <div className="description">
-          {isSelected && consensusClient.data.metadata.shortDescription}
+          {isSelected &&
+            consensusClient.data &&
+            consensusClient.data.metadata.shortDescription}
         </div>
       )}
       {isSelected && newConsClient && (

--- a/packages/admin-ui/src/pages/stakers/components/columns/ExecutionClient.tsx
+++ b/packages/admin-ui/src/pages/stakers/components/columns/ExecutionClient.tsx
@@ -62,7 +62,9 @@ export default function ExecutionClient<T extends Network>({
 
       {executionClient.status === "ok" && (
         <div className="description">
-          {isSelected && executionClient.data.metadata.shortDescription}
+          {isSelected &&
+            executionClient.data &&
+            executionClient.data.metadata.shortDescription}
         </div>
       )}
     </Card>

--- a/packages/admin-ui/src/pages/stakers/components/columns/MevBoost.tsx
+++ b/packages/admin-ui/src/pages/stakers/components/columns/MevBoost.tsx
@@ -82,7 +82,9 @@ export default function MevBoost<T extends Network>({
 
       {mevBoost.status === "ok" && (
         <div className="description">
-          {isSelected && mevBoost.data.metadata.shortDescription}
+          {isSelected &&
+            mevBoost.data &&
+            mevBoost.data.metadata.shortDescription}
         </div>
       )}
     </Card>
@@ -144,9 +146,13 @@ function Relay<T extends Network>({
   return (
     <tr>
       <td>
-        {relay.docs ? (<a href={relay.docs} target="_blank" rel="noreferrer">
-          {relay.operator}
-        </a> ): <>{relay.operator}</>}
+        {relay.docs ? (
+          <a href={relay.docs} target="_blank" rel="noreferrer">
+            {relay.operator}
+          </a>
+        ) : (
+          <>{relay.operator}</>
+        )}
       </td>
       <td>
         {relay.ofacCompliant === undefined ? (

--- a/packages/admin-ui/src/pages/stakers/components/columns/RemoteSigner.tsx
+++ b/packages/admin-ui/src/pages/stakers/components/columns/RemoteSigner.tsx
@@ -57,7 +57,7 @@ export default function RemoteSigner<T extends Network>({
       {signer.status === "ok" &&
         isSelected &&
         signer.isInstalled &&
-        signer.data.metadata.links?.ui && (
+        signer.data?.metadata.links?.ui && (
           <div
             style={{
               alignItems: "center",
@@ -77,7 +77,7 @@ export default function RemoteSigner<T extends Network>({
 
       {signer.status === "ok" && (
         <div className="description">
-          {isSelected && signer.data.metadata.shortDescription}
+          {isSelected && signer.data && signer.data.metadata.shortDescription}
         </div>
       )}
     </Card>

--- a/packages/dappmanager/src/modules/stakerConfig/setStakerConfig.ts
+++ b/packages/dappmanager/src/modules/stakerConfig/setStakerConfig.ts
@@ -55,9 +55,6 @@ export async function setStakerConfig<T extends Network>({
     mevBoost
   } = stakerParamsByNetwork<T>(stakerConfig.network);
 
-  if (stakerConfig.network === "mainnet")
-    currentConsClient === "lighthouse-prater.dnp.dappnode.eth";
-
   // Ensure Execution clients DNP's names are valid
   if (
     stakerConfig.executionClient &&

--- a/packages/dappmanager/src/modules/stakerConfig/utils.ts
+++ b/packages/dappmanager/src/modules/stakerConfig/utils.ts
@@ -212,8 +212,6 @@ export function pickStakerItemData(pkgRelease: PackageRelease): StakerItemData {
       "dnpName",
       "reqVersion",
       "semVersion",
-      "imageFile",
-      "avatarFile",
       "warnings",
       "origin",
       "signedSafe"

--- a/packages/dappmanager/src/modules/stakerConfig/utils.ts
+++ b/packages/dappmanager/src/modules/stakerConfig/utils.ts
@@ -212,6 +212,8 @@ export function pickStakerItemData(pkgRelease: PackageRelease): StakerItemData {
       "dnpName",
       "reqVersion",
       "semVersion",
+      "imageFile",
+      "avatarFile",
       "warnings",
       "origin",
       "signedSafe"


### PR DESCRIPTION
The JSON schemas generated between front and back throw validation errors when users using staker UI and the field `size` was not provided.

Set the size property as optional to avoid a strict JSON schema validation

Needs more research on why the property size was not there eventually
