### PR TITLE
fix fee recipient for teku

### DIFF
--- a/packages/dappmanager/src/modules/stakerConfig/getStakerConfig.ts
+++ b/packages/dappmanager/src/modules/stakerConfig/getStakerConfig.ts
@@ -102,6 +102,7 @@ export async function getStakerConfig<T extends Network>(
                 graffiti = pkgEnv[validatorService]["GRAFFITI"];
                 feeRecipient =
                   pkgEnv[validatorService]["FEE_RECIPIENT_ADDRESS"];
+                  pkgEnv[beaconService]["FEE_RECIPIENT_ADDRESS"];
                 checkpointSync = pkgEnv[beaconService]["CHECKPOINT_SYNC_URL"];
               }
             }

--- a/packages/dappmanager/src/modules/stakerConfig/utils.ts
+++ b/packages/dappmanager/src/modules/stakerConfig/utils.ts
@@ -93,7 +93,8 @@ export function getConsensusUserSettings({
 
               [beaconServiceName]: {
                 // Fee recipient is a mandatory vlaue (for Teku)
-                ["GRAFFITI"]: graffiti || "Validating_from_DAppNode",
+                ["FEE_RECIPIENT_ADDRESS"]:
+                    feeRecipient || "0x0000000000000000000000000000000000000000",
                 // Checkpoint sync is an optional value
                 ["CHECKPOINT_SYNC_URL"]: checkpointSync || ""
               }

--- a/packages/dappmanager/src/modules/stakerConfig/utils.ts
+++ b/packages/dappmanager/src/modules/stakerConfig/utils.ts
@@ -92,6 +92,8 @@ export function getConsensusUserSettings({
               },
 
               [beaconServiceName]: {
+                // Fee recipient is a mandatory vlaue (for Teku)
+                ["GRAFFITI"]: graffiti || "Validating_from_DAppNode",
                 // Checkpoint sync is an optional value
                 ["CHECKPOINT_SYNC_URL"]: checkpointSync || ""
               }

--- a/packages/dappmanager/src/modules/stakerConfig/utils.ts
+++ b/packages/dappmanager/src/modules/stakerConfig/utils.ts
@@ -94,7 +94,7 @@ export function getConsensusUserSettings({
               [beaconServiceName]: {
                 // Fee recipient is a mandatory vlaue (for Teku)
                 ["FEE_RECIPIENT_ADDRESS"]:
-                    feeRecipient || "0x0000000000000000000000000000000000000000",
+                  feeRecipient || "0x0000000000000000000000000000000000000000",
                 // Checkpoint sync is an optional value
                 ["CHECKPOINT_SYNC_URL"]: checkpointSync || ""
               }


### PR DESCRIPTION
<!-- For DAppNode core members, once the Pull Request is created, do not forget to:
1.  Link issues to the PR if available
2.  Mention dappnode core members
3.  Add proper labels
-->

## Context

Tracked in https://github.com/dappnode/DAppNodePackage-teku/issues/34 4 other related PRs are tracked there for each implementation of Teku
fixed handling of fee recipient address ENV variable for Teku, the flag enabling it must be used in both the beacon-chain and validator service.

Fixes #1258 

## Approach

Add functionality in the dappmanager's stakersUI to set the Fee recipient address properly in Teku's beacon-chain service to avoid warnings about certain rare/edge case failures surrounding the fee recipient address the `--validators-proposer-default-fee-recipient-address=<ADDRESS>` flag to both services of Teku, not just the validator service, but also the beacon chain.  


## Test instructions

<!-- MANDATORY: please, do not skip this step, it is very important for DAppNode team to have simple and well defined instructions on how to test this PR.
-->
1. Install core v0.2.61 (or later if Gnosis chain) with this PRs changes.
2. install and sync Teku checked out from the following PRs (Any network: 
    

- [ ] -  Mainnet ETH, https://github.com/dappnode/DAppNodePackage-teku/pull/38

- [ ]  -  Göerli/Prater, https://github.com/dappnode/DAppNodePackage-teku-prater/pull/100

- [ ] - or Gnosis Chain https://github.com/dappnode/DAppNodePackage-teku-gnosis/pull/43

- [x]  -  [Teku Chiado has already been resolved since it doesn't have a StakersUI and the on package fix was simple.])

3. install and sync a compatible EC for the chain you chose to install and sync Teku on.
4. Use the stakersUI to change the fee recipient address, see if it causes restart loops or if it applies variables properly to both services resulting in no warns regarding the fee recipient address on the Beacon-Chain Service.
5. Use the stakersUI to change consensus clients, both to and from Teku, it should, if working properly persists the validators default fee recipient across the different clients.
6. After publishing the updated teku package(s) test installing teku from the stakersUI to test whether the fee recipient address is set properly in both Teku's services resulting in no warnings from the beacon chain service.