### PR TITLE
Improve dark theme danger alerts & errors

### DIFF
--- a/packages/admin-ui/src/dappnode_colors.scss
+++ b/packages/admin-ui/src/dappnode_colors.scss
@@ -29,6 +29,7 @@
   --color-dark-quaternarytext: #c1c1c1; // Used by main
   --color-dark-card: #414141; // Used by cards
   --color-dark-card-hover: #6a6a6a; // Used by cards
+  --color-dark-danger-background: #8d2222; // Used by danger alerts
 
   // Buttons
   --dappnode-white-color: #fff; // Used by buttons

--- a/packages/admin-ui/src/light_dark.scss
+++ b/packages/admin-ui/src/light_dark.scss
@@ -83,6 +83,9 @@
     .status-badge.ok {
       background-color: var(--color-dark-card-hover);
     }
+    .status-badge.not-ok {
+      background-color: var(--color-dark-danger-background);
+    }
 
     .horizontal-navbar .item.active {
       color: var(--color-dark-maintext);
@@ -112,6 +115,10 @@
       background-color: rgba(0, 177, 244, 0.4);
       border-color: var(--color-dark-secondarytext);
       color: var(--color-dark-quaternarytext);
+    }
+
+    .alert-danger {
+      background-color: var(--color-dark-danger-background);
     }
 
     // INPUTS

--- a/packages/admin-ui/src/light_dark.scss
+++ b/packages/admin-ui/src/light_dark.scss
@@ -121,6 +121,11 @@
       background-color: var(--color-dark-danger-background);
     }
 
+    // ERROR VIEW
+    .error-view pre {
+      color: var(--color-dark-secondarytext);
+    }
+
     // INPUTS
     input[type="text"],
     input[type="number"],


### PR DESCRIPTION
Danger alerts and error messages have been defined in `light_dark.scss` to be readable in dark mode

**Before:**
![image](https://github.com/dappnode/DNP_DAPPMANAGER/assets/36164126/938ecb92-3577-4b9d-8208-e2b608111f85)
![Screenshot_20230914_174004](https://github.com/dappnode/DNP_DAPPMANAGER/assets/36164126/b4561b6f-3f10-4fa2-ba88-613f5cd651f5)



**After:**
![image](https://github.com/dappnode/DNP_DAPPMANAGER/assets/36164126/af23359d-1026-4ef9-9f7f-89c61987d2f7)
![Screenshot_20230914_174159](https://github.com/dappnode/DNP_DAPPMANAGER/assets/36164126/b37280da-a09f-4a60-8005-92b0fde7a6d3)
![image](https://github.com/dappnode/DNP_DAPPMANAGER/assets/36164126/7832054b-fd23-48dd-baa0-4e8d57d78f95)
![image](https://github.com/dappnode/DNP_DAPPMANAGER/assets/36164126/d27a5942-5902-4223-bf75-0424249b2428)
