### PR TITLE
Use fee recipient as mandatory

### DIFF
--- a/packages/admin-ui/src/pages/stakers/components/StakerNetwork.tsx
+++ b/packages/admin-ui/src/pages/stakers/components/StakerNetwork.tsx
@@ -54,7 +54,7 @@ export default function StakerNetwork<T extends Network>({
   // Req
   const [reqStatus, setReqStatus] = useState<ReqStatus>({});
   // New config
-  const [newFeeRecipient, setNewFeeRecipient] = useState<string>();
+  const [newFeeRecipient, setNewFeeRecipient] = useState<string>("");
   const [newExecClient, setNewExecClient] = useState<
     StakerItemOk<T, "execution">
   >();
@@ -211,6 +211,7 @@ export default function StakerNetwork<T extends Network>({
             api.stakerConfigSet({
               stakerConfig: {
                 network,
+                feeRecipient: newFeeRecipient,
                 executionClient:
                   newExecClient?.status === "ok"
                     ? { ...newExecClient, data: undefined }

--- a/packages/admin-ui/src/pages/stakers/components/launchpad/LaunchpadSteps.tsx
+++ b/packages/admin-ui/src/pages/stakers/components/launchpad/LaunchpadSteps.tsx
@@ -28,8 +28,8 @@ export const launchpadSteps = <T extends Network>({
   stakerConfig: StakerConfigGetOk<T>;
   setNewConfig(isLaunchpad: boolean): Promise<void>;
   setShowLaunchpadValidators: React.Dispatch<React.SetStateAction<boolean>>;
-  setNewFeeRecipient: React.Dispatch<React.SetStateAction<string | undefined>>;
-  newFeeRecipient?: string;
+  setNewFeeRecipient: React.Dispatch<React.SetStateAction<string>>;
+  newFeeRecipient: string;
   setNewExecClient: React.Dispatch<
     React.SetStateAction<StakerItemOk<T, "execution"> | undefined>
   >;

--- a/packages/admin-ui/src/pages/stakers/components/launchpad/LaunchpadValidators.tsx
+++ b/packages/admin-ui/src/pages/stakers/components/launchpad/LaunchpadValidators.tsx
@@ -24,8 +24,8 @@ export default function LaunchpadValidators<T extends Network>({
   stakerConfig: StakerConfigGetOk<T>;
   setNewConfig(isLaunchpad: boolean): Promise<void>;
   setShowLaunchpadValidators: React.Dispatch<React.SetStateAction<boolean>>;
-  setNewFeeRecipient: React.Dispatch<React.SetStateAction<string | undefined>>;
-  newFeeRecipient?: string;
+  setNewFeeRecipient: React.Dispatch<React.SetStateAction<string>>;
+  newFeeRecipient: string;
   setNewExecClient: React.Dispatch<
     React.SetStateAction<StakerItemOk<T, "execution"> | undefined>
   >;

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -1310,11 +1310,11 @@ export interface StakerConfigGetOk<T extends Network> {
 }
 export interface StakerConfigSet<T extends Network> {
   network: T;
+  feeRecipient: string;
   executionClient?: StakerItemOk<T, "execution">;
   consensusClient?: StakerItemOk<T, "consensus">;
   mevBoost?: StakerItemOk<T, "mev-boost">;
   enableWeb3signer?: boolean;
-  feeRecipient?: string;
 }
 
 export type ExecutionClient<T extends Network> = T extends "mainnet"

--- a/packages/dappmanager/src/daemons/ethMultiClient/index.ts
+++ b/packages/dappmanager/src/daemons/ethMultiClient/index.ts
@@ -83,7 +83,8 @@ export async function runEthClientInstaller(
                 userSettings: getConsensusUserSettings({
                   dnpName: target,
                   network: "mainnet",
-                  useCheckpointSync
+                  useCheckpointSync,
+                  feeRecipient: db.feeRecipientMainnet.get() || ""
                 })
               });
             else await packageInstall({ name: target });

--- a/packages/dappmanager/src/modules/ethClient/ethereumClient.ts
+++ b/packages/dappmanager/src/modules/ethClient/ethereumClient.ts
@@ -221,7 +221,8 @@ export class EthereumClient {
         const userSettings = getConsensusUserSettings({
           dnpName: consClient,
           network: "mainnet",
-          useCheckpointSync
+          useCheckpointSync,
+          feeRecipient: db.feeRecipientMainnet.get() || ""
         });
         await packageInstall({ name: consClient, userSettings });
       } else {

--- a/packages/dappmanager/src/modules/stakerConfig/setStakerConfig.ts
+++ b/packages/dappmanager/src/modules/stakerConfig/setStakerConfig.ts
@@ -302,7 +302,7 @@ async function setConsensusClientConfig<T extends Network>({
   currentConsClientPkg
 }: {
   network: Network;
-  feeRecipient?: string;
+  feeRecipient: string;
   currentConsClient?: T extends "mainnet"
     ? ConsensusClientMainnet
     : T extends "gnosis"

--- a/packages/dappmanager/src/modules/stakerConfig/utils.ts
+++ b/packages/dappmanager/src/modules/stakerConfig/utils.ts
@@ -62,7 +62,7 @@ export function getConsensusUserSettings({
 }: {
   dnpName: string;
   network: Network;
-  feeRecipient?: string;
+  feeRecipient: string;
   useCheckpointSync?: boolean;
 }): UserSettingsAllDnps {
   const validatorServiceName = getValidatorServiceName(dnpName);


### PR DESCRIPTION
Use fee recipient as a mandatory value in the backend. 

Only allow to apply staker changes if fee recipient is valid
