### PR TITLE
When switch to a new client make sure its running

### DIFF
--- a/packages/admin-ui/src/common/routes.ts
+++ b/packages/admin-ui/src/common/routes.ts
@@ -224,6 +224,7 @@ export interface Routes {
    */
   ethClientTargetSet: (kwargs: {
     target: Eth2ClientTarget;
+    sync?: boolean;
     useCheckpointSync?: boolean;
     deletePrevExecClient?: boolean;
     deletePrevExecClientVolumes?: boolean;

--- a/packages/admin-ui/src/pages/system/actions.ts
+++ b/packages/admin-ui/src/pages/system/actions.ts
@@ -115,6 +115,7 @@ export const changeEthClientTarget = (
     () =>
       api.ethClientTargetSet({
         target: nextTarget,
+        sync: false,
         useCheckpointSync,
         deletePrevExecClient,
         deletePrevExecClientVolumes,

--- a/packages/dappmanager/src/calls/ethClientTargetSet.ts
+++ b/packages/dappmanager/src/calls/ethClientTargetSet.ts
@@ -6,6 +6,7 @@ import { ethereumClient } from "../modules/ethClient";
  */
 export async function ethClientTargetSet({
   target,
+  sync = false,
   useCheckpointSync = false,
   deletePrevExecClient = false,
   deletePrevExecClientVolumes = false,
@@ -13,6 +14,7 @@ export async function ethClientTargetSet({
   deletePrevConsClientVolumes = false
 }: {
   target: Eth2ClientTarget;
+  sync?: boolean;
   useCheckpointSync?: boolean;
   deletePrevExecClient?: boolean;
   deletePrevExecClientVolumes?: boolean;
@@ -23,7 +25,7 @@ export async function ethClientTargetSet({
 
   await ethereumClient.changeEthClient(
     target,
-    false,
+    sync,
     useCheckpointSync,
     deletePrevExecClient,
     deletePrevExecClientVolumes,


### PR DESCRIPTION
When switching client through **system > repository > ethereum**, make sure the new client target is running