### PR TITLE
Set `useCheckpointSync` to true for all concensus clients

### DIFF
--- a/packages/admin-ui/src/__mock-backend__/stakerConfig.ts
+++ b/packages/admin-ui/src/__mock-backend__/stakerConfig.ts
@@ -186,7 +186,8 @@ export const stakerConfig: Pick<
                   shortDescription: "Lighthouse consensus client",
                   version: "0.1.0"
                 }
-              }
+              },
+              useCheckpointSync: true
             },
             {
               status: "ok",
@@ -214,7 +215,8 @@ export const stakerConfig: Pick<
                   shortDescription: "Teku consensus client",
                   version: "0.1.0"
                 }
-              }
+              },
+              useCheckpointSync: true
             },
             {
               status: "ok",
@@ -242,7 +244,7 @@ export const stakerConfig: Pick<
                   version: "0.1.0"
                 }
               },
-              useCheckpointSync: false
+              useCheckpointSync: true
             },
             {
               status: "ok",
@@ -270,7 +272,7 @@ export const stakerConfig: Pick<
                   version: "0.1.0"
                 }
               },
-              useCheckpointSync: false
+              useCheckpointSync: true
             }
           ],
           web3Signer: {
@@ -509,7 +511,8 @@ export const stakerConfig: Pick<
                   shortDescription: "Lighthouse consensus client",
                   version: "0.1.0"
                 }
-              }
+              },
+              useCheckpointSync: true
             },
             {
               status: "ok",
@@ -537,7 +540,8 @@ export const stakerConfig: Pick<
                   shortDescription: "Teku consensus client",
                   version: "0.1.0"
                 }
-              }
+              },
+              useCheckpointSync: true
             },
             {
               status: "ok",
@@ -565,7 +569,7 @@ export const stakerConfig: Pick<
                   version: "0.1.0"
                 }
               },
-              useCheckpointSync: false
+              useCheckpointSync: true
             }
           ],
           web3Signer: {
@@ -723,7 +727,8 @@ export const stakerConfig: Pick<
                   shortDescription: "Lighthouse consensus client",
                   version: "0.1.0"
                 }
-              }
+              },
+              useCheckpointSync: true
             },
             {
               status: "ok",
@@ -751,7 +756,8 @@ export const stakerConfig: Pick<
                   shortDescription: "Teku consensus client",
                   version: "0.1.0"
                 }
-              }
+              },
+              useCheckpointSync: true
             },
             {
               status: "ok",
@@ -780,7 +786,7 @@ export const stakerConfig: Pick<
                   version: "0.1.0"
                 }
               },
-              useCheckpointSync: false
+              useCheckpointSync: true
             }
           ],
           web3Signer: {

--- a/packages/admin-ui/src/pages/stakers/components/columns/ConsensusClient.tsx
+++ b/packages/admin-ui/src/pages/stakers/components/columns/ConsensusClient.tsx
@@ -24,7 +24,9 @@ export default function ConsensusClient<T extends Network>({
   isSelected: boolean;
 }) {
   const [useCheckpointSync, setUseCheckpointSync] = useState(
-    consensusClient.useCheckpointSync || false
+    consensusClient.useCheckpointSync !== undefined
+      ? consensusClient.useCheckpointSync
+      : true
   );
   return (
     <Card


### PR DESCRIPTION
<!-- For DAppNode core members, once the Pull Request is created, do not forget to:
1.  Link issues to the PR if available
2.  Mention dappnode core members
3.  Add proper labels
-->

## Context

PR related to issue #1427. Some concensus clients had **_useCheckpointSync_** defined to false by default. Others didn't have it defined (when **_useCheckpointSync_** its not defined properly in each concensus client, its value is set to false, this does not change in this PR) https://github.com/dappnode/DNP_DAPPMANAGER/blob/f3f654426ba28e2b770236fcae3a25e52b522339/packages/admin-ui/src/pages/stakers/components/columns/ConsensusClient.tsx#L27

## Approach

Each concensus clients now has its **_useCheckpointSync_** variable to "true" by default. 

## Test instructions

Check that sync is set to true in "Stakers" frontend by default
![image](https://user-images.githubusercontent.com/36164126/232505735-56c0382a-de08-4ac0-bdc4-02cc0cf3e358.png)

