### PR TITLE
Adding link to Giveth

### DIFF
--- a/packages/admin-ui/src/components/sidebar/navbarItems.ts
+++ b/packages/admin-ui/src/components/sidebar/navbarItems.ts
@@ -45,7 +45,7 @@ export const fundedBy: { logo: string; text: string; link: string }[] = [
   {
     logo: GivethLogo,
     text: "Giveth",
-    link: "https://beta.giveth.io/campaigns/5b44b198647f33526e67c262"
+    link: "https://giveth.io/project/dappnode"
   },
   {
     logo: EcfLogo,


### PR DESCRIPTION
Changing the 3rd icon's link to https://giveth.io/project/dappnode
![Screenshot from 2023-04-27 10-25-54](https://user-images.githubusercontent.com/104903362/234804431-221865df-b6f6-427e-bf33-068ef20be671.png)
