### PR TITLE
Bind mount code in a docker volume

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,8 @@ packages/*/yarn-debug.log*
 packages/*/yarn-error.log*
 # This project uses yarn
 packages/*/package-lock.json 
+
+# Dev links
+packages/dappmanager/dist
+packages/dappmanager/DNCORE
+packages/dappmanager/dnp_repo

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -8,10 +8,6 @@ WORKDIR /app
 
 RUN apk add --no-cache python3 build-base bash
 
-# Install lerna first
-RUN yarn --frozen-lockfile --non-interactive --ignore-scripts --ignore-optional
-RUN yarn
-
 WORKDIR /usr/src/app
 
 RUN apk add --no-cache git
@@ -23,6 +19,8 @@ RUN node getGitData /usr/src/app/.git-data.json
 RUN apk add --no-cache bind-tools docker
 
 ENV DOCKER_COMPOSE_VERSION v2.5.0
+
+ENV REACT_APP_API_URL /
 
 RUN apk add --no-cache curl bind-dev xz libltdl miniupnpc zip unzip dbus bind tmux \
   # See https://github.com/dappnode/DNP_DAPPMANAGER/issues/669

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -8,28 +8,9 @@ WORKDIR /app
 
 RUN apk add --no-cache python3 build-base bash
 
-# Copy and install deps first to cache
-COPY package.json yarn.lock lerna.json ./
-COPY patches patches/
 # Install lerna first
 RUN yarn --frozen-lockfile --non-interactive --ignore-scripts --ignore-optional
-COPY packages/admin-ui/package.json \ 
-  packages/admin-ui/
-COPY packages/dappmanager/package.json \ 
-  packages/dappmanager/
 RUN yarn
-
-# Build UI
-WORKDIR /app/packages/admin-ui/
-COPY packages/admin-ui/ .
-ENV REACT_APP_API_URL /
-RUN yarn build
-# Results in build/*
-
-WORKDIR /app/packages/dappmanager/
-COPY packages/dappmanager/ .
-RUN yarn build
-# Results in build/index.js
 
 WORKDIR /usr/src/app
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -19,6 +19,7 @@ services:
       - "/usr/src/dappnode/DNCORE/:/usr/src/app/DNCORE/"
       - "/var/run/docker.sock:/var/run/docker.sock"
       - "/etc/hostname:/etc/dappnodename:ro"
+      - "./:/app"
     environment:
       - LOG_LEVEL=info
       - ETH_MAINNET_RPC_URL_OVERRIDE=

--- a/docker/start_dev.sh
+++ b/docker/start_dev.sh
@@ -1,15 +1,21 @@
 #!/bin/bash
 
+# link important directories
 ln -s /app/packages/admin-ui/build/ /app/packages/dappmanager/dist
 ln -s /usr/src/app/dnp_repo/ /app/packages/dappmanager
 ln -s /usr/src/app/DNCORE/ /app/packages/dappmanager
 
-tmux new-session -d -s dev 'cd /app/packages/dappmanager;yarn dev'
-tmux split-window;
-tmux send 'cd /app/packages/admin-ui;yarn dev' ENTER;
+# Build admin-ui
+cd /app/packages/admin-ui/ && yarn build
 
-while true
-do
-	echo "Press [CTRL+C] to stop.."
-	sleep 1000
-done
+# Build dappmanager
+cd /app/packages/dappmanager/ && yarn build
+
+
+# execute the scripts in background and wait
+cd /app/packages/dappmanager && yarn dev &
+cd /app/packages/admin-ui && yarn dev &
+echo "========================================="
+echo "Access the ui at http://172.33.1.7:5000/"
+echo "========================================="
+wait

--- a/docker/start_dev.sh
+++ b/docker/start_dev.sh
@@ -5,17 +5,17 @@ ln -s /app/packages/admin-ui/build/ /app/packages/dappmanager/dist
 ln -s /usr/src/app/dnp_repo/ /app/packages/dappmanager
 ln -s /usr/src/app/DNCORE/ /app/packages/dappmanager
 
+# Install lerna first
+yarn --frozen-lockfile --non-interactive --ignore-scripts --ignore-optional
+yarn
+
 # Build admin-ui
 cd /app/packages/admin-ui/ && yarn build
 
 # Build dappmanager
 cd /app/packages/dappmanager/ && yarn build
 
-
 # execute the scripts in background and wait
 cd /app/packages/dappmanager && yarn dev &
 cd /app/packages/admin-ui && yarn dev &
-echo "========================================="
-echo "Access the ui at http://172.33.1.7:5000/"
-echo "========================================="
 wait


### PR DESCRIPTION
To improve the developing experience, bind mount the code in a docker volume so getting into the dev container is no longer needed.