### PR TITLE
Disable submit if email has not changed

### DIFF
--- a/packages/admin-ui/src/pages/system/components/Notifications/EthicalMetrics.tsx
+++ b/packages/admin-ui/src/pages/system/components/Notifications/EthicalMetrics.tsx
@@ -103,6 +103,7 @@ export default function EthicalMetrics() {
                 className="register-button"
                 onClick={enableEthicalMetricsSync}
                 variant="dappnode"
+                disabled={ethicalMetricsConfig.data.mail === mail}
               >
                 Submit
               </Button>


### PR DESCRIPTION
If email has not changed, user should not be able to submit the email change to the ethical metrics server