### PR TITLE
Implement default fee recipient

### DIFF
--- a/packages/dappmanager/src/db/stakerConfig.ts
+++ b/packages/dappmanager/src/db/stakerConfig.ts
@@ -26,6 +26,7 @@ export const stakerItemMetadata = dbCache.indexedByKey<StakerItemData, string>({
 const CONSENSUS_CLIENT_MAINNET = "consensus-client-mainnet";
 const EXECUTION_CLIENT_MAINNET = "execution-client-mainnet";
 const MEVBOOST_MAINNET = "mevboost-mainnet";
+const FEE_RECIPIENT_MAINNET = "fee-recipient-mainnet";
 
 /**
  * Whenever a user switches the EC and/or CC from the stakers UI then
@@ -53,11 +54,17 @@ export const mevBoostMainnet = interceptGlobalEnvOnSet(
   Object.keys({ MEVBOOST_MAINNET })[0]
 );
 
+export const feeRecipientMainnet = interceptGlobalEnvOnSet(
+  dbMain.staticKey<string | null>(FEE_RECIPIENT_MAINNET, null),
+  Object.keys({ FEE_RECIPIENT_MAINNET })[0]
+);
+
 // Gnosis
 
 const CONSENSUS_CLIENT_GNOSIS = "consensus-client-gnosis";
 const EXECUTION_CLIENT_GNOSIS = "execution-client-gnosis";
 const MEVBOOST_GNOSIS = "mevboost-gnosis";
+const FEE_RECIPIENT_GNOSIS = "fee-recipient-gnosis";
 
 export const consensusClientGnosis = interceptGlobalEnvOnSet(
   dbMain.staticKey<ConsensusClientGnosis | null>(CONSENSUS_CLIENT_GNOSIS, null),
@@ -74,11 +81,17 @@ export const mevBoostGnosis = interceptGlobalEnvOnSet(
   Object.keys({ MEVBOOST_GNOSIS })[0]
 );
 
+export const feeRecipientGnosis = interceptGlobalEnvOnSet(
+  dbMain.staticKey<string | null>(FEE_RECIPIENT_GNOSIS, null),
+  Object.keys({ FEE_RECIPIENT_GNOSIS })[0]
+);
+
 // Prater
 
 const CONSENSUS_CLIENT_PRATER = "consensus-client-prater";
 const EXECUTION_CLIENT_PRATER = "execution-client-prater";
 const MEVBOOST_PRATER = "mevboost-prater";
+const FEE_RECIPIENT_PRATER = "fee-recipient-prater";
 
 export const consensusClientPrater = interceptGlobalEnvOnSet(
   dbMain.staticKey<ConsensusClientPrater | null>(CONSENSUS_CLIENT_PRATER, null),
@@ -93,4 +106,9 @@ export const executionClientPrater = interceptGlobalEnvOnSet(
 export const mevBoostPrater = interceptGlobalEnvOnSet(
   dbMain.staticKey<boolean>(MEVBOOST_PRATER, false),
   Object.keys({ MEVBOOST_PRATER })[0]
+);
+
+export const feeRecipientPrater = interceptGlobalEnvOnSet(
+  dbMain.staticKey<string | null>(FEE_RECIPIENT_PRATER, null),
+  Object.keys({ FEE_RECIPIENT_PRATER })[0]
 );

--- a/packages/dappmanager/src/modules/globalEnvs.ts
+++ b/packages/dappmanager/src/modules/globalEnvs.ts
@@ -45,12 +45,15 @@ export function computeGlobalEnvsFromDb<B extends boolean>(
     [`${prefix}CONSENSUS_CLIENT_MAINNET`]: db.consensusClientMainnet.get(),
     [`${prefix}EXECUTION_CLIENT_MAINNET`]: db.executionClientMainnet.get(),
     [`${prefix}MEVBOOST_MAINNET`]: db.mevBoostMainnet.get(),
+    [`${prefix}FEE_RECIPIENT_MAINNET`]: db.feeRecipientMainnet.get(),
     [`${prefix}CONSENSUS_CLIENT_GNOSIS`]: db.consensusClientGnosis.get(),
     [`${prefix}EXECUTION_CLIENT_GNOSIS`]: db.executionClientGnosis.get(),
     [`${prefix}MEVBOOST_GNOSIS`]: db.mevBoostGnosis.get(),
+    [`${prefix}FEE_RECIPIENT_GNOSIS`]: db.feeRecipientGnosis.get(),
     [`${prefix}CONSENSUS_CLIENT_PRATER`]: db.consensusClientPrater.get(),
     [`${prefix}EXECUTION_CLIENT_PRATER`]: db.executionClientPrater.get(),
-    [`${prefix}MEVBOOST_PRATER`]: db.mevBoostPrater.get()
+    [`${prefix}MEVBOOST_PRATER`]: db.mevBoostPrater.get(),
+    [`${prefix}FEE_RECIPIENT_PRATER`]: db.feeRecipientPrater.get()
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } as any;
 }

--- a/packages/dappmanager/src/modules/migrations/index.ts
+++ b/packages/dappmanager/src/modules/migrations/index.ts
@@ -1,9 +1,9 @@
-import { setDefaultStakerConfig } from "./setDefaultStakerConfig.js";
 import { migrateUserActionLogs } from "./migrateUserActionLogs.js";
 import { removeLegacyDockerAssets } from "./removeLegacyDockerAssets.js";
 import { addAliasToRunningContainers } from "./addAliasToRunningContainers.js";
 import { switchEthClientIfOpenethereumOrGethLight } from "./switchEthClientIfOpenethereumOrGethLight.js";
 import { pruneUserActionLogs } from "./pruneUserActionLogs.js";
+import { setDefaultFeeRecipient } from "./setDefaultFeeRecipient.js";
 
 export class MigrationError extends Error {
   migration: string;
@@ -83,6 +83,16 @@ export async function executeMigrations(): Promise<void> {
     migrationErrors.push({
       migration: "prune user action logs if the size is greater than 4 MB",
       coreVersion: "0.2.59",
+      name: "MIGRATION_ERROR",
+      message: e.message,
+      stack: e.stack
+    })
+  );
+
+  setDefaultFeeRecipient().catch(e =>
+    migrationErrors.push({
+      migration: "set default fee recipient",
+      coreVersion: "0.2.67",
       name: "MIGRATION_ERROR",
       message: e.message,
       stack: e.stack

--- a/packages/dappmanager/src/modules/migrations/setDefaultFeeRecipient.ts
+++ b/packages/dappmanager/src/modules/migrations/setDefaultFeeRecipient.ts
@@ -18,6 +18,7 @@ export async function setDefaultFeeRecipient(): Promise<void> {
   for (const network of networks) {
     const envVarName = `FEE_RECIPIENT_ADDRESS`;
     let consensusClientDnpName: ConsensusClient<Network> | null;
+    let envVarValue = "";
 
     switch (network) {
       case "prater":
@@ -32,18 +33,21 @@ export async function setDefaultFeeRecipient(): Promise<void> {
       default:
         throw Error(`Unknown network ${network}`);
     }
-    if (!consensusClientDnpName) continue;
 
-    if (!(await listPackageNoThrow({ dnpName: consensusClientDnpName })))
-      continue;
-    const envVarValue = (await packageGet({ dnpName: consensusClientDnpName }))
-      .userSettings?.environment?.[
-      getValidatorServiceName(consensusClientDnpName)
-    ][envVarName];
+    if (
+      consensusClientDnpName &&
+      (await listPackageNoThrow({ dnpName: consensusClientDnpName }))
+    ) {
+      envVarValue =
+        (await packageGet({ dnpName: consensusClientDnpName })).userSettings
+          ?.environment?.[getValidatorServiceName(consensusClientDnpName)][
+          envVarName
+        ] || "";
+    }
 
     // Set default fee recipient, if no default value, set empty string to avoid triggereing this migration again
-    if (network === "prater") db.feeRecipientPrater.set(envVarValue || "");
-    if (network === "gnosis") db.feeRecipientGnosis.set(envVarValue || "");
-    if (network === "mainnet") db.feeRecipientMainnet.set(envVarValue || "");
+    if (network === "prater") db.feeRecipientPrater.set(envVarValue);
+    if (network === "gnosis") db.feeRecipientGnosis.set(envVarValue);
+    if (network === "mainnet") db.feeRecipientMainnet.set(envVarValue);
   }
 }

--- a/packages/dappmanager/src/modules/migrations/setDefaultFeeRecipient.ts
+++ b/packages/dappmanager/src/modules/migrations/setDefaultFeeRecipient.ts
@@ -1,0 +1,50 @@
+import { ConsensusClient, Network } from "@dappnode/common";
+import * as db from "../../db/index.js";
+import { packageGet } from "../../calls";
+import { listPackageNoThrow } from "../docker/list/listPackages.js";
+import { getValidatorServiceName } from "../stakerConfig/utils.js";
+
+/**
+ * Sets the default global environment variable FEE_RECIPIENT_<NETWORK>
+ * This global env var is used by the DAppNode packages to set the default fee recipient
+ */
+export async function setDefaultFeeRecipient(): Promise<void> {
+  const networks: Network[] = [];
+
+  if (db.feeRecipientPrater.get() === null) networks.push("prater");
+  if (db.feeRecipientGnosis.get() === null) networks.push("gnosis");
+  if (db.feeRecipientMainnet.get() === null) networks.push("mainnet");
+
+  for (const network of networks) {
+    const envVarName = `FEE_RECIPIENT_ADDRESS`;
+    let consensusClientDnpName: ConsensusClient<Network> | null;
+
+    switch (network) {
+      case "prater":
+        consensusClientDnpName = db.consensusClientPrater.get();
+        break;
+      case "gnosis":
+        consensusClientDnpName = db.consensusClientGnosis.get();
+        break;
+      case "mainnet":
+        consensusClientDnpName = db.consensusClientMainnet.get();
+        break;
+      default:
+        throw Error(`Unknown network ${network}`);
+    }
+    if (!consensusClientDnpName) continue;
+
+    if (!(await listPackageNoThrow({ dnpName: consensusClientDnpName })))
+      continue;
+    const envVarValue = (await packageGet({ dnpName: consensusClientDnpName }))
+      .userSettings?.environment?.[
+      getValidatorServiceName(consensusClientDnpName)
+    ][envVarName];
+
+    if (!envVarValue) continue;
+
+    if (network === "prater") db.feeRecipientPrater.set(envVarValue);
+    if (network === "gnosis") db.feeRecipientGnosis.set(envVarValue);
+    if (network === "mainnet") db.feeRecipientMainnet.set(envVarValue);
+  }
+}

--- a/packages/dappmanager/src/modules/migrations/setDefaultFeeRecipient.ts
+++ b/packages/dappmanager/src/modules/migrations/setDefaultFeeRecipient.ts
@@ -41,10 +41,9 @@ export async function setDefaultFeeRecipient(): Promise<void> {
       getValidatorServiceName(consensusClientDnpName)
     ][envVarName];
 
-    if (!envVarValue) continue;
-
-    if (network === "prater") db.feeRecipientPrater.set(envVarValue);
-    if (network === "gnosis") db.feeRecipientGnosis.set(envVarValue);
-    if (network === "mainnet") db.feeRecipientMainnet.set(envVarValue);
+    // Set default fee recipient, if no default value, set empty string to avoid triggereing this migration again
+    if (network === "prater") db.feeRecipientPrater.set(envVarValue || "");
+    if (network === "gnosis") db.feeRecipientGnosis.set(envVarValue || "");
+    if (network === "mainnet") db.feeRecipientMainnet.set(envVarValue || "");
   }
 }


### PR DESCRIPTION
Set `FEE_RECIPIENT_<NETWORK>` global env var. The compose env `FEE_RECIPIENT_ADDRESS` value will be retrieved from the Consensus Client selected, if not possible to retrieve the value the global env `FEE_RECIPIENT_<NETWORK>` will be set to an empty string, in order to avoid triggering the migration again.