### PR TITLE
Fix import for monero

### DIFF
--- a/packages/dappmanager/src/modules/chains/drivers/monero.ts
+++ b/packages/dappmanager/src/modules/chains/drivers/monero.ts
@@ -1,3 +1,4 @@
+// @ts-ignore
 import { Daemon } from "monero-rpc";
 import { InstalledPackageData } from "@dappnode/common";
 import { getPrivateNetworkAlias } from "../../../domains.js";

--- a/packages/dappmanager/src/modules/chains/drivers/monero.ts
+++ b/packages/dappmanager/src/modules/chains/drivers/monero.ts
@@ -1,5 +1,5 @@
 // @ts-ignore
-import Daemon from "monero-rpc";
+import { Daemon } from "monero-rpc";
 import { InstalledPackageData } from "@dappnode/common";
 import { getPrivateNetworkAlias } from "../../../domains.js";
 import { ChainDataResult } from "../types.js";

--- a/packages/dappmanager/src/modules/chains/drivers/monero.ts
+++ b/packages/dappmanager/src/modules/chains/drivers/monero.ts
@@ -1,4 +1,3 @@
-// @ts-ignore
 import { Daemon } from "monero-rpc";
 import { InstalledPackageData } from "@dappnode/common";
 import { getPrivateNetworkAlias } from "../../../domains.js";


### PR DESCRIPTION
Monero chain card was showing `Daemon is not a constructor`. This issue is fixed by updating the import of `monero-rpc` library.
![image](https://user-images.githubusercontent.com/47595345/232782991-bff518b4-6b30-40b9-9788-38d9618380e1.png)
