### PR TITLE
Deprecate `ethClientTarget` in new features to be shown on startup

### DIFF
--- a/packages/dappmanager/src/calls/systemInfoGet.ts
+++ b/packages/dappmanager/src/calls/systemInfoGet.ts
@@ -55,7 +55,10 @@ export async function systemInfoGet(): Promise<SystemInfo> {
 function getNewFeatureIds(): NewFeatureId[] {
   const newFeatureIds: NewFeatureId[] = [];
 
-  if (db.ethClientTarget.get()) {
+  if (
+    db.executionClientMainnet.get() !== null &&
+    db.consensusClientMainnet.get() !== null
+  ) {
     // If the user does not has the fallback on and has not seen the full
     // repository view, show a specific one just asking for the fallback
     if (


### PR DESCRIPTION
Deprecate `ethClientTarget` in new features to be shown on startup. From now on it will depend on execution and consensus client values to be not `null`
