### PR TITLE
Set fee recipient as global env

### DIFF
--- a/packages/admin-ui/src/__mock-backend__/stakerConfig.ts
+++ b/packages/admin-ui/src/__mock-backend__/stakerConfig.ts
@@ -337,7 +337,8 @@ export const stakerConfig: Pick<
                 version: "0.1.},0"
               }
             }
-          }
+          },
+          feeRecipient: "0x71C7656EC7ab88b098defB751B7401B5f6d8976F"
         };
 
       case "prater":
@@ -638,7 +639,8 @@ export const stakerConfig: Pick<
                 version: "0.1.},0"
               }
             }
-          }
+          },
+          feeRecipient: "0x71C7656EC7ab88b098defB751B7401B5f6d8976F"
         };
       case "gnosis":
         return {
@@ -853,7 +855,8 @@ export const stakerConfig: Pick<
                 version: "0.1.},0"
               }
             }
-          }
+          },
+          feeRecipient: "0x71C7656EC7ab88b098defB751B7401B5f6d8976F"
         };
       default:
         throw Error(`Unknown network ${network}`);

--- a/packages/admin-ui/src/pages/stakers/components/AdvanceView.tsx
+++ b/packages/admin-ui/src/pages/stakers/components/AdvanceView.tsx
@@ -47,13 +47,6 @@ export default function AdvanceView<T extends Network>({
       new: newConsClient?.graffiti ? newConsClient?.graffiti : "-"
     },
     {
-      name: "Fee Recipient",
-      current: consensusClient?.feeRecipient
-        ? consensusClient?.feeRecipient
-        : "-",
-      new: newConsClient?.feeRecipient ? newConsClient?.feeRecipient : "-"
-    },
-    {
       name: "Checkpoint Sync",
       current: consensusClient?.checkpointSync
         ? consensusClient?.checkpointSync

--- a/packages/admin-ui/src/pages/stakers/components/StakerNetwork.tsx
+++ b/packages/admin-ui/src/pages/stakers/components/StakerNetwork.tsx
@@ -39,6 +39,7 @@ import "./columns.scss";
 import { ThemeContext } from "App";
 import LaunchpadValidators from "./launchpad/LaunchpadValidators";
 import { FaEthereum } from "react-icons/fa";
+import { InputForm } from "components/InputForm";
 
 export default function StakerNetwork<T extends Network>({
   network,
@@ -133,7 +134,8 @@ export default function StakerNetwork<T extends Network>({
           mevBoost?.status === "ok" && isOkSelectedInstalledAndRunning(mevBoost)
             ? mevBoost
             : undefined,
-        enableWeb3signer
+        enableWeb3signer,
+        feeRecipient
       });
 
       // Set default consensus client: fee recipient, checkpointsync and graffiti
@@ -184,7 +186,8 @@ export default function StakerNetwork<T extends Network>({
           newConsClient,
           newMevBoost,
           newEnableWeb3signer,
-          newExecClient
+          newExecClient,
+          newFeeRecipient
         })
       );
   }, [
@@ -194,7 +197,8 @@ export default function StakerNetwork<T extends Network>({
     newConsClient,
     newMevBoost,
     newEnableWeb3signer,
-    newExecClient
+    newExecClient,
+    newFeeRecipient
   ]);
 
   /**
@@ -299,6 +303,23 @@ export default function StakerNetwork<T extends Network>({
             )}
           </p>
           <br />
+
+          <p>{description}</p>
+          <InputForm
+            fields={[
+              {
+                label: `Default Fee Recipient`,
+                labelId: "new-feeRecipient",
+                name: "new-fee-recipient",
+                autoComplete: "new-feeRecipient",
+                value: newFeeRecipient || "",
+                onValueChange: setNewFeeRecipient,
+                error: feeRecipientError,
+                placeholder:
+                  "Default fee recipient to be used as a fallback in case you have not set a fee recipient for a validator"
+              }
+            ]}
+          />
 
           <Row className="staker-network">
             <Col>

--- a/packages/admin-ui/src/pages/stakers/components/StakerNetwork.tsx
+++ b/packages/admin-ui/src/pages/stakers/components/StakerNetwork.tsx
@@ -60,6 +60,7 @@ export default function StakerNetwork<T extends Network>({
   // Req
   const [reqStatus, setReqStatus] = useState<ReqStatus>({});
   // New config
+  const [newFeeRecipient, setNewFeeRecipient] = useState<string>();
   const [newExecClient, setNewExecClient] = useState<
     StakerItemOk<T, "execution">
   >();
@@ -77,7 +78,6 @@ export default function StakerNetwork<T extends Network>({
   const [defaultGraffiti, setDefaultGraffiti] = useState<string>(
     defaultDappnodeGraffiti
   );
-  const [defaultFeeRecipient, setDefaultFeeRecipient] = useState<string>("");
   const [defaultCheckpointSync, setDefaultCheckpointSync] = useState<string>(
     getDefaultCheckpointSync(network)
   );
@@ -101,7 +101,8 @@ export default function StakerNetwork<T extends Network>({
         executionClients,
         consensusClients,
         mevBoost,
-        web3Signer
+        web3Signer,
+        feeRecipient
       } = currentStakerConfigReq.data;
 
       const executionClient = executionClients.find(ec =>
@@ -119,6 +120,7 @@ export default function StakerNetwork<T extends Network>({
       if (isOkSelectedInstalledAndRunning(mevBoost) && mevBoost.status === "ok")
         setNewMevBoost(mevBoost);
       setNewEnableWeb3signer(enableWeb3signer);
+      if (feeRecipient) setNewFeeRecipient(feeRecipient);
 
       // Set the current config to be displayed in advance view
       setCurrentStakerConfig({
@@ -149,9 +151,6 @@ export default function StakerNetwork<T extends Network>({
             graffiti: defaultDappnodeGraffiti
           });
         else setDefaultGraffiti(consensusClient.graffiti);
-
-        if (consensusClient.feeRecipient)
-          setDefaultFeeRecipient(consensusClient.feeRecipient);
       }
 
       // set allStakerItemsOk
@@ -166,10 +165,13 @@ export default function StakerNetwork<T extends Network>({
   }, [currentStakerConfigReq.data]);
 
   useEffect(() => {
-    if (newConsClient) {
-      setFeeRecipientError(validateEthereumAddress(newConsClient.feeRecipient));
+    if (newFeeRecipient)
+      setFeeRecipientError(validateEthereumAddress(newFeeRecipient));
+  }, [newFeeRecipient]);
+
+  useEffect(() => {
+    if (newConsClient)
       setGraffitiError(validateGraffiti(newConsClient.graffiti));
-    }
   }, [newConsClient]);
 
   useEffect(() => {
@@ -328,9 +330,7 @@ export default function StakerNetwork<T extends Network>({
                       consensusClient.dnpName === newConsClient?.dnpName
                     }
                     graffitiError={graffitiError}
-                    feeRecipientError={feeRecipientError}
                     defaultGraffiti={defaultGraffiti}
-                    defaultFeeRecipient={defaultFeeRecipient}
                     defaultCheckpointSync={defaultCheckpointSync}
                   />
                 )
@@ -419,6 +419,8 @@ export default function StakerNetwork<T extends Network>({
               }
               setNewConfig={setNewConfig}
               setShowLaunchpadValidators={setShowLaunchpadValidators}
+              setNewFeeRecipient={setNewFeeRecipient}
+              newFeeRecipient={newFeeRecipient}
               setNewExecClient={setNewExecClient}
               setNewConsClient={setNewConsClient}
               setNewMevBoost={setNewMevBoost}
@@ -428,7 +430,6 @@ export default function StakerNetwork<T extends Network>({
               feeRecipientError={feeRecipientError}
               graffitiError={graffitiError}
               defaultGraffiti={defaultGraffiti}
-              defaultFeeRecipient={defaultFeeRecipient}
               defaultCheckpointSync={defaultCheckpointSync}
             />
           )}

--- a/packages/admin-ui/src/pages/stakers/components/columns/ConsensusClient.tsx
+++ b/packages/admin-ui/src/pages/stakers/components/columns/ConsensusClient.tsx
@@ -16,10 +16,8 @@ export default function ConsensusClient<T extends Network>({
   setNewConsClient,
   newConsClient,
   isSelected,
-  feeRecipientError,
   graffitiError,
   defaultGraffiti,
-  defaultFeeRecipient,
   defaultCheckpointSync,
   ...props
 }: {
@@ -29,10 +27,8 @@ export default function ConsensusClient<T extends Network>({
   >;
   newConsClient: StakerItemOk<T, "consensus"> | undefined;
   isSelected: boolean;
-  feeRecipientError: string | null;
   graffitiError: string | null;
   defaultGraffiti: string;
-  defaultFeeRecipient: string;
   defaultCheckpointSync: string;
 }) {
   return (
@@ -50,8 +46,6 @@ export default function ConsensusClient<T extends Network>({
                   setNewConsClient({
                     ...consensusClient,
                     graffiti: consensusClient.graffiti || defaultGraffiti,
-                    feeRecipient:
-                      consensusClient.feeRecipient || defaultFeeRecipient,
                     checkpointSync:
                       consensusClient.checkpointSync || defaultCheckpointSync
                   })
@@ -110,17 +104,6 @@ export default function ConsensusClient<T extends Network>({
           <hr />
           <InputForm
             fields={[
-              {
-                label: "Fee recipient address",
-                labelId: "fee-recipient-address",
-                name: "fee-recipient-address",
-                autoComplete: "fee-recipient-address",
-                secret: false,
-                value: newConsClient.feeRecipient || "",
-                onValueChange: (value: string) =>
-                  setNewConsClient({ ...newConsClient, feeRecipient: value }),
-                error: feeRecipientError
-              },
               {
                 label: "Graffiti",
                 labelId: "graffiti",

--- a/packages/admin-ui/src/pages/stakers/components/launchpad/LaunchpadSteps.tsx
+++ b/packages/admin-ui/src/pages/stakers/components/launchpad/LaunchpadSteps.tsx
@@ -196,7 +196,13 @@ export const launchpadSteps = <T extends Network>({
         </div>
         <Button
           variant="dappnode"
-          disabled={!newExecClient || !newConsClient || !newFeeRecipient}
+          disabled={
+            !newExecClient ||
+            !newConsClient ||
+            !newFeeRecipient ||
+            Boolean(feeRecipientError) ||
+            Boolean(graffitiError)
+          }
           onClick={() => {
             setNewConfig(true);
             setShowLaunchpadValidators(false);

--- a/packages/admin-ui/src/pages/stakers/components/launchpad/LaunchpadSteps.tsx
+++ b/packages/admin-ui/src/pages/stakers/components/launchpad/LaunchpadSteps.tsx
@@ -196,13 +196,7 @@ export const launchpadSteps = <T extends Network>({
         </div>
         <Button
           variant="dappnode"
-          disabled={
-            !newExecClient ||
-            !newConsClient ||
-            !newFeeRecipient ||
-            Boolean(feeRecipientError) ||
-            Boolean(graffitiError)
-          }
+          disabled={!newExecClient || !newConsClient || !newFeeRecipient}
           onClick={() => {
             setNewConfig(true);
             setShowLaunchpadValidators(false);

--- a/packages/admin-ui/src/pages/stakers/components/launchpad/LaunchpadSteps.tsx
+++ b/packages/admin-ui/src/pages/stakers/components/launchpad/LaunchpadSteps.tsx
@@ -7,6 +7,7 @@ import { Network, StakerConfigGetOk, StakerItemOk } from "@dappnode/common";
 import { disclaimer } from "pages/stakers/data";
 import RenderMarkdown from "components/RenderMarkdown";
 import { InputForm } from "components/InputForm";
+import Input from "components/Input";
 
 export const launchpadSteps = <T extends Network>({
   network,
@@ -149,20 +150,10 @@ export const launchpadSteps = <T extends Network>({
     component: (
       <div className="launchpad-summary">
         {newFeeRecipient && (
-          <InputForm
-            fields={[
-              {
-                label: `Default Fee Recipient`,
-                labelId: "new-feeRecipient",
-                name: "new-fee-recipient",
-                autoComplete: "new-feeRecipient",
-                value: newFeeRecipient || "",
-                onValueChange: setNewFeeRecipient,
-                error: feeRecipientError,
-                placeholder:
-                  "Default fee recipient to be used as a fallback in case you have not set a fee recipient for a validator"
-              }
-            ]}
+          <Input
+            aria-disabled={true}
+            value={newFeeRecipient}
+            onValueChange={() => {}}
           />
         )}
         {newExecClient && (

--- a/packages/admin-ui/src/pages/stakers/components/launchpad/LaunchpadSteps.tsx
+++ b/packages/admin-ui/src/pages/stakers/components/launchpad/LaunchpadSteps.tsx
@@ -6,12 +6,15 @@ import MevBoost from "../columns/MevBoost";
 import { Network, StakerConfigGetOk, StakerItemOk } from "@dappnode/common";
 import { disclaimer } from "pages/stakers/data";
 import RenderMarkdown from "components/RenderMarkdown";
+import { InputForm } from "components/InputForm";
 
 export const launchpadSteps = <T extends Network>({
   network,
   stakerConfig,
   setNewConfig,
   setShowLaunchpadValidators,
+  setNewFeeRecipient,
+  newFeeRecipient,
   setNewExecClient,
   newExecClient,
   setNewConsClient,
@@ -27,6 +30,8 @@ export const launchpadSteps = <T extends Network>({
   stakerConfig: StakerConfigGetOk<T>;
   setNewConfig(isLaunchpad: boolean): Promise<void>;
   setShowLaunchpadValidators: React.Dispatch<React.SetStateAction<boolean>>;
+  setNewFeeRecipient: React.Dispatch<React.SetStateAction<string | undefined>>;
+  newFeeRecipient?: string;
   setNewExecClient: React.Dispatch<
     React.SetStateAction<StakerItemOk<T, "execution"> | undefined>
   >;
@@ -102,12 +107,28 @@ export const launchpadSteps = <T extends Network>({
       </div>
     )
   },
-  /**{
-      title: "Set the default Fee Recipient",
-      description:
-        "Set the default fee recipient for the validator(s). The fee recipient is the address that will receive the validator's fees. You can change it at any time.",
-      component: <></>
-    },*/
+  {
+    title: "Set the default Fee Recipient",
+    description:
+      "Set the default fee recipient for the validator(s). The fee recipient is the address that will receive the validator's fees. You can change it at any time.",
+    component: (
+      <InputForm
+        fields={[
+          {
+            label: `Default Fee Recipient`,
+            labelId: "new-feeRecipient",
+            name: "new-fee-recipient",
+            autoComplete: "new-feeRecipient",
+            value: newFeeRecipient || "",
+            onValueChange: setNewFeeRecipient,
+            error: feeRecipientError,
+            placeholder:
+              "Default fee recipient to be used as a fallback in case you have not set a fee recipient for a validator"
+          }
+        ]}
+      />
+    )
+  },
   {
     title: "Enable MEV boost and select its relays",
     description:
@@ -127,6 +148,23 @@ export const launchpadSteps = <T extends Network>({
     description: `This is a summary of the staker configuration you have selected. If you are happy with it, click on the "next" button.`,
     component: (
       <div className="launchpad-summary">
+        {newFeeRecipient && (
+          <InputForm
+            fields={[
+              {
+                label: `Default Fee Recipient`,
+                labelId: "new-feeRecipient",
+                name: "new-fee-recipient",
+                autoComplete: "new-feeRecipient",
+                value: newFeeRecipient || "",
+                onValueChange: setNewFeeRecipient,
+                error: feeRecipientError,
+                placeholder:
+                  "Default fee recipient to be used as a fallback in case you have not set a fee recipient for a validator"
+              }
+            ]}
+          />
+        )}
         {newExecClient && (
           <ExecutionClient<T>
             executionClient={newExecClient}

--- a/packages/admin-ui/src/pages/stakers/components/launchpad/LaunchpadSteps.tsx
+++ b/packages/admin-ui/src/pages/stakers/components/launchpad/LaunchpadSteps.tsx
@@ -21,7 +21,6 @@ export const launchpadSteps = <T extends Network>({
   feeRecipientError,
   graffitiError,
   defaultGraffiti,
-  defaultFeeRecipient,
   defaultCheckpointSync
 }: {
   network: T;
@@ -43,7 +42,6 @@ export const launchpadSteps = <T extends Network>({
   feeRecipientError: string | null;
   graffitiError: string | null;
   defaultGraffiti: string;
-  defaultFeeRecipient: string;
   defaultCheckpointSync: string;
 }) => [
   {
@@ -97,9 +95,7 @@ export const launchpadSteps = <T extends Network>({
             newConsClient={newConsClient}
             isSelected={consensusClient.dnpName === newConsClient?.dnpName}
             graffitiError={graffitiError}
-            feeRecipientError={feeRecipientError}
             defaultGraffiti={defaultGraffiti}
-            defaultFeeRecipient={defaultFeeRecipient}
             defaultCheckpointSync={defaultCheckpointSync}
           />
         ))}
@@ -145,9 +141,7 @@ export const launchpadSteps = <T extends Network>({
             newConsClient={newConsClient}
             isSelected={true}
             graffitiError={graffitiError}
-            feeRecipientError={feeRecipientError}
             defaultGraffiti={defaultGraffiti}
-            defaultFeeRecipient={defaultFeeRecipient}
             defaultCheckpointSync={defaultCheckpointSync}
           />
         )}

--- a/packages/admin-ui/src/pages/stakers/components/launchpad/LaunchpadSteps.tsx
+++ b/packages/admin-ui/src/pages/stakers/components/launchpad/LaunchpadSteps.tsx
@@ -196,7 +196,7 @@ export const launchpadSteps = <T extends Network>({
         </div>
         <Button
           variant="dappnode"
-          disabled={!newExecClient || !newConsClient}
+          disabled={!newExecClient || !newConsClient || !newFeeRecipient}
           onClick={() => {
             setNewConfig(true);
             setShowLaunchpadValidators(false);

--- a/packages/admin-ui/src/pages/stakers/components/launchpad/LaunchpadValidators.tsx
+++ b/packages/admin-ui/src/pages/stakers/components/launchpad/LaunchpadValidators.tsx
@@ -56,9 +56,15 @@ export default function LaunchpadValidators<T extends Network>({
   };
 
   useEffect(() => {
-    if (newExecClient && newConsClient) setNextEnabled(true);
+    if (
+      newExecClient &&
+      newConsClient &&
+      newFeeRecipient &&
+      !Boolean(feeRecipientError)
+    )
+      setNextEnabled(true);
     else setNextEnabled(false);
-  }, [newExecClient, newConsClient]);
+  }, [newExecClient, newConsClient, newFeeRecipient, feeRecipientError]);
 
   const steps = launchpadSteps<T>({
     network,

--- a/packages/admin-ui/src/pages/stakers/components/launchpad/LaunchpadValidators.tsx
+++ b/packages/admin-ui/src/pages/stakers/components/launchpad/LaunchpadValidators.tsx
@@ -65,6 +65,8 @@ export default function LaunchpadValidators<T extends Network>({
     stakerConfig,
     setNewConfig,
     setShowLaunchpadValidators,
+    setNewFeeRecipient,
+    newFeeRecipient,
     setNewExecClient,
     newExecClient,
     setNewConsClient,

--- a/packages/admin-ui/src/pages/stakers/components/launchpad/LaunchpadValidators.tsx
+++ b/packages/admin-ui/src/pages/stakers/components/launchpad/LaunchpadValidators.tsx
@@ -10,6 +10,8 @@ export default function LaunchpadValidators<T extends Network>({
   stakerConfig,
   setNewConfig,
   setShowLaunchpadValidators,
+  setNewFeeRecipient,
+  newFeeRecipient,
   setNewExecClient,
   newExecClient,
   setNewConsClient,
@@ -19,13 +21,14 @@ export default function LaunchpadValidators<T extends Network>({
   feeRecipientError,
   graffitiError,
   defaultGraffiti,
-  defaultFeeRecipient,
   defaultCheckpointSync
 }: {
   network: T;
   stakerConfig: StakerConfigGetOk<T>;
   setNewConfig(isLaunchpad: boolean): Promise<void>;
   setShowLaunchpadValidators: React.Dispatch<React.SetStateAction<boolean>>;
+  setNewFeeRecipient: React.Dispatch<React.SetStateAction<string | undefined>>;
+  newFeeRecipient?: string;
   setNewExecClient: React.Dispatch<
     React.SetStateAction<StakerItemOk<T, "execution"> | undefined>
   >;
@@ -41,7 +44,6 @@ export default function LaunchpadValidators<T extends Network>({
   feeRecipientError: string | null;
   graffitiError: string | null;
   defaultGraffiti: string;
-  defaultFeeRecipient: string;
   defaultCheckpointSync: string;
 }) {
   const [stepIndex, setStepIndex] = useState(0);
@@ -72,7 +74,6 @@ export default function LaunchpadValidators<T extends Network>({
     feeRecipientError,
     graffitiError,
     defaultGraffiti,
-    defaultFeeRecipient,
     defaultCheckpointSync
   });
 

--- a/packages/admin-ui/src/pages/stakers/components/launchpad/launchpad-validators.scss
+++ b/packages/admin-ui/src/pages/stakers/components/launchpad/launchpad-validators.scss
@@ -80,11 +80,11 @@
 
     .launchpad-summary {
       display: flex;
-      flex-direction: row;
+      flex-direction: column;
       justify-content: space-between;
       margin-bottom: 1rem;
       > * {
-        margin: 0 2rem;
+        margin: 1rem;
         // Do not allow the child elements to be clickable
         pointer-events: none;
       }

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -11,6 +11,7 @@ import {
   Dependencies,
   PackageEnvs,
 } from "@dappnode/dappnodesdk";
+import { build } from "@dappnode/dappnodesdk/dist/commands/build";
 
 /**
  * Take into account the following tags to document the new types inside this file
@@ -1314,6 +1315,7 @@ export interface StakerConfigSet<T extends Network> {
   consensusClient?: StakerItemOk<T, "consensus">;
   mevBoost?: StakerItemOk<T, "mev-boost">;
   enableWeb3signer?: boolean;
+  feeRecipient?: string;
 }
 
 export type ExecutionClient<T extends Network> = T extends "mainnet"
@@ -1365,6 +1367,7 @@ export interface StakerParamsByNetwork<T extends Network> {
   };
   mevBoost: MevBoost<T>;
   isMevBoostSelected: boolean;
+  feeRecipient: string;
 }
 
 /**

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -1238,7 +1238,6 @@ interface StakerExecution<T extends Network> {
 interface StakerConsensus<T extends Network> {
   dnpName: ConsensusClient<T>;
   graffiti?: string;
-  feeRecipient?: string;
   checkpointSync?: string;
 }
 
@@ -1300,6 +1299,7 @@ export interface StakerConfigGet<T extends Network> {
   consensusClients: StakerItem<T, "consensus">[];
   web3Signer: StakerItem<T, "signer">;
   mevBoost: StakerItem<T, "mev-boost">;
+  feeRecipient: string;
 }
 
 export interface StakerConfigGetOk<T extends Network> {

--- a/packages/dappmanager/src/modules/stakerConfig/getStakerConfig.ts
+++ b/packages/dappmanager/src/modules/stakerConfig/getStakerConfig.ts
@@ -44,7 +44,8 @@ export async function getStakerConfig<T extends Network>(
       currentConsClient,
       web3signer,
       mevBoost,
-      isMevBoostSelected
+      isMevBoostSelected,
+      feeRecipient
     } = stakerParamsByNetwork(network);
 
     const dnpList = await listPackages();
@@ -90,20 +91,17 @@ export async function getStakerConfig<T extends Network>(
               consClient.dnpName
             );
             const isInstalled = getIsInstalled(pkgData, dnpList);
-            let graffiti, feeRecipient, checkpointSync;
+            let graffiti, checkpointSync;
             if (isInstalled) {
               const pkgEnv = (await packageGet({ dnpName: pkgData.dnpName }))
                 .userSettings?.environment;
               if (pkgEnv) {
-                const validatorService = getValidatorServiceName(
-                  pkgData.dnpName
-                );
-                const beaconService = getBeaconServiceName(pkgData.dnpName);
-                graffiti = pkgEnv[validatorService]["GRAFFITI"];
-                feeRecipient =
-                  pkgEnv[validatorService]["FEE_RECIPIENT_ADDRESS"];
-                pkgEnv[beaconService]["FEE_RECIPIENT_ADDRESS"];
-                checkpointSync = pkgEnv[beaconService]["CHECKPOINT_SYNC_URL"];
+                graffiti =
+                  pkgEnv[getValidatorServiceName(pkgData.dnpName)]["GRAFFITI"];
+                checkpointSync =
+                  pkgEnv[getBeaconServiceName(pkgData.dnpName)][
+                    "CHECKPOINT_SYNC_URL"
+                  ];
               }
             }
             return {
@@ -116,7 +114,6 @@ export async function getStakerConfig<T extends Network>(
               data: pkgData,
               isSelected: consClient.dnpName === currentConsClient,
               graffiti,
-              feeRecipient,
               checkpointSync
             };
           } catch (error) {
@@ -186,7 +183,8 @@ export async function getStakerConfig<T extends Network>(
             error
           });
         }
-      })
+      }),
+      feeRecipient
     };
   } catch (e) {
     throw Error(`Error getting staker config: ${e}`);

--- a/packages/dappmanager/src/modules/stakerConfig/setStakerConfig.ts
+++ b/packages/dappmanager/src/modules/stakerConfig/setStakerConfig.ts
@@ -143,7 +143,8 @@ export async function setStakerConfig<T extends Network>({
       network: stakerConfig.network,
       executionClient: currentExecClient,
       consensusClient: stakerConfig.consensusClient?.dnpName,
-      mevBoost: stakerConfig.mevBoost?.dnpName
+      mevBoost: stakerConfig.mevBoost?.dnpName,
+      feeRecipient: stakerConfig.feeRecipient
     });
     throw e;
   });
@@ -160,7 +161,8 @@ export async function setStakerConfig<T extends Network>({
         ...stakerConfig,
         executionClient: currentExecClient,
         consensusClient: currentConsClient,
-        mevBoost: stakerConfig.mevBoost?.dnpName
+        mevBoost: stakerConfig.mevBoost?.dnpName,
+        feeRecipient: stakerConfig.feeRecipient
       });
       throw e;
     });
@@ -176,7 +178,8 @@ export async function setStakerConfig<T extends Network>({
       ...stakerConfig,
       executionClient: currentExecClient,
       consensusClient: currentConsClient,
-      mevBoost: stakerConfig.mevBoost?.dnpName
+      mevBoost: stakerConfig.mevBoost?.dnpName,
+      feeRecipient: stakerConfig.feeRecipient
     });
     throw e;
   });
@@ -186,7 +189,8 @@ export async function setStakerConfig<T extends Network>({
     network: stakerConfig.network,
     executionClient: stakerConfig.executionClient?.dnpName,
     consensusClient: stakerConfig.consensusClient?.dnpName,
-    mevBoost: stakerConfig.mevBoost?.dnpName
+    mevBoost: stakerConfig.mevBoost?.dnpName,
+    feeRecipient: stakerConfig.feeRecipient
   });
 }
 
@@ -468,12 +472,14 @@ function setStakerConfigOnDb<T extends Network>({
   network,
   executionClient,
   consensusClient,
-  mevBoost
+  mevBoost,
+  feeRecipient
 }: {
   network: T;
   executionClient?: ExecutionClient<T>;
   consensusClient?: ConsensusClient<T>;
   mevBoost?: MevBoost<T>;
+  feeRecipient?: string;
 }): void {
   switch (network) {
     case "mainnet":
@@ -487,6 +493,11 @@ function setStakerConfigOnDb<T extends Network>({
         );
       if (db.mevBoostMainnet.get() !== Boolean(mevBoost))
         db.mevBoostMainnet.set(mevBoost ? true : false);
+      if (
+        feeRecipient !== undefined &&
+        db.feeRecipientMainnet.get() !== feeRecipient
+      )
+        db.feeRecipientMainnet.set(feeRecipient);
       break;
     case "gnosis":
       if (db.executionClientGnosis.get() !== executionClient)
@@ -495,6 +506,11 @@ function setStakerConfigOnDb<T extends Network>({
         db.consensusClientGnosis.set(consensusClient as ConsensusClientGnosis);
       if (db.mevBoostGnosis.get() !== Boolean(mevBoost))
         db.mevBoostGnosis.set(mevBoost ? true : false);
+      if (
+        feeRecipient !== undefined &&
+        db.feeRecipientGnosis.get() !== feeRecipient
+      )
+        db.feeRecipientGnosis.set(feeRecipient);
       break;
     case "prater":
       if (db.executionClientPrater.get() !== executionClient)
@@ -503,6 +519,11 @@ function setStakerConfigOnDb<T extends Network>({
         db.consensusClientPrater.set(consensusClient as ConsensusClientPrater);
       if (db.mevBoostPrater.get() !== Boolean(mevBoost))
         db.mevBoostPrater.set(mevBoost ? true : false);
+      if (
+        feeRecipient !== undefined &&
+        db.feeRecipientPrater.get() !== feeRecipient
+      )
+        db.feeRecipientPrater.set(feeRecipient);
       break;
     default:
       throw new Error(`Unsupported network: ${network}`);

--- a/packages/dappmanager/src/modules/stakerConfig/stakerParamsByNetwork.ts
+++ b/packages/dappmanager/src/modules/stakerConfig/stakerParamsByNetwork.ts
@@ -54,7 +54,8 @@ export function stakerParamsByNetwork<T extends Network>(
           minVersion: "0.1.4"
         },
         mevBoost: "mev-boost.dnp.dappnode.eth",
-        isMevBoostSelected: db.mevBoostMainnet.get()
+        isMevBoostSelected: db.mevBoostMainnet.get(),
+        feeRecipient: db.feeRecipientMainnet.get() || ""
       } as StakerParamsByNetwork<T>;
 
     case "gnosis":
@@ -86,7 +87,8 @@ export function stakerParamsByNetwork<T extends Network>(
           minVersion: "0.1.10"
         },
         mevBoost: "mev-boost-gnosis.dnp.dappnode.eth",
-        isMevBoostSelected: db.mevBoostGnosis.get()
+        isMevBoostSelected: db.mevBoostGnosis.get(),
+        feeRecipient: db.feeRecipientGnosis.get() || ""
       } as StakerParamsByNetwork<T>;
     case "prater":
       return {
@@ -125,7 +127,7 @@ export function stakerParamsByNetwork<T extends Network>(
           {
             dnpName: "nimbus-prater.dnp.dappnode.eth",
             minVersion: "0.1.7"
-          },
+          }
         ],
         currentConsClient: db.consensusClientPrater.get(),
         web3signer: {
@@ -133,7 +135,8 @@ export function stakerParamsByNetwork<T extends Network>(
           minVersion: "0.1.11"
         },
         mevBoost: "mev-boost-goerli.dnp.dappnode.eth",
-        isMevBoostSelected: db.mevBoostPrater.get()
+        isMevBoostSelected: db.mevBoostPrater.get(),
+        feeRecipient: db.feeRecipientPrater.get() || ""
       } as StakerParamsByNetwork<T>;
     default:
       throw Error(`Unsupported network: ${network}`);

--- a/packages/dappmanager/src/modules/stakerConfig/utils.ts
+++ b/packages/dappmanager/src/modules/stakerConfig/utils.ts
@@ -105,7 +105,7 @@ export function getConsensusUserSettings({
 
 /**
  * Update environemnt variables for the consensus client
- * only if graffiti, fee recipient or checkpoint sync are set
+ * only if graffiti, or checkpoint sync are set
  */
 export async function updateConsensusEnv<T extends Network>({
   targetConsensusClient,
@@ -114,11 +114,7 @@ export async function updateConsensusEnv<T extends Network>({
   targetConsensusClient: StakerItemOk<T, "consensus">;
   userSettings: UserSettingsAllDnps;
 }): Promise<void> {
-  if (
-    targetConsensusClient.graffiti ||
-    targetConsensusClient.feeRecipient ||
-    targetConsensusClient.checkpointSync
-  ) {
+  if (targetConsensusClient.graffiti || targetConsensusClient.checkpointSync) {
     const serviceEnv = userSettings[targetConsensusClient.dnpName].environment;
 
     if (serviceEnv) {


### PR DESCRIPTION
Set the fee recipient as a new global env instead of been as a env from each consensus client pkg

**TODO** set in every consensus client:
- min dappnode version
- remove fee recipient as env in the compose and set it as new global env in the manifest