### PR TITLE
Hide beta tag for light mode

### DIFF
--- a/packages/admin-ui/src/App.tsx
+++ b/packages/admin-ui/src/App.tsx
@@ -14,6 +14,8 @@ import { pages, defaultPage } from "./pages";
 import { Login } from "./start-pages/Login";
 import { Register } from "./start-pages/Register";
 import { NoConnection } from "start-pages/NoConnection";
+// Types
+import { Theme, UsageMode } from "types";
 
 export const UsageContext = React.createContext({
   usage: "advanced",
@@ -39,8 +41,8 @@ function MainApp({ username }: { username: string }) {
   const initialTheme =
     storedTheme === "light" || storedTheme === "dark" ? storedTheme : "light";
 
-  const [theme, setTheme] = useState<"light" | "dark">(initialTheme);
-  const [usage, setUsage] = useState<"basic" | "advanced">(initialUsage);
+  const [theme, setTheme] = useState<Theme>(initialTheme);
+  const [usage, setUsage] = useState<UsageMode>(initialUsage);
 
   const toggleTheme = () => {
     setTheme(curr => (curr === "light" ? "dark" : "light"));
@@ -77,6 +79,7 @@ function MainApp({ username }: { username: string }) {
           <SideBar screenWidth={screenWidth} />
           <TopBar
             username={username}
+            theme={theme}
             toggleUsage={toggleUsage}
             toggleTheme={toggleTheme}
           />

--- a/packages/admin-ui/src/components/topbar/TopBar.tsx
+++ b/packages/admin-ui/src/components/topbar/TopBar.tsx
@@ -9,13 +9,17 @@ import ThemeSwitch from "./dropdownMenus/ThemeSwitch";
 import "./topbar.scss";
 import "./notifications.scss";
 // import UsageSwitch from "./dropdownMenus/UsageSwitch";
+// Types
+import { Theme } from "types";
 
 export const TopBar = ({
   username,
+  theme,
   toggleTheme,
   toggleUsage
 }: {
   username: string;
+  theme: Theme;
   toggleTheme: () => void;
   toggleUsage: () => void;
 }) => (
@@ -23,7 +27,7 @@ export const TopBar = ({
     {/* Right justified items */}
 
     <div className="beta">
-      <span>BETA</span>
+      {theme === "light" && <span>BETA</span>}
       {/* Theme usage requires more feedback */}
       {/*<UsageSwitch toggleUsage={toggleUsage} /> */}
       <ThemeSwitch toggleTheme={toggleTheme} />

--- a/packages/admin-ui/src/types.ts
+++ b/packages/admin-ui/src/types.ts
@@ -43,3 +43,7 @@ export interface DappnodeParams {
   DNCORE_DIR: string;
   REPO_DIR: string;
 }
+
+export type Theme = "light" | "dark";
+
+export type UsageMode = "basic" | "advanced";


### PR DESCRIPTION
Beta tag will only be shown while the user is in light mode