### PR TITLE
fix ethers error on production

### DIFF
--- a/packages/dappmanager/webpack.config.js
+++ b/packages/dappmanager/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require("path");
+const webpack = require('webpack'); //to access built-in plugins
 const { NODE_ENV = "production" } = process.env;
 module.exports = {
   entry: "./src/index.ts",
@@ -27,6 +28,12 @@ module.exports = {
       }
     ]
   },
+  plugins: [
+    new webpack.ProvidePlugin({
+      WebSocket: 'ws',
+      fetch: ['node-fetch', 'default'],
+    }),
+  ],
   optimization: {
     // Minimization does not provide great disk space savings, but reduces debug capacity
     minimize: false


### PR DESCRIPTION
fix 
```
Error: could not detect network (event="noNetwork", code=NETWORK_ERROR, version=providers/x.y.z)
```
