### PR TITLE
Switch Ethereum repository with `useCheckpointSync`

### DIFF
--- a/packages/admin-ui/src/pages/system/components/Repository/Eth.tsx
+++ b/packages/admin-ui/src/pages/system/components/Repository/Eth.tsx
@@ -48,7 +48,7 @@ export default function Eth() {
   }, [target, ethClientTarget]);
 
   function changeClient() {
-    if (target) dispatch(changeEthClientTarget(target));
+    if (target) dispatch(changeEthClientTarget(target, useCheckpointSync));
   }
 
   async function changeFallback(newFallback: EthClientFallback) {


### PR DESCRIPTION
When switching repository to a new full node, make sure to use the checkpointSync arg
