### PR TITLE
Add more information on TEST API errors

### DIFF
--- a/packages/dappmanager/src/api/startTestApi.ts
+++ b/packages/dappmanager/src/api/startTestApi.ts
@@ -71,7 +71,6 @@ export function startTestApi(): http.Server {
   });
 
   app.use((req, res) => {
-    console.log("endpoint not found")
     res.status(404).send("Not found");
   });
 

--- a/packages/dappmanager/src/api/startTestApi.ts
+++ b/packages/dappmanager/src/api/startTestApi.ts
@@ -40,8 +40,12 @@ export function startTestApi(): http.Server {
           callFn(req.body as never)
             .then(data => res.send(data))
             .catch(e => {
-              logs.error(`Error in ${callCasted}: ${e.stack}`);
-              res.status(500).send(e.message);
+              const errorResponse = {
+                name: e.name,
+                message: e.message,
+                stack: e.stack
+              };
+              res.status(500).send(errorResponse);
             });
         });
       } else {
@@ -49,8 +53,12 @@ export function startTestApi(): http.Server {
           callFn(req.query as never)
             .then(data => res.send(data))
             .catch(e => {
-              logs.error(`Error in ${callCasted}: ${e.stack}`);
-              res.status(500).send(e.message);
+              const errorResponse = {
+                name: e.name,
+                message: e.message,
+                stack: e.stack
+              };
+              res.status(500).send(errorResponse);
             });
         });
       }
@@ -63,6 +71,7 @@ export function startTestApi(): http.Server {
   });
 
   app.use((req, res) => {
+    console.log("endpoint not found")
     res.status(404).send("Not found");
   });
 


### PR DESCRIPTION
<!-- For DAppNode core members, once the Pull Request is created, do not forget to:
1.  Link issues to the PR if available
2.  Mention dappnode core members
3.  Add proper labels
-->

## Context

When dappmanager TEST API endpoints return errors, only the error message is printed. This makes debugging hard to do since the error stack is missing. 

## Approach

Add more information about the error in the API response. Added error name and stack so debugging is easier. Example:

Up until now, API returned:
`Error:"kwarg id must be defined"`

From now on, API returns:
![image](https://user-images.githubusercontent.com/36164126/236447220-34ca715b-9b50-4a09-aa32-be8ab7b53e63.png)


## Test instructions

<!-- MANDATORY: please, do not skip this step, it is very importand for DAppNode team to have simple and well defined instructions on how to test this PR.
-->

1. Start your own dappmanager in dev mode with `docker-compose -f docker-compose-dev.yml up`.
2. Execute calls to the TEST API (port 7000) so that they return an error.
3. Check returned error by the API. Error name, message and stack shoud be printed.
