### PR TITLE
Use container core prefix for core containers on `packageRestartVolumes`

### DIFF
--- a/packages/dappmanager/src/calls/packageRestartVolumes.ts
+++ b/packages/dappmanager/src/calls/packageRestartVolumes.ts
@@ -15,7 +15,7 @@ import {
 import { listPackage } from "../modules/docker/list/index.js";
 import { packageInstalledHasPid } from "../utils/pid.js";
 import { ComposeFileEditor } from "../modules/compose/editor.js";
-import { containerNamePrefix } from "@dappnode/types";
+import { containerNamePrefix, containerCoreNamePrefix } from "@dappnode/types";
 
 /**
  * Removes a package volumes. The re-ups the package
@@ -62,7 +62,11 @@ export async function packageRestartVolumes({
     for (const containerName of containersToRemove) {
       // get the service name from the container name
       const serviceName = containerName
-        .split(containerNamePrefix)[1]
+        .split(
+          containerName.includes(containerNamePrefix)
+            ? containerNamePrefix
+            : containerCoreNamePrefix
+        )[1]
         .split(".")[0];
       // only stop containers that are running
       if (containersStatus[serviceName]?.targetStatus === "running")


### PR DESCRIPTION
Use container core prefix for core containers on `packageRestartVolumes`. This would fix the issue of removing volumes from core containers