### PR TITLE
fix: Fix the 'Default Fee Recipient' not being persisted on the stakers tab

### DIFF
--- a/packages/dappmanager/src/modules/stakerConfig/set/setStakerConfig.ts
+++ b/packages/dappmanager/src/modules/stakerConfig/set/setStakerConfig.ts
@@ -33,6 +33,7 @@ import { listPackages } from "../../docker/list/listPackages.js";
  * TODO: add option to remove previous or not
  */
 export async function setStakerConfig<T extends Network>({
+  feeRecipient,
   network,
   executionClient,
   consensusClient,
@@ -49,7 +50,6 @@ export async function setStakerConfig<T extends Network>({
   const {
     executionClient: currentExecutionClient,
     consensusClient: currentConsensusClient,
-    feeRecipient
   } = getStakerConfigByNetwork(network);
 
   const pkgs = await listPackages();


### PR DESCRIPTION
## Context

This PR fixes an issue that is causing users to no longer be able to save changes to the "Default Fee Recipient" on the Stakers tab. Several users are reporting this issue on Discord, e.g. https://discord.com/channels/747647430450741309/747816600077598730/1136472991635603567

---

It looks like 3 weeks ago, some major React refactoring was done to the Stakers tab. As part of this effort, The `saveStakerConfig` function was introduced: https://github.com/dappnode/DNP_DAPPMANAGER/commit/1ae4d3a660201b6b172cbad82d3b20b845bff284#diff-a60d42deae0a452229f718d54f68aacb37bf67042dca2e1ee2cc495944530e4cR22-R28

The signature of this function suggests that there is a `feeRecipient` key being passed into this function. Please refer to the TS definition for `StakerConfigSet` here: https://github.com/dappnode/DNP_DAPPMANAGER/blob/develop/packages/common/src/types.ts#L1255-L1262

But for some reason the function is not making use of it. So rather than setting a new fee recipient as the user desires, the function is loading in the current fee recipient stored in the ENV file (https://github.com/dappnode/DNP_DAPPMANAGER/commit/1ae4d3a660201b6b172cbad82d3b20b845bff284#diff-a60d42deae0a452229f718d54f68aacb37bf67042dca2e1ee2cc495944530e4cR39), so this function will never change the fee recipient to something new.

## Approach

This PR passes the fee recipient (as typed by the user) through to the DB call which updates the global fee recipient.

## Test instructions

Try to set a new mainnet fee recipient in the stakers tab. Refresh the page. The fee recipient doesn't "stick" without this change.