### PR TITLE
Display progress percent with 2 fraction digits

### DIFF
--- a/packages/admin-ui/src/components/navbar/dropdownMenus/BaseDropdown.tsx
+++ b/packages/admin-ui/src/components/navbar/dropdownMenus/BaseDropdown.tsx
@@ -10,12 +10,11 @@ type BubbleColor = "danger" | "warning" | "success" | "light";
 // Utilities
 
 const ProgressBarWrapper = ({ progress }: { progress: number }) => {
-  const progressPercent = Math.floor(100 * progress);
   return (
     <ProgressBar
-      now={progressPercent}
+      now={progress * 100}
       animated={true}
-      label={`${progressPercent}%`}
+      label={`${(progress * 100).toFixed(2)}%`}
     />
   );
 };

--- a/packages/admin-ui/src/pages/dashboard/components/ChainCard.tsx
+++ b/packages/admin-ui/src/pages/dashboard/components/ChainCard.tsx
@@ -35,7 +35,7 @@ function ChainCard(chain: ChainData) {
           <ProgressBar
             now={progress * 100}
             animated={true}
-            label={`${Math.floor(progress * 100)}%`}
+            label={`${(progress * 100).toFixed(2)}%`}
           />
         )
       ) : error ? (


### PR DESCRIPTION
<!-- For DAppNode core members, once the Pull Request is created, do not forget to:
1.  Link issues to the PR if available
2.  Mention dappnode core members
3.  Add proper labels
-->

## Context

Currently chain synchronization progress is shown floored to the closest integer, as such during a refresh UI may jump from 99% to 100%. This is fine in cases where the time it takes to make 1% progress is linear. Though in reality chain synchronization progress may seriously slow down in the last few percent, as such the experience is often to see the UI stuck at 99% for a very long time.

The purpose of this PR is to allow showing 2 fractional digits on the progress bar as to provide more granular progress in order to provide more accurate feedback in the last few percent of chain synchronization.

## Approach

Use the `toFixed(2)` JavaScript number method to remove other fractional digits.

## Test instructions

Chain synchronization progress in both the chain card in the main dashboard and in the chain dropdown should show percentage as `xx.xx%` instead of `xx%`. You can stop a chain for a minute and restart in order to cause synchronization progress to show for that chain.