### PR TITLE
Use absolute paths to redirect to stakers

### DIFF
--- a/packages/admin-ui/src/pages/installer/components/dappnodeDappstore/InstallerDnp.tsx
+++ b/packages/admin-ui/src/pages/installer/components/dappnodeDappstore/InstallerDnp.tsx
@@ -66,8 +66,8 @@ export const InstallerDnp: React.FC = routeProps => {
     // - Mainnet: http://my.dappnode/stakers/mainnet
     // - Gnosis: http://my.dappnode/stakers/gnosis
     // - Stakehouse: http://my.dappnode/stakers/stakehouse
-    if (id === "ethereum.dnp.dappnode.eth") navigate("stakers/mainnet");
-    else if (id === "gnosis.dnp.dappnode.eth") navigate("stakers/gnosis");
+    if (id === "ethereum.dnp.dappnode.eth") navigate("/stakers/mainnet");
+    else if (id === "gnosis.dnp.dappnode.eth") navigate("/stakers/gnosis");
     else if (id === "stakehouse.dnp.dappnode.eth") {
       // open a dialog that says it will open an external link, are you sure?
       confirmPromise({

--- a/packages/admin-ui/src/pages/installer/components/dappnodeDappstore/InstallerDnp.tsx
+++ b/packages/admin-ui/src/pages/installer/components/dappnodeDappstore/InstallerDnp.tsx
@@ -66,7 +66,7 @@ export const InstallerDnp: React.FC = routeProps => {
     // - Mainnet: http://my.dappnode/stakers/mainnet
     // - Gnosis: http://my.dappnode/stakers/gnosis
     // - Stakehouse: http://my.dappnode/stakers/stakehouse
-    if (id === "ethereum.dnp.dappnode.eth") navigate("/stakers/mainnet");
+    if (id === "ethereum.dnp.dappnode.eth") navigate("/stakers/ethereum");
     else if (id === "gnosis.dnp.dappnode.eth") navigate("/stakers/gnosis");
     else if (id === "stakehouse.dnp.dappnode.eth") {
       // open a dialog that says it will open an external link, are you sure?


### PR DESCRIPTION
In stakers mainnet and gnosis fake cards, use absolute paths for redirection