### PR TITLE
Fix Linter

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -5,7 +5,7 @@ module.exports = {
   ],
   parserOptions: {
     ecmaVersion: "latest", // For target ESNext
-    sourceType: "module", // Allows for the use of imports
+    sourceType: "module", // Allows the use of imports
   },
   env: {
     node: true,

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -8,12 +8,7 @@ module.exports = {
     ecmaVersion: 2022,
     sourceType: "module", // Allows for the use of imports
   },
-  plugins: ["@typescript-eslint"],
-  ignorePatterns: [
-    "packages/dappmanager/src/modules/chains/drivers/bitcoin.ts",
-    "packages/dappmanager/src/modules/chains/drivers/monero.ts",
-    "packages/dappmanager/src/modules/ipfs/writeStreamToFs.ts",
-  ],
+  //plugins: ["@typescript-eslint"],
   env: {
     node: true,
     mocha: true,

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -3,12 +3,10 @@ module.exports = {
   extends: [
     "plugin:@typescript-eslint/recommended", // Uses the recommended rules from the @typescript-eslint/eslint-plugin
   ],
-  // "extends": ["plugin:prettier/recommended","eslint:recommended"],
   parserOptions: {
-    ecmaVersion: 2022,
+    ecmaVersion: "latest", // For target ESNext
     sourceType: "module", // Allows for the use of imports
   },
-  //plugins: ["@typescript-eslint"],
   env: {
     node: true,
     mocha: true,
@@ -16,11 +14,5 @@ module.exports = {
   },
   rules: {
     "max-len": ["error", 1000],
-    // ##### Some libraries do not have typings and the compiler does not understand .d.ts files
-    "@typescript-eslint/no-var-requires": "off",
-    // ##### typescript does not understand hoisting
-    "@typescript-eslint/no-use-before-define": "off",
-    // ### This project uses docker-compose which has many variables not in camelCase
-    "@typescript-eslint/camelcase": "off",
   },
 };

--- a/package.json
+++ b/package.json
@@ -28,6 +28,10 @@
     "postinstall-postinstall": "^2.1.0"
   },
   "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^4.30.0",
+    "@typescript-eslint/parser": "^4.30.0",
+    "eslint": "^7.32.0",
+    "eslint-config-react-app": "^7.0.1",
     "lerna": "^6.3.0",
     "rimraf": "^3.0.2",
     "ts-node": "^10.8.1"

--- a/packages/admin-ui/.eslintrc.cjs
+++ b/packages/admin-ui/.eslintrc.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  extends: ["react-app"],
+  rules: {
+    "no-console": ["warn", { allow: ["warn", "error"] }]
+  }
+};

--- a/packages/admin-ui/.eslintrc.json
+++ b/packages/admin-ui/.eslintrc.json
@@ -1,6 +1,0 @@
-{
-  "extends": ["react-app"],
-  "rules": {
-    "no-console": ["warn", { "allow": ["warn", "error"] }]
-  }
-}

--- a/packages/common/.eslintrc.cjs
+++ b/packages/common/.eslintrc.cjs
@@ -1,0 +1,21 @@
+module.exports = {
+  extends: [
+    "../../.eslintrc.cjs", // Uses the recommended rules from the @typescript-eslint/eslint-plugin
+  ],
+  rules: {
+    // ##### @ts-ignore is needed in some cases
+    "@typescript-eslint/ban-ts-comment": "off",
+    // ##### Some schemas need a line length of more than 1000
+    "max-len": "off",
+    // Sometimes we need {} or Function as a type
+    "@typescript-eslint/ban-types": [
+      "error",
+      {
+        types: {
+          "{}": false,
+          Function: false,
+        },
+      },
+    ],
+  },
+};

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -15,7 +15,8 @@
   "scripts": {
     "build": "yarn run generate && tsc -p tsconfig.json",
     "generate": "ts-node ./src/validation/generateSchemas.ts tsconfig.json ./src/validation/schemas",
-    "dev": "tsc -w"
+    "dev": "tsc -w",
+    "lint": "eslint . --ext .ts --fix"
   },
   "dependencies": {
     "@dappnode/dappnodesdk": "^0.2.83",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -16,7 +16,7 @@
     "build": "yarn run generate && tsc -p tsconfig.json",
     "generate": "ts-node ./src/validation/generateSchemas.ts tsconfig.json ./src/validation/schemas",
     "dev": "tsc -w",
-    "lint": "eslint . --ext .ts --fix"
+    "lint": "eslint . --ext .ts --fix src"
   },
   "dependencies": {
     "@dappnode/dappnodesdk": "^0.2.83",

--- a/packages/dappmanager/.eslintrc.cjs
+++ b/packages/dappmanager/.eslintrc.cjs
@@ -1,0 +1,10 @@
+module.exports = {
+  extends: [
+    "../../.eslintrc.cjs" // Uses the recommended rules from the @typescript-eslint/eslint-plugin
+  ],
+  ignorePatterns: [
+    "/src/modules/chains/drivers/bitcoin.ts",
+    "src/modules/chains/drivers/monero.ts",
+    "src/modules/ipfs/writeStreamToFs.ts"
+  ]
+};

--- a/packages/dappmanager/.eslintrc.cjs
+++ b/packages/dappmanager/.eslintrc.cjs
@@ -6,5 +6,13 @@ module.exports = {
     "/src/modules/chains/drivers/bitcoin.ts",
     "src/modules/chains/drivers/monero.ts",
     "src/modules/ipfs/writeStreamToFs.ts"
-  ]
+  ],
+  rules: {
+    // ##### Some libraries do not have typings and the compiler does not understand .d.ts files
+    "@typescript-eslint/no-var-requires": "off",
+    // ##### typescript does not understand hoisting
+    "@typescript-eslint/no-use-before-define": "off",
+    // ### This project uses docker-compose which has many variables not in camelCase
+    "@typescript-eslint/camelcase": "off"
+  }
 };

--- a/packages/dappmanager/.eslintrc.cjs
+++ b/packages/dappmanager/.eslintrc.cjs
@@ -7,6 +7,9 @@ module.exports = {
     "src/modules/chains/drivers/monero.ts",
     "src/modules/ipfs/writeStreamToFs.ts"
   ],
+  parserOptions: {
+    ecmaVersion: 2019 // For target ES2019
+  },
   rules: {
     // ##### Some libraries do not have typings and the compiler does not understand .d.ts files
     "@typescript-eslint/no-var-requires": "off",

--- a/packages/dappmanager/package.json
+++ b/packages/dappmanager/package.json
@@ -96,11 +96,8 @@
   },
   "devDependencies": {
     "@types/node": "^18.15.11",
-    "@typescript-eslint/eslint-plugin": "^4.30.0",
-    "@typescript-eslint/parser": "^4.30.0",
     "chai": "^4.1.2",
     "dotenv": "^8.2.0",
-    "eslint": "^7.32.0",
     "mocha": "^10.2.0",
     "nodemon": "^2.0.6",
     "prettier": "^2.3.2",


### PR DESCRIPTION
1. Linter was not being used in `common`
2. Linter was not taking advantage of inheritance
3. Linter files were not consistent with format (`.json` and `.cjs`)