### PR TITLE
Disallow setStakerConfig migration

### DIFF
--- a/packages/dappmanager/src/modules/migrations/index.ts
+++ b/packages/dappmanager/src/modules/migrations/index.ts
@@ -1,4 +1,3 @@
-import { setDefaultStakerConfig } from "./setDefaultStakerConfig";
 import AggregateError = require("aggregate-error");
 import { migrateUserActionLogs } from "./migrateUserActionLogs";
 import { removeLegacyDockerAssets } from "./removeLegacyDockerAssets";
@@ -55,7 +54,10 @@ export async function executeMigrations(): Promise<void> {
     })
   );
 
-  setDefaultStakerConfig().catch(e =>
+  /**
+   * WARNING! This migration is dangerous if user has not set a staker config, the docker daemon can crash and is safer to not do it automatically
+   *  
+   setDefaultStakerConfig().catch(e =>
     migrationErrors.push({
       migration: "set default staker configuration",
       coreVersion: "v0.2.58",
@@ -64,6 +66,7 @@ export async function executeMigrations(): Promise<void> {
       stack: e.stack
     })
   );
+   */
 
   switchEthClientIfOpenethereumOrGethLight().catch(e =>
     migrationErrors.push({


### PR DESCRIPTION
Disallow the `setDefaultStakerConfig` migration. This uses `packageSetEnvironment` to update the staker config envs var which in the ends rewrites compose files and restart containers.
