### PR TITLE
Allow empty fee recipient in stakers

### DIFF
--- a/packages/admin-ui/src/pages/stakers/components/useStakerConfig.ts
+++ b/packages/admin-ui/src/pages/stakers/components/useStakerConfig.ts
@@ -194,14 +194,6 @@ function getChanges<T extends Network>({
             severity: "secondary"
         };
 
-    // Not allowed if no fee recipient
-    if (!newFeeRecipient)
-        return {
-            isAllowed: false,
-            reason: "A fee recipient must be set",
-            severity: "warning"
-        };
-
     // Not allowed if changes AND (EC AND CC are deselected) AND (changes in signer or MEV boost)
     if (isExecAndConsDeSelected && (newEnableWeb3signer || newMevBoost))
         return {

--- a/packages/dappmanager/src/modules/globalEnvs.ts
+++ b/packages/dappmanager/src/modules/globalEnvs.ts
@@ -53,7 +53,7 @@ export function computeGlobalEnvsFromDb<B extends boolean>(
     [`${prefix}CONSENSUS_CLIENT_PRATER`]: db.consensusClientPrater.get(),
     [`${prefix}EXECUTION_CLIENT_PRATER`]: db.executionClientPrater.get(),
     [`${prefix}MEVBOOST_PRATER`]: db.mevBoostPrater.get(),
-    [`${prefix}FEE_RECIPIENT_PRATER`]: db.feeRecipientLukso.get(),
+    [`${prefix}FEE_RECIPIENT_PRATER`]: db.feeRecipientPrater.get(),
     [`${prefix}CONSENSUS_CLIENT_LUKSO`]: db.consensusClientLukso.get(),
     [`${prefix}EXECUTION_CLIENT_LUKSO`]: db.executionClientLukso.get(),
     [`${prefix}MEVBOOST_LUKSO`]: db.mevBoostLukso.get(),


### PR DESCRIPTION
The fee recipient field in the stakers becomes empty after refreshing, except if the fee recipient is already stored in the `maindb.json`. The DB is not updated when hitting "Appy changes". For Lukso this fix is necessary, as there is no user whose DB includes the fee recipient for LUKSO