### PR TITLE
Fix https race condition

### DIFF
--- a/packages/dappmanager/src/modules/https-portal/index.ts
+++ b/packages/dappmanager/src/modules/https-portal/index.ts
@@ -34,12 +34,6 @@ export class HttpsPortal {
     const externalNetworkAlias = getExternalNetworkAlias(container);
     const aliases = [externalNetworkAlias];
 
-    // Call Http Portal API to add the mapping
-    await this.httpsPortalApiClient.add({
-      fromSubdomain: mapping.fromSubdomain,
-      toHost: `${externalNetworkAlias}:${mapping.port}`
-    });
-
     // Ensure network exists
     const networks = await dockerListNetworks();
     if (!networks.find(network => network.Name === externalNetworkName)) {
@@ -65,6 +59,12 @@ export class HttpsPortal {
         Aliases: aliases
       });
     }
+
+        // Call Http Portal API to add the mapping
+    await this.httpsPortalApiClient.add({
+      fromSubdomain: mapping.fromSubdomain,
+      toHost: `${externalNetworkAlias}:${mapping.port}`
+    });
 
     // Edit compose to persist the setting
     addNetworkAliasCompose(container, externalNetworkName, aliases);


### PR DESCRIPTION
When creating new HTTPS mapping, container should first be connected to the external network and then HTTPS api should be called.