### PR TITLE
ui changes for dark mode

### DIFF
--- a/packages/admin-ui/src/components/multiClient.scss
+++ b/packages/admin-ui/src/components/multiClient.scss
@@ -37,8 +37,8 @@
 
   // Button feel
   &:hover:not(.selected) {
-    border-color: rgb(218, 218, 218);
-    background-color: rgb(218, 218, 218);
+    border-color: var(--color-light-card-hover);
+    background-color: var(--color-light-card-hover);
     cursor: pointer;
   }
   &.selected {

--- a/packages/admin-ui/src/components/sidebar/sidebar.scss
+++ b/packages/admin-ui/src/components/sidebar/sidebar.scss
@@ -56,7 +56,6 @@
     color: black;
     font-weight: 800;
     text-decoration: none;
-    background-color: #e6eceb80;
   }
   &.selectable:hover svg,
   &.selectable.active svg {

--- a/packages/admin-ui/src/dappnode_colors.scss
+++ b/packages/admin-ui/src/dappnode_colors.scss
@@ -18,6 +18,7 @@
   // LIGHT mode
   --color-light-background-sidebar-topbar: white; // Used by sidebar and topbar
   --color-light-background-main: #f7f9f9; // Used by main
+  --color-light-card-hover: #dadada; // Used by cards
 
   // DARK mode
   --color-dark-background-sidebar: #212121; // Used by sidebar

--- a/packages/admin-ui/src/dappnode_styles.scss
+++ b/packages/admin-ui/src/dappnode_styles.scss
@@ -255,7 +255,6 @@ p.no-p-style:last-child {
 .input-append-button {
   display: flex !important;
   font-size: 20px !important;
-  border-color: #ced4da !important;
   svg {
     opacity: 0.7;
   }

--- a/packages/admin-ui/src/light_dark.scss
+++ b/packages/admin-ui/src/light_dark.scss
@@ -7,12 +7,24 @@
 #light {
   #main {
     background-color: var(--color-light-background-main);
+    
+    // BUTTONS
+    .input-append-button {
+      border-color: #ced4da !important;
+    }
 
     .eth-multi-client,
     .ipfs-multi-client {
       &:hover:not(.selected) {
-        border-color: rgb(218, 218, 218);
-        background-color: rgb(218, 218, 218);
+        border-color: var(--color-light-card-hover);
+        background-color: var(--color-light-card-hover);
+      }
+    }
+
+    // ACTIVITY LOGS
+    .list-group-item-action {
+      &:hover:not(.selected) {
+        background-color: var(--color-dark-card-hover) !important;
       }
     }
   }
@@ -114,6 +126,31 @@
       color: var(--color-dark-quaternarytext);
     }
 
+    .alert-success {
+      background-color: rgba(0, 110, 0, 0.4);
+      border-color: var(--color-dark-secondarytext);
+      color: var(--color-dark-quaternarytext);
+    }
+
+    .alert-danger {
+      background-color: rgba(160, 0, 0, 0.4);
+      border-color: var(--color-dark-secondarytext);
+      color: var(--color-dark-quaternarytext);
+    }
+
+    .alert-warning {
+      background-color: rgba(164, 140, 0, 0.4);
+      border-color: var(--color-dark-secondarytext);
+      color: var(--color-dark-quaternarytext);
+    }
+
+    // ERROR-VIEW
+    .error-view {
+      pre {
+        color: var(--color-dark-secondarytext);
+      }
+    }
+
     // INPUTS
     input[type="text"],
     input[type="number"],
@@ -125,13 +162,42 @@
       color: white;
       border: none;
       &::placeholder {
-        color: rgba(255, 255, 255, 0.85);
+        color: rgba(160, 160, 160, 0.85);
       }
     }
     a.btn-outline-secondary,
     button.btn-outline-secondary {
       border-color: var(--color-dark-quaternarytext);
       color: white;
+    }
+
+    .custom-file-label:after {
+      background-color: transparent;
+    }
+
+    .input-append-button {
+      background-color: rgba(96,95,95,.839);
+      border: 1px solid #3a3a3a!important;
+    }
+
+    .form-control {
+      border: 1px solid #3a3a3a;
+    }
+
+    .switch {
+      input + label {
+        &::before {
+          background-color: #5a5a5a;
+        }
+        &::after {
+          background-color: var(--color-dark-card);
+        }
+      }
+      input:checked + label {
+        &::before {
+          background-color: var(--dappnode-color);
+        }
+      }
     }
 
     .input-group-text {
@@ -150,11 +216,25 @@
     }
     .eth-multi-client,
     .ipfs-multi-client {
+      border-bottom: 6px solid var(--color-dark-card);
+      &.selected {
+        border-color: var(--dappnode-color);
+        .title {
+          color: var(--dappnode-color);
+        }
+      }
       &:hover:not(.selected) {
         border-color: var(--color-dark-card-hover);
         background-color: var(--color-dark-card-hover);
       }
     }
+
+    // TABLES
+    .table-bordered td,
+    .table-bordered th {
+      border: 1px solid #4b4a4a;
+    }
+
 
     // ACTIVITY LOGS
     .list-group-item-action {

--- a/packages/admin-ui/src/pages/stakers/components/columns.scss
+++ b/packages/admin-ui/src/pages/stakers/components/columns.scss
@@ -17,8 +17,7 @@
   .execution-client,
   .mev-boost,
   .remote-signer {
-    border: 2px solid rgba(40, 40, 40, 0.5);
-    border-bottom: 6px solid rgba(40, 40, 40, 0.75);
+    border-bottom: 6px solid var(--color-dark-card);
     .title {
       color: var(--color-dark-maintext) !important;
     }
@@ -26,12 +25,12 @@
       .title {
         color: var(--dappnode-color) !important;
       }
-      border: 2px solid rgba(40, 40, 40, 0.5) !important;
       border-bottom: 6px solid var(--dappnode-color) !important;
     }
     &:hover:not(.isSelected) {
       cursor: pointer;
       background-color: rgb(85, 85, 85);
+      border-color: rgb(85, 85, 85);
     }
   }
 }
@@ -62,8 +61,8 @@
   // Button feel
   &:hover:not(.isSelected) {
     cursor: pointer;
-    border-color: rgb(218, 218, 218);
-    background-color: rgb(218, 218, 218);
+    border-color: var(--color-light-card-hover);
+    background-color: rgb(--color-light-card-hover);
   }
   &.isSelected {
     border-color: var(--dappnode-color);

--- a/packages/admin-ui/src/pages/stakers/components/columns/ConsensusClient.tsx
+++ b/packages/admin-ui/src/pages/stakers/components/columns/ConsensusClient.tsx
@@ -80,17 +80,19 @@ export default function ConsensusClient<T extends Network>({
               </div>
             )}
             {consensusClient.useCheckpointSync !== undefined && (
-              <Switch
-                checked={useCheckpointSync}
-                onToggle={() => {
-                  setNewConsClient({
-                    ...consensusClient,
-                    useCheckpointSync: !useCheckpointSync
-                  });
-                  setUseCheckpointSync(!useCheckpointSync);
-                }}
-                label={"Use checksync"}
-              />
+              <div>
+                <Switch
+                  checked={useCheckpointSync}
+                  onToggle={() => {
+                    setNewConsClient({
+                      ...consensusClient,
+                      useCheckpointSync: !useCheckpointSync
+                    });
+                    setUseCheckpointSync(!useCheckpointSync);
+                  }}
+                  label={"Use checksync"}
+                />
+              </div>
             )}
           </>
         </>

--- a/packages/admin-ui/src/pages/support/components/Activity.tsx
+++ b/packages/admin-ui/src/pages/support/components/Activity.tsx
@@ -11,6 +11,7 @@ import { parseStaticDate } from "utils/dates";
 import { stringifyObjSafe } from "utils/objects";
 import { stringSplit } from "utils/strings";
 import newTabProps from "utils/newTabProps";
+import { ThemeContext } from "App";
 // Own module
 import "./activity.scss";
 
@@ -85,6 +86,8 @@ function ActivityItem({ log }: { log: UserActionLog }) {
   const date = parseStaticDate(log.timestamp);
   const eventShort = stringSplit(log.event, ".")[0];
 
+  const { theme } = React.useContext(ThemeContext);
+
   // Force a re-render every 15 seconds for the timeFrom to show up correctly
   const [, setClock] = useState(0);
   useEffect(() => {
@@ -118,7 +121,7 @@ function ActivityItem({ log }: { log: UserActionLog }) {
             ) : null}
             {/* Count badge */}
             {log.count ? (
-              <span className={badgeClass + "light"}>{log.count}</span>
+              <span className={badgeClass + theme}>{log.count}</span>
             ) : null}
             {/* Call name */}
             <span className={"text-" + type}>

--- a/packages/admin-ui/src/pages/support/components/activity.scss
+++ b/packages/admin-ui/src/pages/support/components/activity.scss
@@ -2,9 +2,7 @@
   /* Spacing */
   padding: 0.5rem;
   /* Box styling */
-  border: solid 1px #d3d3d396;
   border-radius: 5px;
-  background-color: #f5f5f552;
   /* Text styling */
   display: block;
   white-space: pre;

--- a/packages/admin-ui/src/pages/vpn/components/wireguard/wireguard.scss
+++ b/packages/admin-ui/src/pages/vpn/components/wireguard/wireguard.scss
@@ -85,7 +85,6 @@
     overflow: auto;
     padding: 1.25rem;
     border-radius: 0.25rem;
-    background-color: #f7f9f9;
   }
 
   .show-local-credentials {

--- a/packages/admin-ui/src/pages/wifi/components/wifiLocal.scss
+++ b/packages/admin-ui/src/pages/wifi/components/wifiLocal.scss
@@ -28,9 +28,7 @@
   /* Spacing */
   padding: 0.5rem;
   /* Box styling */
-  border: solid 1px #d3d3d396;
   border-radius: 5px;
-  background-color: #f5f5f552;
   /* Text styling */
   display: block;
   white-space: pre;


### PR DESCRIPTION
## Context

This small PR makes some changes to the dark mode UI. It fixes some unreadable color combinations and makes everything more consistent with the light theme.

## Approach

Should fix #1414, among other things (I didn't only change the text color but also background, because the colors would be too bright; oriented on the already existing banner colors). I used my best judgement to select fitting colors, but that's subjective of course.

## Test instructions

Major improvements are the alerts banners, some of them were almost not readable, for example the "All packages are up to date" banner on the main dashboard. Another issue was the VPN credentials section in the VPN -> Wireguard -> Get link tab. The support tab also looks cleaner now, for example.