### PR TITLE
Fix OP Erigon not showing peers

### DIFF
--- a/packages/dappmanager/src/modules/chains/drivers/ethereum.ts
+++ b/packages/dappmanager/src/modules/chains/drivers/ethereum.ts
@@ -47,7 +47,9 @@ export async function ethereum(
   const provider = new ethers.providers.JsonRpcProvider(apiUrl);
   const [syncing, peersCount, blockNumber] = await Promise.all([
     provider.send("eth_syncing", []).then(parseEthersSyncing),
-    provider.send("net_peerCount", []).then(parseInt),
+    // net_peerCount is not always available. OP Erigon does not support it
+    // Not logging error because it would flood the logs
+    provider.send("net_peerCount", []).then(parseInt).catch(() => undefined),
     provider.getBlockNumber()
   ]);
 
@@ -61,7 +63,7 @@ export async function ethereum(
 export function parseEthereumState(
   syncing: EthSyncing,
   blockNumber: number,
-  peersCount: number
+  peersCount?: number
 ): ChainDataResult {
   if (syncing) {
     const {


### PR DESCRIPTION
OP Erigon and OP geth include the flag `--nodiscover` so in the case of OP Erigon this is probably the cause that `net_peerCount` returns an error. This error should not prevent the user from seeing whether the client is synced or not

![Screenshot from 2023-09-29 09-56-03](https://github.com/dappnode/DNP_DAPPMANAGER/assets/144998261/d4744f07-4f5a-437e-aac2-d1fbece73bf6)
