### PR TITLE
Ensure aliases uniqueness

### DIFF
--- a/packages/dappmanager/src/modules/migrations/addAliasToRunningContainers.ts
+++ b/packages/dappmanager/src/modules/migrations/addAliasToRunningContainers.ts
@@ -160,9 +160,11 @@ function updateEndpointConfig(
   currentEndpointConfig: Dockerode.NetworkInfo | null,
   aliases: string[]
 ) {
+  const currentAliases = currentEndpointConfig?.Aliases || [];
+  const newAliases = uniq([...currentAliases, ...aliases]);
   return {
     ...currentEndpointConfig,
-    Aliases: [...(currentEndpointConfig?.Aliases || []), ...aliases]
+    Aliases: newAliases
   };
 }
 


### PR DESCRIPTION
We didnt check for existing aliases when adding new aliases so aliases duplicated were added:
``` 
"Aliases": [
                        "DAppNodePackage-geth.dnp.dappnode.eth",
                        "geth.dnp.dappnode.eth",
                        "geth.dappnode",
                        "4104c791f928",
                        "geth.dnp.dappnode.eth.geth.dappnode",
                        "geth.dappnode"
                    ],```