### PR TITLE
Optional modules

### DIFF
--- a/packages/admin-ui/src/pages/rollups/components/Optimism.tsx
+++ b/packages/admin-ui/src/pages/rollups/components/Optimism.tsx
@@ -172,7 +172,7 @@ export default function Optimism({ description }: { description: string }) {
             </Col>
 
             <Col>
-              <SubTitle>Legacy Geth</SubTitle>
+              <SubTitle>Optional Modules</SubTitle>
               <LegacyGeth
                 archive={currentOptimismConfigReq.data.archive}
                 setNewArchive={setNewArchive}


### PR DESCRIPTION
Update copy in Rollups>Optimism

Replaced "Legacy Geth" by "Optional Modules"