### PR TITLE
Update `fullnode.dappnode` domain on staker selection

### DIFF
--- a/packages/admin-ui/src/pages/stakers/components/StakerNetwork.tsx
+++ b/packages/admin-ui/src/pages/stakers/components/StakerNetwork.tsx
@@ -204,7 +204,10 @@ export default function StakerNetwork<T extends Network>({
                 (consensusClient, i) => (
                   <ConsensusClient<T>
                     key={i}
-                    consensusClient={{...consensusClient, useCheckpointSync: true}}
+                    consensusClient={{
+                      ...consensusClient,
+                      useCheckpointSync: true
+                    }}
                     setNewConsClient={setNewConsClient}
                     isSelected={
                       consensusClient.dnpName === newConsClient?.dnpName

--- a/packages/dappmanager/src/modules/stakerConfig/set/setStakerConfig.ts
+++ b/packages/dappmanager/src/modules/stakerConfig/set/setStakerConfig.ts
@@ -89,7 +89,8 @@ export async function setStakerConfig<T extends Network>({
     setExecutionClient<T>({
       currentExecutionClient,
       targetExecutionClient: executionClient,
-      currentExecClientPkg
+      currentExecClientPkg,
+      network
     }),
     // CONSENSUS CLIENT (+ Fee recipient address + Graffiti + Checkpointsync)
     setConsensusClient<T>({


### PR DESCRIPTION
It seems that the domain `fullnode.dappnode` is not being updated after switching the Ethereum mainnet client in the stakers tab