### PR TITLE
add lodestar metric

### DIFF
--- a/packages/dappmanager/src/api/routes/metrics.ts
+++ b/packages/dappmanager/src/api/routes/metrics.ts
@@ -95,6 +95,7 @@ register.registerMetric(
         if (client.includes("nimbus")) return 2;
         if (client.includes("prysm")) return 3;
         if (client.includes("teku")) return 4;
+        if (client.includes("lodestar")) return 5;
 
         return 0;
       }


### PR DESCRIPTION
one liner to set prometheus metric `dappmanager_staker_config` to 5 if lodestar is set.