### PR TITLE
Unregister EM before removal

### DIFF
--- a/packages/dappmanager/src/calls/packageRemove.ts
+++ b/packages/dappmanager/src/calls/packageRemove.ts
@@ -15,7 +15,7 @@ import { isRunningHttps } from "../modules/https-portal/utils/isRunningHttps.js"
 import { httpsPortal } from "./httpsPortal.js";
 import * as db from "../db/index.js";
 import { mevBoostMainnet, mevBoostPrater, stakerPkgs } from "@dappnode/types";
-import { unregister } from "../modules/ethicalMetrics/unregister.js";
+import { ethicalMetricsDnpName, unregister } from "../modules/ethicalMetrics/index.js";
 
 /**
  * Remove package data: docker down + disk files
@@ -66,7 +66,7 @@ export async function packageRemove({
   }
 
   // If Ethical Metrics is being removed, unregister the instance first
-  if (dnp.dnpName === "ethical-metrics.dnp.dappnode.eth") {
+  if (dnp.dnpName === ethicalMetricsDnpName) {
     try {
       await unregister();
     } catch (e) {

--- a/packages/dappmanager/src/calls/packageRemove.ts
+++ b/packages/dappmanager/src/calls/packageRemove.ts
@@ -15,6 +15,7 @@ import { isRunningHttps } from "../modules/https-portal/utils/isRunningHttps.js"
 import { httpsPortal } from "./httpsPortal.js";
 import * as db from "../db/index.js";
 import { mevBoostMainnet, mevBoostPrater, stakerPkgs } from "@dappnode/types";
+import { unregister } from "../modules/ethicalMetrics/unregister.js";
 
 /**
  * Remove package data: docker down + disk files
@@ -62,6 +63,15 @@ export async function packageRemove({
       `Error trying to remove https mappings from ${dnp.dnpName}. Continue with package remove`,
       e
     );
+  }
+
+  // If Ethical Metrics is being removed, unregister the instance first
+  if (dnp.dnpName === "ethical-metrics.dnp.dappnode.eth") {
+    try {
+      await unregister();
+    } catch (e) {
+      logs.error(`Error unregistering Ethical Metrics instance`, e);
+    }
   }
 
   // Only no-cores reach this block

--- a/packages/dappmanager/src/calls/packageRestartVolumes.ts
+++ b/packages/dappmanager/src/calls/packageRestartVolumes.ts
@@ -16,6 +16,7 @@ import { listPackage } from "../modules/docker/list/index.js";
 import { packageInstalledHasPid } from "../utils/pid.js";
 import { ComposeFileEditor } from "../modules/compose/editor.js";
 import { containerNamePrefix, containerCoreNamePrefix } from "@dappnode/types";
+import { unregister } from "../modules/ethicalMetrics/unregister.js";
 
 /**
  * Removes a package volumes. The re-ups the package
@@ -53,6 +54,15 @@ export async function packageRestartVolumes({
   // Skip early to prevent calling dockerComposeUp
   if (volumesToRemove.length === 0) {
     return;
+  }
+
+  // The Ethical Metrics instance must be unregistered if the tor hidden service volume is removed
+  if ((dnp.dnpName === "ethical-metrics.dnp.dappnode.eth" && !volumeName) || volumeName === "ethical-metricsdnpdappnodeeth_tor-hidden-service") {
+    try {
+      await unregister();
+    } catch (e) {
+      logs.error(`Error unregistering Ethical Metrics instance`, e);
+    }
   }
 
   const containersStatus = await getContainersStatus({ dnpName });

--- a/packages/dappmanager/src/calls/packageRestartVolumes.ts
+++ b/packages/dappmanager/src/calls/packageRestartVolumes.ts
@@ -17,6 +17,7 @@ import { packageInstalledHasPid } from "../utils/pid.js";
 import { ComposeFileEditor } from "../modules/compose/editor.js";
 import { containerNamePrefix, containerCoreNamePrefix } from "@dappnode/types";
 import { unregister } from "../modules/ethicalMetrics/unregister.js";
+import { ethicalMetricsDnpName, ethicalMetricsTorServiceVolume } from "../modules/ethicalMetrics/index.js";
 
 /**
  * Removes a package volumes. The re-ups the package
@@ -57,7 +58,7 @@ export async function packageRestartVolumes({
   }
 
   // The Ethical Metrics instance must be unregistered if the tor hidden service volume is removed
-  if ((dnp.dnpName === "ethical-metrics.dnp.dappnode.eth" && !volumeName) || volumeName === "ethical-metricsdnpdappnodeeth_tor-hidden-service") {
+  if ((dnp.dnpName === ethicalMetricsDnpName && !volumeName) || volumeName === ethicalMetricsTorServiceVolume) {
     try {
       await unregister();
     } catch (e) {

--- a/packages/dappmanager/src/modules/ethicalMetrics/params.ts
+++ b/packages/dappmanager/src/modules/ethicalMetrics/params.ts
@@ -1,3 +1,5 @@
 export const ethicalMetricsDnpName = "ethical-metrics.dnp.dappnode.eth";
 export const ethicalMetricsEndpoint =
   "http://api-ui.ethical-metrics.dappnode:3000";
+export const ethicalMetricsTorServiceVolume =
+  "ethical-metricsdnpdappnodeeth_tor-hidden-service";


### PR DESCRIPTION
Ethical Metrics instance should be unregistered before removing the package volumes