### PR TITLE
Ensure is synced with remote execution

### DIFF
--- a/packages/dappmanager/src/modules/ethClient/clientStatus.ts
+++ b/packages/dappmanager/src/modules/ethClient/clientStatus.ts
@@ -96,7 +96,9 @@ export async function getMultiClientStatus(
               );
             })) &&
             (await isSyncedWithRemoteExecution(execUrl).catch(e => {
-              throw Error(
+              // Do not throw if checking remote execution fails
+              // Otherwise the fallback will be triggered and the remote node may not be available
+              logs.error(
                 `Error while checking if synced with remote execution: ${e.message}`
               );
             }))

--- a/packages/dappmanager/src/modules/ethClient/ethersProvider.ts
+++ b/packages/dappmanager/src/modules/ethClient/ethersProvider.ts
@@ -38,6 +38,10 @@ export async function getEthProviderUrl(): Promise<string> {
   // Remote is selected, just return remote
   if (target === "remote") return params.ETH_MAINNET_RPC_URL_REMOTE;
 
+  // Full node is selected, ensure client is not empty
+  if (!target.execClient) throw Error("No execution client selected yet");
+  if (!target.consClient) throw Error("No consensus client selected yet");
+
   const status = await getMultiClientStatus(
     target.execClient,
     target.consClient

--- a/packages/dappmanager/src/utils/ethers.ts
+++ b/packages/dappmanager/src/utils/ethers.ts
@@ -54,3 +54,11 @@ export function parseEthersSyncing(syncing: EthSyncingReturn): EthSyncing {
     highestBlock: parsedSyncing.highestBlock || 0
   };
 }
+/**
+ * Parse an eth_blocknumber call to an ethers provider
+ * Makes sure all keys are defined (cleans null values) and parses hex strings
+ * @param syncing
+ */
+export async function parseEthersBlock(ethBlock: string): Promise<number> {
+  return parseInt(ethBlock);
+}


### PR DESCRIPTION
In Ethereum repository, when using full node and fallback is activated, compare the latest block of dappnode remote node and local full node to determine if it is synced or not