### PR TITLE
Disable submit on email not change (EM) for `v0.2.73`

### DIFF
--- a/packages/admin-ui/src/pages/system/components/Notifications/EthicalMetrics.tsx
+++ b/packages/admin-ui/src/pages/system/components/Notifications/EthicalMetrics.tsx
@@ -103,6 +103,7 @@ export default function EthicalMetrics() {
                 className="register-button"
                 onClick={enableEthicalMetricsSync}
                 variant="dappnode"
+                disabled={ethicalMetricsConfig.data.mail === mail}
               >
                 Submit
               </Button>


### PR DESCRIPTION
Regenerating version `v0.2.73` of the dappmanager to include this feature:

New email submit should only be allowed if it is different to the registered one