### PR TITLE
Bum dappnodesdk dependency

### DIFF
--- a/packages/admin-ui/package.json
+++ b/packages/admin-ui/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@dappnode/common": "^0.1.0",
     "@dappnode/dappmanager": "^0.1.0",
-    "@dappnode/dappnodesdk": "^0.2.71",
+    "@dappnode/dappnodesdk": "^0.2.82",
     "@reduxjs/toolkit": "^1.3.5",
     "@types/clipboard": "^2.0.7",
     "@types/node": "^18.11.18",

--- a/packages/admin-ui/src/__mock-backend__/data/dnps/types.ts
+++ b/packages/admin-ui/src/__mock-backend__/data/dnps/types.ts
@@ -1,4 +1,4 @@
-import { Manifest, SetupWizard } from "@dappnode/dappnodesdk";
+import { Manifest, SetupWizard } from "@dappnode/dappnodesdk/dist/types";
 import {
   UserSettings,
   SpecialPermission,

--- a/packages/admin-ui/src/components/SetupWizard/InputField.tsx
+++ b/packages/admin-ui/src/components/SetupWizard/InputField.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { SetupWizardField } from "@dappnode/dappnodesdk";
+import { SetupWizardField } from "@dappnode/dappnodesdk/dist/types";
 import Input from "components/Input";
 import InputFieldSelect from "./InputFieldSelect";
 import InputFieldFile from "./InputFieldFile";

--- a/packages/admin-ui/src/pages/installer/components/Steps/Warnings.tsx
+++ b/packages/admin-ui/src/pages/installer/components/Steps/Warnings.tsx
@@ -3,7 +3,7 @@ import Card from "components/Card";
 import { RequestedDnp } from "@dappnode/common";
 import RenderMarkdown from "components/RenderMarkdown";
 import Button from "components/Button";
-import { Manifest } from "@dappnode/dappnodesdk";
+import { Manifest } from "@dappnode/dappnodesdk/dist/types";
 
 export default function Warnings({
   goNext,

--- a/packages/admin-ui/src/pages/installer/parsers/formDataParser.ts
+++ b/packages/admin-ui/src/pages/installer/parsers/formDataParser.ts
@@ -7,7 +7,7 @@ import {
   SetupWizardAllDnps
 } from "@dappnode/common";
 import { SetupWizardFormDataReturn } from "../types";
-import { SetupSchema } from "@dappnode/dappnodesdk";
+import { SetupSchema } from "@dappnode/dappnodesdk/dist/types";
 import { SetupTargetAllDnps } from "types";
 
 const ajv = new Ajv({ allErrors: true });

--- a/packages/admin-ui/src/pages/packages/actions.ts
+++ b/packages/admin-ui/src/pages/packages/actions.ts
@@ -6,7 +6,7 @@ import { api } from "api";
 import { withToastNoThrow } from "components/toast/Toast";
 import { InstalledPackageData, PackageContainer } from "@dappnode/common";
 import { continueIfCalleDisconnected } from "api/utils";
-import { PackageEnvs } from "@dappnode/dappnodesdk";
+import { PackageEnvs } from "@dappnode/dappnodesdk/dist/types";
 
 // Used in package interface / envs
 

--- a/packages/admin-ui/src/pages/packages/components/Backup/Download.tsx
+++ b/packages/admin-ui/src/pages/packages/components/Backup/Download.tsx
@@ -9,7 +9,7 @@ import ErrorView from "components/ErrorView";
 // Utils
 import { prettyDnpName } from "utils/format";
 import newTabProps from "utils/newTabProps";
-import { PackageBackup } from "@dappnode/dappnodesdk";
+import { PackageBackup } from "@dappnode/dappnodesdk/dist/types";
 import { ReqStatus } from "types";
 
 export function BackupDownload({

--- a/packages/admin-ui/src/pages/packages/components/Backup/Restore.tsx
+++ b/packages/admin-ui/src/pages/packages/components/Backup/Restore.tsx
@@ -10,7 +10,7 @@ import ErrorView from "components/ErrorView";
 import { prettyDnpName } from "utils/format";
 import humanFS from "utils/humanFileSize";
 import { ReqStatus } from "types";
-import { PackageBackup } from "@dappnode/dappnodesdk";
+import { PackageBackup } from "@dappnode/dappnodesdk/dist/types";
 
 type ProgressType = { label: string; percent?: number };
 type UploadReqStatus = ReqStatus<true, ProgressType>;

--- a/packages/admin-ui/src/pages/packages/components/Backup/index.tsx
+++ b/packages/admin-ui/src/pages/packages/components/Backup/index.tsx
@@ -4,7 +4,7 @@ import Columns from "components/Columns";
 import { BackupDownload } from "./Download";
 import { BackupRestore } from "./Restore";
 import "./backup.scss";
-import { PackageBackup } from "@dappnode/dappnodesdk";
+import { PackageBackup } from "@dappnode/dappnodesdk/dist/types";
 
 export function Backup({
   dnpName,

--- a/packages/admin-ui/src/pages/packages/components/Config.tsx
+++ b/packages/admin-ui/src/pages/packages/components/Config.tsx
@@ -6,7 +6,7 @@ import { SetupWizard } from "components/SetupWizard";
 import {
   SetupWizard as SetupWizardType,
   PackageEnvs
-} from "@dappnode/dappnodesdk";
+} from "@dappnode/dappnodesdk/dist/types";
 import { UserSettingsAllDnps, UserSettings } from "@dappnode/common";
 import { difference } from "utils/lodashExtended";
 

--- a/packages/admin-ui/src/pages/packages/components/Info/Links.tsx
+++ b/packages/admin-ui/src/pages/packages/components/Info/Links.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import newTabProps from "utils/newTabProps";
 import { MdHome, MdSettingsRemote, MdSettings, MdInfo } from "react-icons/md";
 import { AiFillBug } from "react-icons/ai";
-import { Manifest } from "@dappnode/dappnodesdk";
+import { Manifest } from "@dappnode/dappnodesdk/dist/types";
 
 export function Links({
   links,

--- a/packages/admin-ui/src/pages/packages/components/Info/index.tsx
+++ b/packages/admin-ui/src/pages/packages/components/Info/index.tsx
@@ -9,7 +9,7 @@ import { MdClose } from "react-icons/md";
 import { Links } from "./Links";
 import newTabProps from "utils/newTabProps";
 import { InstalledPackageDetailData } from "@dappnode/common";
-import { Manifest } from "@dappnode/dappnodesdk";
+import { Manifest } from "@dappnode/dappnodesdk/dist/types";
 import { ipfsGatewayUrl } from "pages/system/data";
 import { RemovePackage } from "./RemovePackage";
 import { VolumesList } from "./VolumesList";

--- a/packages/admin-ui/src/types.ts
+++ b/packages/admin-ui/src/types.ts
@@ -1,4 +1,4 @@
-import { SetupTarget } from "@dappnode/dappnodesdk";
+import { SetupTarget } from "@dappnode/dappnodesdk/dist/types";
 import { PackageVersionData } from "@dappnode/common";
 
 export interface WifiCredentials {

--- a/packages/admin-ui/src/utils/getRepoSlugFromManifest.ts
+++ b/packages/admin-ui/src/utils/getRepoSlugFromManifest.ts
@@ -1,5 +1,5 @@
 import { stringSplit, stringIncludes } from "./strings";
-import { Manifest } from "@dappnode/dappnodesdk";
+import { Manifest } from "@dappnode/dappnodesdk/dist/types";
 
 const githubBaseUrl = "https://github.com/";
 

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -18,7 +18,7 @@
     "dev": "tsc -w"
   },
   "dependencies": {
-    "@dappnode/dappnodesdk": "^0.2.71",
+    "@dappnode/dappnodesdk": "^0.2.82",
     "@types/node": "^18.11.18",
     "lodash-es": "^4.17.21"
   },

--- a/packages/common/src/routes.ts
+++ b/packages/common/src/routes.ts
@@ -44,9 +44,9 @@ import {
   Network,
   StakerConfigSet,
   StakerConfigGet,
-  Eth2ClientTarget
-} from "./types";
-import { PackageBackup, PackageEnvs } from "@dappnode/dappnodesdk";
+  Eth2ClientTarget,
+} from "./types.js";
+import { PackageBackup, PackageEnvs } from "@dappnode/dappnodesdk/dist/types";
 
 export interface Routes {
   /**
@@ -773,7 +773,7 @@ export const routesData: { [P in keyof Routes]: RouteData } = {
   wireguardDeviceAdd: { log: true },
   wireguardDeviceRemove: { log: true },
   wireguardDeviceGet: {},
-  wireguardDevicesGet: {}
+  wireguardDevicesGet: {},
 };
 
 // DO NOT REMOVE

--- a/packages/common/src/subscriptions.ts
+++ b/packages/common/src/subscriptions.ts
@@ -8,7 +8,7 @@ import {
   UserActionLog,
   VolumeData,
   VpnDevice,
-} from "./types";
+} from "./types.js";
 
 export interface SubscriptionsTypes {
   /**

--- a/packages/common/src/transport/jsonRpc/index.ts
+++ b/packages/common/src/transport/jsonRpc/index.ts
@@ -1,4 +1,4 @@
-import { RpcResponse } from "../../types";
+import { RpcResponse } from "../../types.js";
 
 /**
  * Parse RPC response, to be used in the client
@@ -13,7 +13,7 @@ export async function parseRpcResponse<R>(body: RpcResponse<R>): Promise<R> {
     }
     throw error;
   } else {
-    return (body.result as unknown) as R;
+    return body.result as unknown as R;
   }
 }
 

--- a/packages/common/src/transport/socketIo/index.ts
+++ b/packages/common/src/transport/socketIo/index.ts
@@ -1,6 +1,6 @@
 import Ajv from "ajv";
 import { mapValues } from "lodash-es";
-import { Args, LoggerMiddleware } from "../../types";
+import { Args, LoggerMiddleware } from "../../types.js";
 import { Subscriptions, subscriptionsData } from "../../subscriptions.js";
 
 const ajv = new Ajv({ allErrors: true });
@@ -58,7 +58,7 @@ export function subscriptionsFactory(
         }
       },
       on: (handler: (...args: Args) => void | Promise<void>): void => {
-        io.on(route, async function(...args: Args): Promise<void> {
+        io.on(route, async function (...args: Args): Promise<void> {
           // Use try / catch and await to be safe for async and sync methods
           try {
             if (onCall) onCall(`on - ${route}`, args);

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -10,8 +10,7 @@ import {
   PackageBackup,
   Dependencies,
   PackageEnvs,
-} from "@dappnode/dappnodesdk";
-import { build } from "@dappnode/dappnodesdk/dist/commands/build";
+} from "@dappnode/dappnodesdk/dist/types";
 
 /**
  * Take into account the following tags to document the new types inside this file

--- a/packages/dappmanager/package.json
+++ b/packages/dappmanager/package.json
@@ -22,7 +22,7 @@
   "license": "GPL-3.0",
   "dependencies": {
     "@dappnode/common": "^0.1.0",
-    "@dappnode/dappnodesdk": "^0.2.71",
+    "@dappnode/dappnodesdk": "^0.2.82",
     "@ipld/car": "^3.1.16",
     "@types/async": "^3.0.1",
     "@types/async-retry": "^1.4.2",
@@ -95,8 +95,8 @@
     "tweetnacl-util": "^0.15.0"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^4.30.0",
-    "@typescript-eslint/parser": "^4.30.0",
+    "@typescript-eslint/eslint-plugin": "^5.57.0",
+    "@typescript-eslint/parser": "^5.57.0",
     "chai": "^4.1.2",
     "dotenv": "^8.2.0",
     "eslint": "^7.32.0",
@@ -107,6 +107,6 @@
     "sinon": "^5.0.10",
     "socket.io-client": "^4.5.1",
     "ts-node": "^10.8.1",
-    "typescript": "^4.7.3"
+    "typescript": "^5.0.2"
   }
 }

--- a/packages/dappmanager/src/calls/backupGet.ts
+++ b/packages/dappmanager/src/calls/backupGet.ts
@@ -9,7 +9,7 @@ import { listPackage } from "../modules/docker/list/index.js";
 // Utils
 import shell from "../utils/shell.js";
 import validateBackupArray from "../utils/validateBackupArray.js";
-import { PackageBackup } from "@dappnode/dappnodesdk";
+import { PackageBackup } from "@dappnode/dappnodesdk/dist/exports";
 
 const tempTransferDir = params.TEMP_TRANSFER_DIR;
 

--- a/packages/dappmanager/src/calls/backupRestore.ts
+++ b/packages/dappmanager/src/calls/backupRestore.ts
@@ -7,7 +7,7 @@ import { listPackage } from "../modules/docker/list/index.js";
 import { packageRestart } from "./packageRestart.js";
 import shell from "../utils/shell.js";
 import validateBackupArray from "../utils/validateBackupArray.js";
-import { PackageBackup } from "@dappnode/dappnodesdk";
+import { PackageBackup } from "@dappnode/dappnodesdk/dist/exports";
 
 const tempTransferDir = params.TEMP_TRANSFER_DIR;
 

--- a/packages/dappmanager/src/calls/fetchDnpRequest.ts
+++ b/packages/dappmanager/src/calls/fetchDnpRequest.ts
@@ -1,6 +1,6 @@
 import { mapValues, omit } from "lodash-es";
 import { valid, gt } from "semver";
-import { Manifest, SetupWizardField } from "@dappnode/dappnodesdk";
+import { Manifest, SetupWizardField } from "@dappnode/dappnodesdk/dist/exports";
 import { listPackages } from "../modules/docker/list/index.js";
 import params from "../params.js";
 import shouldUpdate from "../modules/dappGet/utils/shouldUpdate.js";

--- a/packages/dappmanager/src/calls/packageSetEnvironment.ts
+++ b/packages/dappmanager/src/calls/packageSetEnvironment.ts
@@ -6,7 +6,7 @@ import {
   dockerComposeUpPackage
 } from "../modules/docker/index.js";
 import { packageInstalledHasPid } from "../utils/pid.js";
-import { PackageEnvs } from "@dappnode/dappnodesdk";
+import { PackageEnvs } from "@dappnode/dappnodesdk/dist/exports";
 
 /**
  * Updates the .env file of a package. If requested, also re-ups it

--- a/packages/dappmanager/src/domains.ts
+++ b/packages/dappmanager/src/domains.ts
@@ -1,4 +1,5 @@
-import params, { getContainerDomain } from "./params.js";
+import params from "./params.js";
+import { getContainerDomain } from "@dappnode/dappnodesdk/dist/exports";
 
 export function stripCharacters(s: string): string {
   return s.replace(RegExp("_", "g"), "");

--- a/packages/dappmanager/src/modules/chains/drivers/ethereum.ts
+++ b/packages/dappmanager/src/modules/chains/drivers/ethereum.ts
@@ -3,7 +3,7 @@ import { InstalledPackageData } from "@dappnode/common";
 import { whyDoesGethTakesSoMuchToSync } from "../../../externalLinks.js";
 import { EthSyncing, parseEthersSyncing } from "../../../utils/ethers.js";
 import { getPrivateNetworkAlias } from "../../../domains.js";
-import { ChainDriverSpecs } from "@dappnode/dappnodesdk";
+import { ChainDriverSpecs } from "@dappnode/dappnodesdk/dist/exports";
 import { ChainDataResult } from "../types.js";
 import { safeProgress } from "../utils.js";
 

--- a/packages/dappmanager/src/modules/chains/drivers/ethereum2.ts
+++ b/packages/dappmanager/src/modules/chains/drivers/ethereum2.ts
@@ -1,5 +1,5 @@
 import fetch from "node-fetch";
-import { ChainDriverSpecs } from "@dappnode/dappnodesdk";
+import { ChainDriverSpecs } from "@dappnode/dappnodesdk/dist/exports";
 import { getPrivateNetworkAlias } from "../../../domains.js";
 import { urlJoin } from "../../../utils/url.js";
 import { InstalledPackageData } from "@dappnode/common";

--- a/packages/dappmanager/src/modules/chains/getChainDriverName.ts
+++ b/packages/dappmanager/src/modules/chains/getChainDriverName.ts
@@ -1,5 +1,5 @@
 import { InstalledPackageData } from "@dappnode/common";
-import { ChainDriver } from "@dappnode/dappnodesdk";
+import { ChainDriver } from "@dappnode/dappnodesdk/dist/exports";
 
 /**
  * Get ChainDriver for a given dnp

--- a/packages/dappmanager/src/modules/chains/types.ts
+++ b/packages/dappmanager/src/modules/chains/types.ts
@@ -1,5 +1,5 @@
 import { ChainData } from "@dappnode/common";
-import { ChainDriver } from "@dappnode/dappnodesdk";
+import { ChainDriver } from "@dappnode/dappnodesdk/dist/exports";
 
 export interface Chain {
   dnpName: string; // geth.dnp.dappnode.eth

--- a/packages/dappmanager/src/modules/compose/clean.ts
+++ b/packages/dappmanager/src/modules/compose/clean.ts
@@ -1,5 +1,5 @@
 import { mapValues, omitBy, isObject, isEmpty, pick } from "lodash-es";
-import { Compose } from "@dappnode/dappnodesdk";
+import { Compose } from "@dappnode/dappnodesdk/dist/exports";
 
 /**
  * Cleans empty or null properties

--- a/packages/dappmanager/src/modules/compose/editor.ts
+++ b/packages/dappmanager/src/modules/compose/editor.ts
@@ -20,7 +20,7 @@ import {
   ComposeServiceNetwork,
   PackageEnvs,
   Manifest
-} from "@dappnode/dappnodesdk";
+} from "@dappnode/dappnodesdk/dist/exports";
 import {
   stringifyPortMappings,
   parsePortMappings,

--- a/packages/dappmanager/src/modules/compose/environment.ts
+++ b/packages/dappmanager/src/modules/compose/environment.ts
@@ -1,4 +1,4 @@
-import { PackageEnvs } from "@dappnode/dappnodesdk";
+import { PackageEnvs } from "@dappnode/dappnodesdk/dist/exports";
 import { pickBy } from "lodash-es";
 
 /**

--- a/packages/dappmanager/src/modules/compose/labelsDb.ts
+++ b/packages/dappmanager/src/modules/compose/labelsDb.ts
@@ -7,7 +7,7 @@ import {
   ChainDriverType,
   chainDriversTypes,
   Dependencies
-} from "@dappnode/dappnodesdk";
+} from "@dappnode/dappnodesdk/dist/exports";
 import { pick, omitBy, mapValues } from "lodash-es";
 
 /**

--- a/packages/dappmanager/src/modules/compose/networks.ts
+++ b/packages/dappmanager/src/modules/compose/networks.ts
@@ -1,7 +1,7 @@
 import {
   ComposeServiceNetworks,
   ComposeServiceNetworksObj
-} from "@dappnode/dappnodesdk";
+} from "@dappnode/dappnodesdk/dist/exports";
 
 /**
  * Parse service networks to object form

--- a/packages/dappmanager/src/modules/compose/setDappnodeComposeDefaults.ts
+++ b/packages/dappmanager/src/modules/compose/setDappnodeComposeDefaults.ts
@@ -1,5 +1,5 @@
 import { mapValues, toPairs, sortBy, fromPairs, pick } from "lodash-es";
-import params, { getImageTag, getContainerName } from "../../params.js";
+import params, { getContainerName } from "../../params.js";
 import { getIsCore } from "../manifest/getIsCore.js";
 import { cleanCompose } from "./clean.js";
 import { parseEnvironment } from "./environment.js";
@@ -11,7 +11,8 @@ import {
   ComposeService,
   ComposeServiceNetworks,
   ComposeNetworks,
-  composeSafeKeys
+  composeSafeKeys,
+  getImageTag
 } from "@dappnode/dappnodesdk/dist/exports";
 import { lt } from "semver";
 

--- a/packages/dappmanager/src/modules/compose/setDappnodeComposeDefaults.ts
+++ b/packages/dappmanager/src/modules/compose/setDappnodeComposeDefaults.ts
@@ -12,7 +12,7 @@ import {
   ComposeServiceNetworks,
   ComposeNetworks,
   composeSafeKeys
-} from "@dappnode/dappnodesdk";
+} from "@dappnode/dappnodesdk/dist/exports";
 import { lt } from "semver";
 
 /**

--- a/packages/dappmanager/src/modules/compose/specialPermissions.ts
+++ b/packages/dappmanager/src/modules/compose/specialPermissions.ts
@@ -1,5 +1,5 @@
 import { SpecialPermission } from "@dappnode/common";
-import { Compose } from "@dappnode/dappnodesdk";
+import { Compose } from "@dappnode/dappnodesdk/dist/exports";
 
 /**
  * Parses relevant settings in the compose that may be dangerous or grant

--- a/packages/dappmanager/src/modules/compose/userSettings.ts
+++ b/packages/dappmanager/src/modules/compose/userSettings.ts
@@ -9,7 +9,7 @@ import {
   getDevicePath
 } from "./index.js";
 import { PortMapping, UserSettings, VolumeMapping } from "@dappnode/common";
-import { Compose } from "@dappnode/dappnodesdk";
+import { Compose } from "@dappnode/dappnodesdk/dist/exports";
 import { cleanCompose, isOmitable } from "./clean.js";
 import { stringifyVolumeMappings } from "./volumes.js";
 import { readContainerLabels, writeDefaultsToLabels } from "./labelsDb.js";

--- a/packages/dappmanager/src/modules/compose/validate.ts
+++ b/packages/dappmanager/src/modules/compose/validate.ts
@@ -1,6 +1,6 @@
 import { getValidator } from "../../utils/schema.js";
 import compose3xSchema from "./compose_v3x.schema.json" assert { type: "json" };
-import { Compose } from "@dappnode/dappnodesdk";
+import { Compose } from "@dappnode/dappnodesdk/dist/exports";
 
 /**
  * Validates a compose 3.x not strictly

--- a/packages/dappmanager/src/modules/compose/verify.ts
+++ b/packages/dappmanager/src/modules/compose/verify.ts
@@ -1,5 +1,5 @@
 import { maxPortNumber } from "../../params.js";
-import { Compose } from "@dappnode/dappnodesdk";
+import { Compose } from "@dappnode/dappnodesdk/dist/exports";
 import { applyRecursivelyToStringValues } from "../../utils/objects.js";
 import { parsePortMappings } from "./ports.js";
 

--- a/packages/dappmanager/src/modules/dappGet/fetch/DappGetFetcher.ts
+++ b/packages/dappmanager/src/modules/dappGet/fetch/DappGetFetcher.ts
@@ -1,4 +1,4 @@
-import { Dependencies } from "@dappnode/dappnodesdk";
+import { Dependencies } from "@dappnode/dappnodesdk/dist/exports";
 import { validRange, satisfies, valid } from "semver";
 import { ReleaseFetcher } from "../../release/index.js";
 

--- a/packages/dappmanager/src/modules/dappGet/utils/dnpUtils.ts
+++ b/packages/dappmanager/src/modules/dappGet/utils/dnpUtils.ts
@@ -1,4 +1,4 @@
-import { Dependencies } from "@dappnode/dappnodesdk";
+import { Dependencies } from "@dappnode/dappnodesdk/dist/exports";
 import { DappGetDnps, DappGetDnp } from "../types.js";
 import { sanitizeDependencies } from "./sanitizeDependencies.js";
 

--- a/packages/dappmanager/src/modules/dappGet/utils/sanitizeDependencies.ts
+++ b/packages/dappmanager/src/modules/dappGet/utils/sanitizeDependencies.ts
@@ -1,4 +1,4 @@
-import { Dependencies } from "@dappnode/dappnodesdk";
+import { Dependencies } from "@dappnode/dappnodesdk/dist/exports";
 import { mapValues } from "lodash-es";
 
 /**

--- a/packages/dappmanager/src/modules/globalEnvs.ts
+++ b/packages/dappmanager/src/modules/globalEnvs.ts
@@ -3,7 +3,7 @@ import { mapKeys } from "lodash-es";
 import * as db from "../db/index.js";
 import params from "../params.js";
 import { stringifyEnvironment } from "../modules/compose/index.js";
-import { PackageEnvs } from "@dappnode/dappnodesdk";
+import { PackageEnvs } from "@dappnode/dappnodesdk/dist/exports";
 import { packageSetEnvironment } from "../calls/packageSetEnvironment.js";
 import { logs } from "../logs.js";
 import { ComposeFileEditor } from "./compose/editor.js";

--- a/packages/dappmanager/src/modules/installer/createVolumeDevicePaths.ts
+++ b/packages/dappmanager/src/modules/installer/createVolumeDevicePaths.ts
@@ -1,5 +1,5 @@
 import path from "path";
-import { Compose } from "@dappnode/dappnodesdk";
+import { Compose } from "@dappnode/dappnodesdk/dist/exports";
 import { logs } from "../../logs.js";
 import { uniq } from "lodash-es";
 import { shellHost } from "../../utils/shell.js";

--- a/packages/dappmanager/src/modules/manifest/getIsCore.ts
+++ b/packages/dappmanager/src/modules/manifest/getIsCore.ts
@@ -1,4 +1,4 @@
-import { Manifest } from "@dappnode/dappnodesdk";
+import { Manifest } from "@dappnode/dappnodesdk/dist/exports";
 
 export function getIsCore(manifest: Manifest): boolean {
   return manifest.type === "dncore";

--- a/packages/dappmanager/src/modules/manifest/manifestFile.ts
+++ b/packages/dappmanager/src/modules/manifest/manifestFile.ts
@@ -1,5 +1,5 @@
 import fs from "fs";
-import { Manifest } from "@dappnode/dappnodesdk";
+import { Manifest } from "@dappnode/dappnodesdk/dist/exports";
 import * as getPath from "../../utils/getPath.js";
 import * as validate from "../../utils/validate.js";
 import { isNotFoundError } from "../../utils/node.js";

--- a/packages/dappmanager/src/modules/manifest/manifestToCompose.ts
+++ b/packages/dappmanager/src/modules/manifest/manifestToCompose.ts
@@ -1,9 +1,13 @@
 import { pick } from "lodash-es";
 import { parseVolumeMappings } from "../compose/volumes.js";
 import { parseEnvironment } from "../compose/environment.js";
-import params, { getContainerName, getImageTag } from "../../params.js";
+import params, { getContainerName } from "../../params.js";
 import { ManifestWithImage } from "../../types.js";
-import { Compose, ComposeVolumes } from "@dappnode/dappnodesdk/dist/exports";
+import {
+  Compose,
+  ComposeVolumes,
+  getImageTag
+} from "@dappnode/dappnodesdk/dist/exports";
 import { getIsCore } from "./getIsCore.js";
 import { cleanCompose } from "../compose/clean.js";
 

--- a/packages/dappmanager/src/modules/manifest/manifestToCompose.ts
+++ b/packages/dappmanager/src/modules/manifest/manifestToCompose.ts
@@ -3,7 +3,7 @@ import { parseVolumeMappings } from "../compose/volumes.js";
 import { parseEnvironment } from "../compose/environment.js";
 import params, { getContainerName, getImageTag } from "../../params.js";
 import { ManifestWithImage } from "../../types.js";
-import { Compose, ComposeVolumes } from "@dappnode/dappnodesdk";
+import { Compose, ComposeVolumes } from "@dappnode/dappnodesdk/dist/exports";
 import { getIsCore } from "./getIsCore.js";
 import { cleanCompose } from "../compose/clean.js";
 

--- a/packages/dappmanager/src/modules/manifest/parseMetadataFromManifest.ts
+++ b/packages/dappmanager/src/modules/manifest/parseMetadataFromManifest.ts
@@ -1,7 +1,7 @@
 import { omit } from "lodash-es";
 import { setupWizard1To2 } from "../setupWizard/setupWizard1To2.js";
 import { ManifestWithImage } from "../../types.js";
-import { Manifest } from "@dappnode/dappnodesdk";
+import { Manifest } from "@dappnode/dappnodesdk/dist/exports";
 
 /**
  * Sanitize metadata from the manifest.

--- a/packages/dappmanager/src/modules/manifest/validate.ts
+++ b/packages/dappmanager/src/modules/manifest/validate.ts
@@ -1,7 +1,7 @@
 import { getValidator } from "../../utils/schema.js";
 import manifestBasicSchema from "./manifest-basic.schema.json" assert { type: "json" };
 import manifestWithImageSchema from "./manifest-with-image.schema.json" assert { type: "json" };
-import { Manifest } from "@dappnode/dappnodesdk";
+import { Manifest } from "@dappnode/dappnodesdk/dist/exports";
 import { ManifestWithImage } from "../../types.js";
 
 /**

--- a/packages/dappmanager/src/modules/migrations/addAliasToRunningContainers.ts
+++ b/packages/dappmanager/src/modules/migrations/addAliasToRunningContainers.ts
@@ -1,4 +1,7 @@
-import { ComposeNetwork, ComposeServiceNetwork } from "@dappnode/dappnodesdk";
+import {
+  ComposeNetwork,
+  ComposeServiceNetwork
+} from "@dappnode/dappnodesdk/dist/exports";
 import Dockerode from "dockerode";
 import { uniq } from "lodash-es";
 import { PackageContainer } from "@dappnode/common";

--- a/packages/dappmanager/src/modules/nsupdate/utils.ts
+++ b/packages/dappmanager/src/modules/nsupdate/utils.ts
@@ -1,6 +1,7 @@
 import { isEmpty } from "lodash-es";
 import { PackageContainer } from "@dappnode/common";
-import params, { getContainerDomain } from "../../params.js";
+import params from "../../params.js";
+import { getContainerDomain } from "@dappnode/dappnodesdk/dist/exports";
 import {
   getPrivateNetworkAlias,
   stripCharacters,

--- a/packages/dappmanager/src/modules/release/getImage.ts
+++ b/packages/dappmanager/src/modules/release/getImage.ts
@@ -4,7 +4,7 @@ import * as validate from "../../utils/validate.js";
 import verifyXz from "../../utils/verifyXz.js";
 import downloadImage from "./ipfs/downloadImage.js";
 import { DistributedFile } from "@dappnode/common";
-import { getImageTag } from "../../params.js";
+import { getImageTag } from "@dappnode/dappnodesdk/dist/exports";
 import { dockerImageManifest } from "../docker/cli.js";
 
 export default async function getImage(

--- a/packages/dappmanager/src/modules/release/getManifest.ts
+++ b/packages/dappmanager/src/modules/release/getManifest.ts
@@ -1,9 +1,8 @@
 import { ipfs, IPFSEntry } from "../ipfs/index.js";
 import { parseManifest, validateManifestBasic } from "../manifest/index.js";
-import { Manifest } from "@dappnode/dappnodesdk/dist/exports";
+import { Manifest, releaseFiles } from "@dappnode/dappnodesdk/dist/exports";
 import { isDirectoryRelease } from "./ipfs/isDirectoryRelease.js";
 import { IpfsClientTarget } from "@dappnode/common";
-import { releaseFiles } from "../../params.js";
 
 export async function getManifest(contentUri: string): Promise<Manifest> {
   let data: string;

--- a/packages/dappmanager/src/modules/release/getManifest.ts
+++ b/packages/dappmanager/src/modules/release/getManifest.ts
@@ -1,6 +1,6 @@
 import { ipfs, IPFSEntry } from "../ipfs/index.js";
 import { parseManifest, validateManifestBasic } from "../manifest/index.js";
-import { Manifest } from "@dappnode/dappnodesdk";
+import { Manifest } from "@dappnode/dappnodesdk/dist/exports";
 import { isDirectoryRelease } from "./ipfs/isDirectoryRelease.js";
 import { IpfsClientTarget } from "@dappnode/common";
 import { releaseFiles } from "../../params.js";

--- a/packages/dappmanager/src/modules/release/index.ts
+++ b/packages/dappmanager/src/modules/release/index.ts
@@ -4,7 +4,7 @@ import { getManifest } from "./getManifest.js";
 import { PackageRequest } from "../../types.js";
 import dappGet, { DappgetOptions } from "../dappGet/index.js";
 import { Apm } from "../apm/index.js";
-import { Manifest } from "@dappnode/dappnodesdk";
+import { Manifest } from "@dappnode/dappnodesdk/dist/exports";
 import { DappGetState } from "../dappGet/types.js";
 import { PackageRelease } from "@dappnode/common";
 

--- a/packages/dappmanager/src/modules/release/ipfs/downloadDirectoryFiles.ts
+++ b/packages/dappmanager/src/modules/release/ipfs/downloadDirectoryFiles.ts
@@ -1,6 +1,6 @@
 import { mapValues } from "lodash-es";
 import { ReleaseSignature } from "../../../types.js";
-import { Compose, Manifest } from "@dappnode/dappnodesdk";
+import { Compose, Manifest } from "@dappnode/dappnodesdk/dist/exports";
 import { findEntries } from "./findEntries.js";
 import { downloadAsset } from "./downloadAssets.js";
 import { IPFSEntry } from "ipfs-core-types/src/root";

--- a/packages/dappmanager/src/modules/release/ipfs/downloadRelease.ts
+++ b/packages/dappmanager/src/modules/release/ipfs/downloadRelease.ts
@@ -21,7 +21,7 @@ import {
   validateDappnodeCompose,
   validateManifestSchema,
   validateSetupWizardSchema
-} from "@dappnode/dappnodesdk";
+} from "@dappnode/dappnodesdk/dist/exports";
 import { getIsCore } from "../../manifest/getIsCore.js";
 import { DistributedFile } from "@dappnode/common";
 

--- a/packages/dappmanager/src/modules/release/ipfs/downloadRelease.ts
+++ b/packages/dappmanager/src/modules/release/ipfs/downloadRelease.ts
@@ -11,7 +11,6 @@ import { NoImageForArchError } from "../errors.js";
 import { downloadDirectoryFiles } from "./downloadDirectoryFiles.js";
 import { getImageByArch } from "./getImageByArch.js";
 import { findEntries } from "./findEntries.js";
-import { releaseFiles } from "../../../params.js";
 import { downloadAssetRequired } from "./downloadAssets.js";
 import { isDirectoryRelease } from "./isDirectoryRelease.js";
 import { serializeIpfsDirectory } from "../releaseSignature.js";
@@ -20,6 +19,7 @@ import {
   Manifest,
   validateDappnodeCompose,
   validateManifestSchema,
+  releaseFiles,
   validateSetupWizardSchema
 } from "@dappnode/dappnodesdk/dist/exports";
 import { getIsCore } from "../../manifest/getIsCore.js";

--- a/packages/dappmanager/src/modules/release/ipfs/findEntries.ts
+++ b/packages/dappmanager/src/modules/release/ipfs/findEntries.ts
@@ -1,4 +1,4 @@
-import { releaseFiles } from "../../../params.js";
+import { releaseFiles } from "@dappnode/dappnodesdk/dist/exports";
 import { FileConfig, IPFSEntryName } from "../types.js";
 
 type ReleaseFiles = typeof releaseFiles;

--- a/packages/dappmanager/src/modules/release/ipfs/getImageByArch.ts
+++ b/packages/dappmanager/src/modules/release/ipfs/getImageByArch.ts
@@ -1,5 +1,9 @@
 import { NodeArch } from "../../../types.js";
-import { Manifest, Architecture, defaultArch } from "@dappnode/dappnodesdk";
+import {
+  Manifest,
+  Architecture,
+  defaultArch
+} from "@dappnode/dappnodesdk/dist/exports";
 import { NoImageForArchError } from "../errors.js";
 import { getImagePath, getLegacyImagePath } from "../../../params.js";
 import { IPFSEntryName } from "../types.js";

--- a/packages/dappmanager/src/modules/release/ipfs/getImageByArch.ts
+++ b/packages/dappmanager/src/modules/release/ipfs/getImageByArch.ts
@@ -2,10 +2,11 @@ import { NodeArch } from "../../../types.js";
 import {
   Manifest,
   Architecture,
-  defaultArch
+  defaultArch,
+  getImagePath,
+  getLegacyImagePath
 } from "@dappnode/dappnodesdk/dist/exports";
 import { NoImageForArchError } from "../errors.js";
-import { getImagePath, getLegacyImagePath } from "../../../params.js";
 import { IPFSEntryName } from "../types.js";
 
 export function getImageByArch<T extends IPFSEntryName>(

--- a/packages/dappmanager/src/modules/release/ipfs/isDirectoryRelease.ts
+++ b/packages/dappmanager/src/modules/release/ipfs/isDirectoryRelease.ts
@@ -1,4 +1,4 @@
-import { releaseFiles } from "../../../params.js";
+import { releaseFiles } from "@dappnode/dappnodesdk/dist/exports";
 import { IPFSEntry } from "ipfs-core-types/src/root";
 
 /**

--- a/packages/dappmanager/src/modules/release/ipfs/params.ts
+++ b/packages/dappmanager/src/modules/release/ipfs/params.ts
@@ -6,10 +6,10 @@ import {
   SetupTarget,
   SetupUiJson,
   Manifest,
-  Compose
+  Compose,
+  releaseFiles
 } from "@dappnode/dappnodesdk/dist/exports";
 import { ReleaseSignature } from "../../../types.js";
-import { releaseFiles } from "../../../params.js";
 import { validateManifestBasic } from "../../manifest/index.js";
 import { validateCompose } from "../../compose/index.js";
 

--- a/packages/dappmanager/src/modules/release/ipfs/params.ts
+++ b/packages/dappmanager/src/modules/release/ipfs/params.ts
@@ -5,13 +5,13 @@ import {
   PrometheusTarget,
   SetupTarget,
   SetupUiJson,
-  Manifest
-} from "@dappnode/dappnodesdk";
+  Manifest,
+  Compose
+} from "@dappnode/dappnodesdk/dist/exports";
 import { ReleaseSignature } from "../../../types.js";
 import { releaseFiles } from "../../../params.js";
 import { validateManifestBasic } from "../../manifest/index.js";
 import { validateCompose } from "../../compose/index.js";
-import { Compose } from "@dappnode/dappnodesdk";
 
 // Re-declare releaseFilesToDownload to prevent downloading un-wanted assets
 // that may be added in the future

--- a/packages/dappmanager/src/modules/release/releaseSignature.ts
+++ b/packages/dappmanager/src/modules/release/releaseSignature.ts
@@ -3,7 +3,6 @@ import { base58btc } from "multiformats/bases/base58";
 import { base32 } from "multiformats/bases/base32";
 import { base64, base64url } from "multiformats/bases/base64";
 import { ReleaseSignature } from "../../types.js";
-import { releaseFiles } from "../../params.js";
 import { ReleaseSignatureWithData } from "./types.js";
 import { IPFSEntry } from "../ipfs/index.js";
 import {
@@ -13,6 +12,7 @@ import {
   ReleaseSignatureProtocol
 } from "@dappnode/common";
 import { CID } from "ipfs-http-client";
+import { releaseFiles } from "@dappnode/dappnodesdk/dist/exports";
 
 export function getReleaseSignatureStatus(
   dnpName: string,

--- a/packages/dappmanager/src/modules/release/types.ts
+++ b/packages/dappmanager/src/modules/release/types.ts
@@ -1,7 +1,7 @@
 import { DistributedFile } from "@dappnode/common";
 import { ReleaseSignature } from "../../types.js";
 import { FileFormat } from "../../types.js";
-import { Manifest, Compose } from "@dappnode/dappnodesdk";
+import { Manifest, Compose } from "@dappnode/dappnodesdk/dist/exports";
 import { IPFSEntry } from "ipfs-core-types/src/root";
 
 export interface FileConfig {

--- a/packages/dappmanager/src/modules/setupWizard/setupWizard1To2.ts
+++ b/packages/dappmanager/src/modules/setupWizard/setupWizard1To2.ts
@@ -6,7 +6,7 @@ import {
   SetupWizardField,
   SetupUiJson,
   SetupTarget
-} from "@dappnode/dappnodesdk";
+} from "@dappnode/dappnodesdk/dist/exports";
 
 /**
  * Format setup wizard v1 files as a unique setup wizard v2 object

--- a/packages/dappmanager/src/modules/stakerConfig/utils.ts
+++ b/packages/dappmanager/src/modules/stakerConfig/utils.ts
@@ -12,7 +12,7 @@ import { packageSetEnvironment } from "../../calls/index.js";
 import { logs } from "../../logs.js";
 import { dockerContainerStop } from "../docker/index.js";
 import { pick } from "lodash-es";
-import { Manifest } from "@dappnode/dappnodesdk";
+import { Manifest } from "@dappnode/dappnodesdk/dist/exports";
 import { ReleaseFetcher } from "../release/index.js";
 import { eventBus } from "../../eventBus.js";
 

--- a/packages/dappmanager/src/params.ts
+++ b/packages/dappmanager/src/params.ts
@@ -1,6 +1,6 @@
 import path from "path";
 import { FileFormat } from "./types.js";
-import { Architecture } from "@dappnode/dappnodesdk";
+import { Architecture } from "@dappnode/dappnodesdk/dist/exports";
 import { EthClientTargetPackage, UserSettings } from "@dappnode/common";
 
 const devMode = process.env.LOG_LEVEL === "DEV_MODE";

--- a/packages/dappmanager/src/params.ts
+++ b/packages/dappmanager/src/params.ts
@@ -1,6 +1,5 @@
 import path from "path";
-import { FileFormat } from "./types.js";
-import { Architecture } from "@dappnode/dappnodesdk/dist/exports";
+import { getContainerDomain } from "@dappnode/dappnodesdk/dist/exports";
 import { EthClientTargetPackage, UserSettings } from "@dappnode/common";
 
 const devMode = process.env.LOG_LEVEL === "DEV_MODE";
@@ -359,33 +358,6 @@ export const ethClientData: {
 
 // Naming
 
-/**
- * Get a unique domain per container, considering multi-service packages
- */
-export const getContainerDomain = ({
-  dnpName,
-  serviceName
-}: {
-  serviceName: string;
-  dnpName: string;
-}): string => {
-  if (!serviceName || serviceName === dnpName) {
-    return dnpName;
-  } else {
-    return [serviceName, dnpName].join(".");
-  }
-};
-
-export const getImageTag = ({
-  dnpName,
-  serviceName,
-  version
-}: {
-  dnpName: string;
-  serviceName: string;
-  version: string;
-}): string => [getContainerDomain({ dnpName, serviceName }), version].join(":");
-
 export const getContainerName = ({
   dnpName,
   serviceName,
@@ -400,103 +372,3 @@ export const getContainerName = ({
     isCore ? params.CONTAINER_CORE_NAME_PREFIX : params.CONTAINER_NAME_PREFIX,
     getContainerDomain({ dnpName, serviceName })
   ].join("");
-
-// From SDK, must be in sync
-
-export const releaseFiles = {
-  manifest: {
-    regex: /dappnode_package.*\.(json|yaml|yml)$/,
-    format: FileFormat.YAML,
-    maxSize: 100e3, // Limit size to ~100KB
-    required: true as const,
-    multiple: false as const
-  },
-  compose: {
-    regex: /compose.*\.yml$/,
-    format: FileFormat.YAML,
-    maxSize: 10e3, // Limit size to ~10KB
-    required: true as const,
-    multiple: false as const
-  },
-  signature: {
-    regex: /^signature\.json$/,
-    format: FileFormat.JSON,
-    maxSize: 10e3, // Limit size to ~10KB
-    required: false as const,
-    multiple: false as const
-  },
-  avatar: {
-    regex: /avatar.*\.png$/,
-    format: null,
-    maxSize: 100e3,
-    required: true as const,
-    multiple: false as const
-  },
-  setupWizard: {
-    regex: /setup-wizard\..*(json|yaml|yml)$/,
-    format: FileFormat.YAML,
-    maxSize: 100e3,
-    required: false as const,
-    multiple: false as const
-  },
-  setupSchema: {
-    regex: /setup\..*\.json$/,
-    format: FileFormat.JSON,
-    maxSize: 10e3,
-    required: false as const,
-    multiple: false as const
-  },
-  setupTarget: {
-    regex: /setup-target\..*json$/,
-    format: FileFormat.JSON,
-    maxSize: 10e3,
-    required: false as const,
-    multiple: false as const
-  },
-  setupUiJson: {
-    regex: /setup-ui\..*json$/,
-    format: FileFormat.JSON,
-    maxSize: 10e3,
-    required: false as const,
-    multiple: false as const
-  },
-  disclaimer: {
-    regex: /disclaimer\.md$/i,
-    format: FileFormat.TEXT,
-    maxSize: 100e3,
-    required: false as const,
-    multiple: false as const
-  },
-  gettingStarted: {
-    regex: /getting.*started\.md$/i,
-    format: FileFormat.TEXT,
-    maxSize: 100e3,
-    required: false as const,
-    multiple: false as const
-  },
-  prometheusTargets: {
-    regex: /.*prometheus-targets.(json|yaml|yml)$/,
-    format: FileFormat.YAML,
-    maxSize: 10e3,
-    required: false as const,
-    multiple: false as const
-  },
-  grafanaDashboards: {
-    regex: /.*grafana-dashboard.json$/,
-    format: FileFormat.JSON,
-    maxSize: 10e6, // ~ 10MB
-    required: false as const,
-    multiple: true as const
-  }
-};
-
-// Single arch images
-export const getArchTag = (arch: Architecture): string =>
-  arch.replace(/\//g, "-");
-export const getImagePath = (
-  dnpName: string,
-  version: string,
-  arch: Architecture
-): string => `${dnpName}_${version}_${getArchTag(arch)}.txz`;
-export const getLegacyImagePath = (dnpName: string, version: string): string =>
-  `${dnpName}_${version}.tar.xz`;

--- a/packages/dappmanager/src/types.ts
+++ b/packages/dappmanager/src/types.ts
@@ -1,4 +1,8 @@
-import { ChainDriver, Dependencies, Manifest } from "@dappnode/dappnodesdk";
+import {
+  ChainDriver,
+  Dependencies,
+  Manifest
+} from "@dappnode/dappnodesdk/dist/types";
 import {
   ExecutionClientMainnet,
   ReleaseSignatureProtocol

--- a/packages/dappmanager/src/utils/pid.ts
+++ b/packages/dappmanager/src/utils/pid.ts
@@ -1,4 +1,4 @@
-import { Compose } from "@dappnode/dappnodesdk";
+import { Compose } from "@dappnode/dappnodesdk/dist/exports";
 import { ComposeServicesSharingPid } from "../types.js";
 import { InstallPackageData, PackageContainer } from "@dappnode/common";
 

--- a/packages/dappmanager/src/utils/validateBackupArray.ts
+++ b/packages/dappmanager/src/utils/validateBackupArray.ts
@@ -1,4 +1,4 @@
-import { PackageBackup } from "@dappnode/dappnodesdk";
+import { PackageBackup } from "@dappnode/dappnodesdk/dist/exports";
 import path from "path";
 
 /**

--- a/packages/dappmanager/test/integration/dnpLifecycle.test.int.ts
+++ b/packages/dappmanager/test/integration/dnpLifecycle.test.int.ts
@@ -1,7 +1,11 @@
 import "mocha";
 import { expect } from "chai";
 import path from "path";
-import { Compose, Manifest, PackageEnvs } from "@dappnode/dappnodesdk";
+import {
+  Compose,
+  Manifest,
+  PackageEnvs
+} from "@dappnode/dappnodesdk/dist/exports";
 import { mapValues, pick } from "lodash-es";
 import * as calls from "../../src/calls/index.js";
 import params from "../../src/params.js";

--- a/packages/dappmanager/test/integration/fetchRelease.test.int.ts
+++ b/packages/dappmanager/test/integration/fetchRelease.test.int.ts
@@ -2,7 +2,7 @@ import "mocha";
 import { expect } from "chai";
 import path from "path";
 import { omit } from "lodash-es";
-import { Manifest, SetupWizard } from "@dappnode/dappnodesdk";
+import { Manifest, SetupWizard } from "@dappnode/dappnodesdk/dist/exports";
 import * as calls from "../../src/calls/index.js";
 import { ManifestWithImage } from "../../src/types.js";
 import {

--- a/packages/dappmanager/test/integration/integrationSpecs/buildReleaseDirectory.ts
+++ b/packages/dappmanager/test/integration/integrationSpecs/buildReleaseDirectory.ts
@@ -11,7 +11,7 @@ import {
   Compose,
   SetupWizard,
   ComposeService
-} from "@dappnode/dappnodesdk";
+} from "@dappnode/dappnodesdk/dist/exports";
 import { testDir, manifestFileName, composeFileName } from "../../testUtils.js";
 import { ipfsAddAll } from "../testIpfsUtils.js";
 import { saveNewImageToDisk } from "./mockImage.js";

--- a/packages/dappmanager/test/integration/signedRelease.test.int.ts
+++ b/packages/dappmanager/test/integration/signedRelease.test.int.ts
@@ -5,7 +5,7 @@ import { ipfs } from "../../src/modules/ipfs/index.js";
 import { ReleaseFetcher } from "../../src/modules/release/index.js";
 import { getContainerName, getImageTag } from "../../src/params.js";
 import { ReleaseSignatureStatusCode } from "@dappnode/common";
-import { Manifest } from "@dappnode/dappnodesdk";
+import { Manifest } from "@dappnode/dappnodesdk/dist/exports";
 import { uploadDirectoryRelease } from "./integrationSpecs/index.js";
 import { signRelease } from "./integrationSpecs/signRelease.js";
 

--- a/packages/dappmanager/test/integration/testIpfsUtils.ts
+++ b/packages/dappmanager/test/integration/testIpfsUtils.ts
@@ -5,7 +5,7 @@ import { AddResult } from "ipfs-core-types/src/root";
 import { sleep } from "../../src/utils/asyncFlows.js";
 import all from "it-all";
 import shell from "../../src/utils/shell.js";
-import { Manifest } from "@dappnode/dappnodesdk";
+import { Manifest } from "@dappnode/dappnodesdk/dist/exports";
 
 const ipfsRemoteUrl = "https://api.ipfs.dappnode.io";
 const ipfsTestContainerName = "dappnode_ipfs_host";

--- a/packages/dappmanager/test/testUtils.ts
+++ b/packages/dappmanager/test/testUtils.ts
@@ -5,7 +5,7 @@ import { clearCacheDb, clearMainDb } from "../src/db/index.js";
 import { ManifestWithImage } from "../src/types.js";
 import { DockerApiSystemDfReturn } from "../src/modules/docker/api/index.js";
 import params from "../src/params.js";
-import { Compose, Manifest } from "@dappnode/dappnodesdk";
+import { Compose, Manifest } from "@dappnode/dappnodesdk/dist/exports";
 import {
   PackageContainer,
   InstalledPackageData,

--- a/packages/dappmanager/test/unit/calls/packageInstall.test.ts
+++ b/packages/dappmanager/test/unit/calls/packageInstall.test.ts
@@ -9,7 +9,7 @@ import { packageInstall as packageInstallType } from "../../../src/calls/package
 import { DappGetState } from "../../../src/modules/dappGet/types.js";
 import { mockManifest, mockRelease } from "../../testUtils.js";
 import { ReleaseFetcher } from "../../../src/modules/release/index.js";
-import { Manifest } from "@dappnode/dappnodesdk";
+import { Manifest } from "@dappnode/dappnodesdk/dist/exports";
 import { PackageRequest } from "../../../src/types.js";
 
 describe.skip("Call function: packageInstall", function () {

--- a/packages/dappmanager/test/unit/modules/compose/composeSpecs.test.ts
+++ b/packages/dappmanager/test/unit/modules/compose/composeSpecs.test.ts
@@ -2,7 +2,7 @@ import "mocha";
 import { expect } from "chai";
 import fs from "fs";
 import path from "path";
-import { Manifest, Compose } from "@dappnode/dappnodesdk";
+import { Manifest, Compose } from "@dappnode/dappnodesdk/dist/exports";
 import { yamlParse, yamlDump } from "../../../../src/utils/yaml.js";
 import {
   setDappnodeComposeDefaults,

--- a/packages/dappmanager/test/unit/modules/compose/editor/composeAliases.test.ts
+++ b/packages/dappmanager/test/unit/modules/compose/editor/composeAliases.test.ts
@@ -8,7 +8,7 @@ import params from "../../../../../src/params.js";
 import { shellSafe } from "../../../../testUtils.js";
 import fs from "fs";
 import { parseServiceNetworks } from "../../../../../src/modules/compose/networks.js";
-import { ComposeServiceNetwork } from "@dappnode/dappnodesdk";
+import { ComposeServiceNetwork } from "@dappnode/dappnodesdk/dist/exports";
 
 describe("compose service editor", () => {
   const exampleCompose = `

--- a/packages/dappmanager/test/unit/modules/compose/setDappnodeComposeDefaults.test.ts
+++ b/packages/dappmanager/test/unit/modules/compose/setDappnodeComposeDefaults.test.ts
@@ -4,7 +4,7 @@ import {
   Compose,
   Manifest,
   validateDappnodeCompose
-} from "@dappnode/dappnodesdk";
+} from "@dappnode/dappnodesdk/dist/exports";
 import { setDappnodeComposeDefaults } from "../../../../src/modules/compose/setDappnodeComposeDefaults.js";
 
 describe("setDappnodeComposeDefaults", () => {

--- a/packages/dappmanager/test/unit/modules/compose/specialPermissions.test.ts
+++ b/packages/dappmanager/test/unit/modules/compose/specialPermissions.test.ts
@@ -3,7 +3,7 @@ import { expect } from "chai";
 import { mapValues } from "lodash-es";
 import { parseSpecialPermissions } from "../../../../src/modules/compose/specialPermissions.js";
 import { mockCompose } from "../../../testUtils.js";
-import { Compose } from "@dappnode/dappnodesdk";
+import { Compose } from "@dappnode/dappnodesdk/dist/exports";
 
 describe("Modules > compose", () => {
   describe("parseSpecialPermissions", () => {

--- a/packages/dappmanager/test/unit/modules/compose/userSettings.test.ts
+++ b/packages/dappmanager/test/unit/modules/compose/userSettings.test.ts
@@ -1,7 +1,7 @@
 import "mocha";
 import { expect } from "chai";
 import { pick } from "lodash-es";
-import { Compose, ComposeService } from "@dappnode/dappnodesdk";
+import { Compose, ComposeService } from "@dappnode/dappnodesdk/dist/exports";
 import { UserSettings } from "@dappnode/common";
 import {
   parseUserSettings,

--- a/packages/dappmanager/test/unit/modules/compose/validate.test.ts
+++ b/packages/dappmanager/test/unit/modules/compose/validate.test.ts
@@ -1,7 +1,7 @@
 import "mocha";
 import { expect } from "chai";
 import { mockCompose } from "../../../testUtils.js";
-import { Compose } from "@dappnode/dappnodesdk";
+import { Compose } from "@dappnode/dappnodesdk/dist/exports";
 import { validateCompose } from "../../../../src/modules/compose/index.js";
 
 describe("validateCompose", () => {

--- a/packages/dappmanager/test/unit/modules/compose/verify.test.ts
+++ b/packages/dappmanager/test/unit/modules/compose/verify.test.ts
@@ -1,6 +1,6 @@
 import "mocha";
 import { expect } from "chai";
-import { Compose, ComposeService } from "@dappnode/dappnodesdk";
+import { Compose, ComposeService } from "@dappnode/dappnodesdk/dist/exports";
 import { verifyCompose } from "../../../../src/modules/compose/index.js";
 
 describe("verify compose", () => {

--- a/packages/dappmanager/test/unit/modules/dappGet/testHelpers.ts
+++ b/packages/dappmanager/test/unit/modules/dappGet/testHelpers.ts
@@ -6,7 +6,7 @@ import {
   DappGetState,
   DappGetDnps
 } from "../../../../src/modules/dappGet/types.js";
-import { Dependencies } from "@dappnode/dappnodesdk";
+import { Dependencies } from "@dappnode/dappnodesdk/dist/exports";
 
 export interface DappgetTestCase {
   // Data for test

--- a/packages/dappmanager/test/unit/modules/installer/createVolumeDevicePaths.test.ts
+++ b/packages/dappmanager/test/unit/modules/installer/createVolumeDevicePaths.test.ts
@@ -1,6 +1,6 @@
 import "mocha";
 import { expect } from "chai";
-import { Compose } from "@dappnode/dappnodesdk";
+import { Compose } from "@dappnode/dappnodesdk/dist/exports";
 import { getVolumeDevicePaths } from "../../../../src/modules/installer/createVolumeDevicePaths.js";
 
 describe("Module > installer > createVolumeDevicePaths", () => {

--- a/packages/dappmanager/test/unit/modules/manifest/manifestToCompose.test.ts
+++ b/packages/dappmanager/test/unit/modules/manifest/manifestToCompose.test.ts
@@ -1,7 +1,7 @@
 import "mocha";
 import { expect } from "chai";
 import { ManifestWithImage } from "../../../../src/types.js";
-import { Compose } from "@dappnode/dappnodesdk";
+import { Compose } from "@dappnode/dappnodesdk/dist/exports";
 import { mockManifestWithImage, mockCompose } from "../../../testUtils.js";
 import { manifestToCompose } from "../../../../src/modules/manifest/index.js";
 import { ComposeEditor } from "../../../../src/modules/compose/editor.js";

--- a/packages/dappmanager/test/unit/modules/manifest/parseMetadataFromManifest.test.ts
+++ b/packages/dappmanager/test/unit/modules/manifest/parseMetadataFromManifest.test.ts
@@ -1,6 +1,6 @@
 import "mocha";
 import { expect } from "chai";
-import { Manifest } from "@dappnode/dappnodesdk";
+import { Manifest } from "@dappnode/dappnodesdk/dist/exports";
 import { parseMetadataFromManifest } from "../../../../src/modules/manifest/index.js";
 
 describe("parseMetadataFromManifest", () => {

--- a/packages/dappmanager/test/unit/modules/manifest/validate.test.ts
+++ b/packages/dappmanager/test/unit/modules/manifest/validate.test.ts
@@ -2,7 +2,7 @@ import "mocha";
 import { expect } from "chai";
 import { mockManifest, mockManifestWithImage } from "../../../testUtils.js";
 import { ManifestWithImage } from "../../../../src/types.js";
-import { Manifest } from "@dappnode/dappnodesdk";
+import { Manifest } from "@dappnode/dappnodesdk/dist/exports";
 import {
   validateManifestBasic,
   validateManifestWithImage

--- a/packages/dappmanager/test/unit/modules/setupWizard/setupWizardParsers.test.ts
+++ b/packages/dappmanager/test/unit/modules/setupWizard/setupWizardParsers.test.ts
@@ -4,7 +4,7 @@ import {
   SetupSchema,
   SetupUiJson,
   SetupTarget
-} from "@dappnode/dappnodesdk";
+} from "@dappnode/dappnodesdk/dist/exports";
 import { expect } from "chai";
 import fs from "fs";
 import path from "path";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1238,10 +1238,10 @@
   resolved "https://registry.yarnpkg.com/@csstools/selector-specificity/-/selector-specificity-2.0.2.tgz#1bfafe4b7ed0f3e4105837e056e0a89b108ebe36"
   integrity sha512-IkpVW/ehM1hWKln4fCA3NzJU8KwD+kIOvPZA4cqxoJHtE21CCzjyp+Kxbu0i5I4tBNOlXPL9mjwnWlL0VEG4Fg==
 
-"@dappnode/dappnodesdk@^0.2.71":
-  version "0.2.71"
-  resolved "https://registry.yarnpkg.com/@dappnode/dappnodesdk/-/dappnodesdk-0.2.71.tgz#2d65bc3a088ee8a80da774a70d80707c4a237bc7"
-  integrity sha512-bfk3EWM8hwx7PZWFF73Gqpd4pJioHRC66Urt6ZEYOL9RdBuNxe79ZjNr8taS8mabz3I46Fj1faaQXNPjY0ylwA==
+"@dappnode/dappnodesdk@^0.2.82":
+  version "0.2.82"
+  resolved "https://registry.yarnpkg.com/@dappnode/dappnodesdk/-/dappnodesdk-0.2.82.tgz#27672e471c05e28fdf87f8c50fa04def9fd95543"
+  integrity sha512-4zJOsSMEOKkJjAVw5oUzJn58zMQGQ0XtYKRU9SrxQPNZw6xpV3l4rzDMN0hBC7lSYG3GMHttJ7tpZpHFUeNXsQ==
   dependencies:
     "@octokit/rest" "^18.0.12"
     ajv "^8.11.0"
@@ -1258,7 +1258,7 @@
     inquirer "^6.2.1"
     js-yaml "^3.12.1"
     listr "^0.14.3"
-    lodash "^4.17.20"
+    lodash-es "^4.17.21"
     mime-types "^2.1.24"
     moment "^2.27.0"
     prettier "^2.1.2"
@@ -1286,6 +1286,18 @@
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
   integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
+
+"@eslint-community/eslint-utils@^4.2.0":
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz#a23514e8fb9af1269d5f7788aa556798d61c6b59"
+  integrity sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==
+  dependencies:
+    eslint-visitor-keys "^3.3.0"
+
+"@eslint-community/regexpp@^4.4.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.5.0.tgz#f6f729b02feee2c749f57e334b7a1b5f40a81724"
+  integrity sha512-vITaYzIcNmjn5tF5uxcZ/ft7/RXGrMUIS9HalWckEOF6ESiwXKoMzAQf2UW0aVd6rnOeExTJVd5hmWXucBKGXQ==
 
 "@eslint/eslintrc@^0.4.3":
   version "0.4.3"
@@ -3945,7 +3957,7 @@
   resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-3.12.7.tgz#330c5d97a3500e9c903210d6e49f02964af04a0e"
   integrity sha512-S6+8JAYTE1qdsc9HMVsfY7+SgSuUU/Tp6TYTmITW0PZxiyIMvol3Gy//y69Wkhs0ti4py5qgR3uZH6uz/DNzJQ==
 
-"@types/json-schema@*", "@types/json-schema@^7.0.4", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.7", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
+"@types/json-schema@*", "@types/json-schema@^7.0.4", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
   version "7.0.11"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
   integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
@@ -4354,20 +4366,6 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@^4.30.0":
-  version "4.33.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz#c24dc7c8069c7706bc40d99f6fa87edcb2005276"
-  integrity sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==
-  dependencies:
-    "@typescript-eslint/experimental-utils" "4.33.0"
-    "@typescript-eslint/scope-manager" "4.33.0"
-    debug "^4.3.1"
-    functional-red-black-tree "^1.0.1"
-    ignore "^5.1.8"
-    regexpp "^3.1.0"
-    semver "^7.3.5"
-    tsutils "^3.21.0"
-
 "@typescript-eslint/eslint-plugin@^5.5.0":
   version "5.47.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.47.1.tgz#50cc5085578a7fa22cd46a0806c2e5eae858af02"
@@ -4383,17 +4381,21 @@
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/experimental-utils@4.33.0":
-  version "4.33.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.33.0.tgz#6f2a786a4209fa2222989e9380b5331b2810f7fd"
-  integrity sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==
+"@typescript-eslint/eslint-plugin@^5.57.0":
+  version "5.57.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.57.0.tgz#52c8a7a4512f10e7249ca1e2e61f81c62c34365c"
+  integrity sha512-itag0qpN6q2UMM6Xgk6xoHa0D0/P+M17THnr4SVgqn9Rgam5k/He33MA7/D7QoJcdMxHFyX7U9imaBonAX/6qA==
   dependencies:
-    "@types/json-schema" "^7.0.7"
-    "@typescript-eslint/scope-manager" "4.33.0"
-    "@typescript-eslint/types" "4.33.0"
-    "@typescript-eslint/typescript-estree" "4.33.0"
-    eslint-scope "^5.1.1"
-    eslint-utils "^3.0.0"
+    "@eslint-community/regexpp" "^4.4.0"
+    "@typescript-eslint/scope-manager" "5.57.0"
+    "@typescript-eslint/type-utils" "5.57.0"
+    "@typescript-eslint/utils" "5.57.0"
+    debug "^4.3.4"
+    grapheme-splitter "^1.0.4"
+    ignore "^5.2.0"
+    natural-compare-lite "^1.4.0"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
 
 "@typescript-eslint/experimental-utils@^5.0.0":
   version "5.47.1"
@@ -4401,16 +4403,6 @@
   integrity sha512-zWHo/VbqAiRvhXP5byQqW7rGQtdanajHnItGqtmv8JaIi58zMPnmGZ1bW/drXIjU1fuOyfTVoDkNS7aEWGDSLg==
   dependencies:
     "@typescript-eslint/utils" "5.47.1"
-
-"@typescript-eslint/parser@^4.30.0":
-  version "4.33.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.33.0.tgz#dfe797570d9694e560528d18eecad86c8c744899"
-  integrity sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==
-  dependencies:
-    "@typescript-eslint/scope-manager" "4.33.0"
-    "@typescript-eslint/types" "4.33.0"
-    "@typescript-eslint/typescript-estree" "4.33.0"
-    debug "^4.3.1"
 
 "@typescript-eslint/parser@^5.5.0":
   version "5.47.1"
@@ -4422,13 +4414,15 @@
     "@typescript-eslint/typescript-estree" "5.47.1"
     debug "^4.3.4"
 
-"@typescript-eslint/scope-manager@4.33.0":
-  version "4.33.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz#d38e49280d983e8772e29121cf8c6e9221f280a3"
-  integrity sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==
+"@typescript-eslint/parser@^5.57.0":
+  version "5.57.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.57.0.tgz#f675bf2cd1a838949fd0de5683834417b757e4fa"
+  integrity sha512-orrduvpWYkgLCyAdNtR1QIWovcNZlEm6yL8nwH/eTxWLd8gsP+25pdLHYzL2QdkqrieaDwLpytHqycncv0woUQ==
   dependencies:
-    "@typescript-eslint/types" "4.33.0"
-    "@typescript-eslint/visitor-keys" "4.33.0"
+    "@typescript-eslint/scope-manager" "5.57.0"
+    "@typescript-eslint/types" "5.57.0"
+    "@typescript-eslint/typescript-estree" "5.57.0"
+    debug "^4.3.4"
 
 "@typescript-eslint/scope-manager@5.47.1":
   version "5.47.1"
@@ -4437,6 +4431,14 @@
   dependencies:
     "@typescript-eslint/types" "5.47.1"
     "@typescript-eslint/visitor-keys" "5.47.1"
+
+"@typescript-eslint/scope-manager@5.57.0":
+  version "5.57.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.57.0.tgz#79ccd3fa7bde0758059172d44239e871e087ea36"
+  integrity sha512-NANBNOQvllPlizl9LatX8+MHi7bx7WGIWYjPHDmQe5Si/0YEYfxSljJpoTyTWFTgRy3X8gLYSE4xQ2U+aCozSw==
+  dependencies:
+    "@typescript-eslint/types" "5.57.0"
+    "@typescript-eslint/visitor-keys" "5.57.0"
 
 "@typescript-eslint/type-utils@5.47.1":
   version "5.47.1"
@@ -4448,28 +4450,25 @@
     debug "^4.3.4"
     tsutils "^3.21.0"
 
-"@typescript-eslint/types@4.33.0":
-  version "4.33.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.33.0.tgz#a1e59036a3b53ae8430ceebf2a919dc7f9af6d72"
-  integrity sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==
+"@typescript-eslint/type-utils@5.57.0":
+  version "5.57.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.57.0.tgz#98e7531c4e927855d45bd362de922a619b4319f2"
+  integrity sha512-kxXoq9zOTbvqzLbdNKy1yFrxLC6GDJFE2Yuo3KqSwTmDOFjUGeWSakgoXT864WcK5/NAJkkONCiKb1ddsqhLXQ==
+  dependencies:
+    "@typescript-eslint/typescript-estree" "5.57.0"
+    "@typescript-eslint/utils" "5.57.0"
+    debug "^4.3.4"
+    tsutils "^3.21.0"
 
 "@typescript-eslint/types@5.47.1":
   version "5.47.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.47.1.tgz#459f07428aec5a8c4113706293c2ae876741ac8e"
   integrity sha512-CmALY9YWXEpwuu6377ybJBZdtSAnzXLSQcxLSqSQSbC7VfpMu/HLVdrnVJj7ycI138EHqocW02LPJErE35cE9A==
 
-"@typescript-eslint/typescript-estree@4.33.0":
-  version "4.33.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz#0dfb51c2908f68c5c08d82aefeaf166a17c24609"
-  integrity sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==
-  dependencies:
-    "@typescript-eslint/types" "4.33.0"
-    "@typescript-eslint/visitor-keys" "4.33.0"
-    debug "^4.3.1"
-    globby "^11.0.3"
-    is-glob "^4.0.1"
-    semver "^7.3.5"
-    tsutils "^3.21.0"
+"@typescript-eslint/types@5.57.0":
+  version "5.57.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.57.0.tgz#727bfa2b64c73a4376264379cf1f447998eaa132"
+  integrity sha512-mxsod+aZRSyLT+jiqHw1KK6xrANm19/+VFALVFP5qa/aiJnlP38qpyaTd0fEKhWvQk6YeNZ5LGwI1pDpBRBhtQ==
 
 "@typescript-eslint/typescript-estree@5.47.1":
   version "5.47.1"
@@ -4478,6 +4477,19 @@
   dependencies:
     "@typescript-eslint/types" "5.47.1"
     "@typescript-eslint/visitor-keys" "5.47.1"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/typescript-estree@5.57.0":
+  version "5.57.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.57.0.tgz#ebcd0ee3e1d6230e888d88cddf654252d41e2e40"
+  integrity sha512-LTzQ23TV82KpO8HPnWuxM2V7ieXW8O142I7hQTxWIHDcCEIjtkat6H96PFkYBQqGFLW/G/eVVOB9Z8rcvdY/Vw==
+  dependencies:
+    "@typescript-eslint/types" "5.57.0"
+    "@typescript-eslint/visitor-keys" "5.57.0"
     debug "^4.3.4"
     globby "^11.1.0"
     is-glob "^4.0.3"
@@ -4498,13 +4510,19 @@
     eslint-utils "^3.0.0"
     semver "^7.3.7"
 
-"@typescript-eslint/visitor-keys@4.33.0":
-  version "4.33.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz#2a22f77a41604289b7a186586e9ec48ca92ef1dd"
-  integrity sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==
+"@typescript-eslint/utils@5.57.0":
+  version "5.57.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.57.0.tgz#eab8f6563a2ac31f60f3e7024b91bf75f43ecef6"
+  integrity sha512-ps/4WohXV7C+LTSgAL5CApxvxbMkl9B9AUZRtnEFonpIxZDIT7wC1xfvuJONMidrkB9scs4zhtRyIwHh4+18kw==
   dependencies:
-    "@typescript-eslint/types" "4.33.0"
-    eslint-visitor-keys "^2.0.0"
+    "@eslint-community/eslint-utils" "^4.2.0"
+    "@types/json-schema" "^7.0.9"
+    "@types/semver" "^7.3.12"
+    "@typescript-eslint/scope-manager" "5.57.0"
+    "@typescript-eslint/types" "5.57.0"
+    "@typescript-eslint/typescript-estree" "5.57.0"
+    eslint-scope "^5.1.1"
+    semver "^7.3.7"
 
 "@typescript-eslint/visitor-keys@5.47.1":
   version "5.47.1"
@@ -4512,6 +4530,14 @@
   integrity sha512-rF3pmut2JCCjh6BLRhNKdYjULMb1brvoaiWDlHfLNVgmnZ0sBVJrs3SyaKE1XoDDnJuAx/hDQryHYmPUuNq0ig==
   dependencies:
     "@typescript-eslint/types" "5.47.1"
+    eslint-visitor-keys "^3.3.0"
+
+"@typescript-eslint/visitor-keys@5.57.0":
+  version "5.57.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.57.0.tgz#e2b2f4174aff1d15eef887ce3d019ecc2d7a8ac1"
+  integrity sha512-ery2g3k0hv5BLiKpPuwYt9KBkAp2ugT6VvyShXdLOkax895EC55sP0Tx5L0fZaQueiK3fBLvHVvEl3jFS5ia+g==
+  dependencies:
+    "@typescript-eslint/types" "5.57.0"
     eslint-visitor-keys "^3.3.0"
 
 "@uphold/request-logger@^2.0.0":
@@ -8950,7 +8976,7 @@ globals@^13.19.0, globals@^13.6.0, globals@^13.9.0:
   dependencies:
     type-fest "^0.20.2"
 
-globby@^11.0.2, globby@^11.0.3, globby@^11.0.4, globby@^11.1.0:
+globby@^11.0.2, globby@^11.0.4, globby@^11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
   integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
@@ -9450,7 +9476,7 @@ ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-ignore@^5.0.4, ignore@^5.1.8, ignore@^5.2.0:
+ignore@^5.0.4, ignore@^5.2.0:
   version "5.2.4"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
@@ -16818,6 +16844,11 @@ typescript-json-schema@^0.55.0:
   version "4.9.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.4.tgz#a2a3d2756c079abda241d75f149df9d561091e78"
   integrity sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==
+
+typescript@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.2.tgz#891e1a90c5189d8506af64b9ef929fca99ba1ee5"
+  integrity sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==
 
 typescript@~4.8.2:
   version "4.8.4"


### PR DESCRIPTION
Bum dappnodesdk dependency to 0.2.82 and modify the way how is imported.

Importing modules (`exports` in the `package.json`) is not currently working in typescript
