### PR TITLE
Add Erigon Gnosis chain to stakersUI [Blocked]

### DIFF
--- a/packages/dappmanager/src/modules/stakerConfig/stakerParamsByNetwork.ts
+++ b/packages/dappmanager/src/modules/stakerConfig/stakerParamsByNetwork.ts
@@ -68,6 +68,10 @@ export function stakerParamsByNetwork<T extends Network>(
           {
             dnpName: "nethermind-xdai.dnp.dappnode.eth",
             minVersion: "1.0.18"
+          },
+          {
+            dnpName: "erigon-gnosis.dnp.dappnode.eth",
+            minVersion: "0.1.0"
           }
         ],
         currentExecClient: db.executionClientGnosis.get(),


### PR DESCRIPTION
<!-- For DAppNode core members, once the Pull Request is created, do not forget to:
1.  Link issues to the PR if available
2.  Mention dappnode core members
3.  Add proper labels
-->

## Context

Adding client diversity to Gnosis chain, Since OpenEthereum was deprecated Nethermind xDai has again been the only option for an EL client on dappnode for gnosis chain, Erigon has since added support for gnosis chain and is ready to be tested on Dappnode.

## Approach

adds Erigon for gnosis chain to stakersUI

## Test instructions

All Gnosis CLs currently have the logic published  to allow switching between clients, but need a line in each entrypoint.sh changed to use the appropriate endpoint between erigon gnosis chain and nethermind xdai, the line just hardcodes nethermind to always be the endpoint regardless of global env setting.

Install erigon gnosis chain package from ipfs hash under releases, edit teku, lodestar, or lighthouse to remove the hardcoded value in the entrypoint, and install thhis branch of the dappmanager.