### PR TITLE
Upgrade node to 19.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG NODE_VERSION=18.12.1
+ARG NODE_VERSION=19.2.0
 
 # Common base so it's cached
 # --platform=$BUILDPLATFORM is used build javascript source with host arch

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-ARG NODE_VERSION=18.12.1
+ARG NODE_VERSION=19.2.0
 
 # Common base so it's cached
 # --platform=$BUILDPLATFORM is used build javascript source with host arch


### PR DESCRIPTION
Upgrade node to 19.2.0 so the crypto module does not miss a strong random source.  18 is not working.

This is critical for creating from scratch the dynds identity
