### PR TITLE
Use port 4500 for nimbus

### DIFF
--- a/packages/dappmanager/src/modules/ethClient/apiUrl.ts
+++ b/packages/dappmanager/src/modules/ethClient/apiUrl.ts
@@ -27,6 +27,12 @@ export function getEthExecClientApiUrl(dnpName: string, port = 8545): string {
  * @param dnpName
  */
 export function getEthConsClientApiUrl(dnpName: string, port = 3500): string {
+  //  TODO: find a proper way to get the port dynamically
+  // Lighthouse, Teku and Prysm use 3500
+  // Nimbus uses 4500 because it is a monoservice and the validator API is using that port
+  if (dnpName.includes("nimbus")) {
+    port = 4500;
+  }
   /**
    * Binded to the domain mapper module 'nsupdate'
    * ```


### PR DESCRIPTION
The Nimbus package is a monoservice and is using the following ports:
- 3500: validator API
- 4500: beacon APi

See [ref](https://github.com/dappnode/DAppNodePackage-nimbus)

Todo: find a better way to get dynamically the beacon API