### PR TITLE
Use static method to get op node rpc url

### DIFF
--- a/packages/dappmanager/src/modules/optimism/getOptimismConfig.ts
+++ b/packages/dappmanager/src/modules/optimism/getOptimismConfig.ts
@@ -14,7 +14,7 @@ import {
   getIsUpdated
 } from "../../calls/fetchDnpRequest.js";
 import { fileToGatewayUrl } from "../../utils/distributedFile.js";
-import { getOptimismNodeRpcUrl } from "./getOptimismNodeRpcUrl.js";
+import { getOptimismNodeRpcUrlIfExists } from "./getOptimismNodeRpcUrlIfExists.js";
 
 export async function getOptimismConfig(): Promise<OptimismConfigGet> {
   try {
@@ -61,7 +61,7 @@ export async function getOptimismConfig(): Promise<OptimismConfigGet> {
               throw Error(`Repository ${optimismNode} does not exist`);
 
             const pkgData = await getPkgData(releaseFetcher, optimismNode);
-            const mainnetRpcUrl = getOptimismNodeRpcUrl();
+            const mainnetRpcUrl = getOptimismNodeRpcUrlIfExists();
             const isRunning = getIsRunning(pkgData, dnpList);
             resolve({
               status: "ok",

--- a/packages/dappmanager/src/modules/optimism/getOptimismNodeRpcUrlIfExists.ts
+++ b/packages/dappmanager/src/modules/optimism/getOptimismNodeRpcUrlIfExists.ts
@@ -2,11 +2,11 @@ import { optimismNode } from "@dappnode/types";
 import { ComposeFileEditor } from "../compose/editor.js";
 import { opNodeRpcUrlEnvName, opNodeServiceName } from "./params.js";
 
-export function getOptimismNodeRpcUrl(): string {
-  const userSettings = new ComposeFileEditor(
+export function getOptimismNodeRpcUrlIfExists(): string {
+  const userSettings = ComposeFileEditor.getUserSettingsIfExist(
     optimismNode,
     false
-  ).getUserSettings();
+  );
   return userSettings.environment
     ? userSettings.environment[opNodeServiceName][opNodeRpcUrlEnvName]
     : "";


### PR DESCRIPTION
Use static method `getUserSettingIfEsists` to get the optimism rpc URL and avoid having an unhandled error
