### PR TITLE
Catch error renaming container with the same name

### DIFF
--- a/packages/dappmanager/src/calls/packageSetEnvironment.ts
+++ b/packages/dappmanager/src/calls/packageSetEnvironment.ts
@@ -1,9 +1,16 @@
 import { eventBus } from "../eventBus";
 import { listPackage } from "../modules/docker/list";
 import { ComposeFileEditor } from "../modules/compose/editor";
-import { getContainersStatus, dockerComposeUpPackage } from "../modules/docker";
+import {
+  getContainersStatus,
+  dockerComposeUpPackage,
+  dockerComposeDown
+} from "../modules/docker";
 import { packageInstalledHasPid } from "../utils/pid";
 import { PackageEnvs } from "@dappnode/dappnodesdk";
+import { logs } from "../logs";
+import * as getPath from "../utils/getPath";
+import fs from "fs";
 
 /**
  * Updates the .env file of a package. If requested, also re-ups it
@@ -37,6 +44,30 @@ export async function packageSetEnvironment({
   // - Packages sharing PID must be recreated to ensure startup order
   await dockerComposeUpPackage({ dnpName }, containersStatus, {
     forceRecreate: packageInstalledHasPid(compose.compose)
+  }).catch(async e => {
+    if (
+      e.message.includes(
+        "Renaming a container with the same name as its current name"
+      )
+    ) {
+      // Catch error: Error response from daemon: Renaming a container with the same name as its current name
+      // Ref: https://github.com/docker/compose/issues/6704
+      logs.info("Catch error renaming container with the same name");
+
+      // Retry with forceRecreate
+      await dockerComposeUpPackage({ dnpName }, containersStatus, {
+        forceRecreate: true
+      }).catch(async () => {
+        // Do compose down and compose up
+        const composePath = getPath.dockerCompose(dnp.dnpName, false);
+        if (fs.existsSync(composePath)) {
+          await dockerComposeDown(composePath);
+          await dockerComposeUpPackage({ dnpName }, containersStatus);
+        }
+      });
+    } else {
+      throw e;
+    }
   });
 
   // Emit packages update

--- a/packages/dappmanager/src/calls/packageSetEnvironment.ts
+++ b/packages/dappmanager/src/calls/packageSetEnvironment.ts
@@ -1,16 +1,9 @@
 import { eventBus } from "../eventBus";
 import { listPackage } from "../modules/docker/list";
 import { ComposeFileEditor } from "../modules/compose/editor";
-import {
-  getContainersStatus,
-  dockerComposeUpPackage,
-  dockerComposeDown
-} from "../modules/docker";
+import { getContainersStatus, dockerComposeUpPackage } from "../modules/docker";
 import { packageInstalledHasPid } from "../utils/pid";
 import { PackageEnvs } from "@dappnode/dappnodesdk";
-import { logs } from "../logs";
-import * as getPath from "../utils/getPath";
-import fs from "fs";
 
 /**
  * Updates the .env file of a package. If requested, also re-ups it
@@ -44,30 +37,6 @@ export async function packageSetEnvironment({
   // - Packages sharing PID must be recreated to ensure startup order
   await dockerComposeUpPackage({ dnpName }, containersStatus, {
     forceRecreate: packageInstalledHasPid(compose.compose)
-  }).catch(async e => {
-    if (
-      e.message.includes(
-        "Renaming a container with the same name as its current name"
-      )
-    ) {
-      // Catch error: Error response from daemon: Renaming a container with the same name as its current name
-      // Ref: https://github.com/docker/compose/issues/6704
-      logs.info("Catch error renaming container with the same name");
-
-      // Retry with forceRecreate
-      await dockerComposeUpPackage({ dnpName }, containersStatus, {
-        forceRecreate: true
-      }).catch(async () => {
-        // Do compose down and compose up
-        const composePath = getPath.dockerCompose(dnp.dnpName, false);
-        if (fs.existsSync(composePath)) {
-          await dockerComposeDown(composePath);
-          await dockerComposeUpPackage({ dnpName }, containersStatus);
-        }
-      });
-    } else {
-      throw e;
-    }
   });
 
   // Emit packages update


### PR DESCRIPTION
Catch error when renaming a container with the same name. If that happens then:
1. Try recreating the containers
2. Try `compose down` and `compose up`