### PR TITLE
Fix `fullnode.dappnode` alias

### DIFF
--- a/packages/dappmanager/src/daemons/ethMultiClient/index.ts
+++ b/packages/dappmanager/src/daemons/ethMultiClient/index.ts
@@ -195,7 +195,6 @@ export function startEthMultiClientDaemon(signal: AbortSignal): void {
               // 1. Domain for BIND package
               db.fullnodeDomainTarget.set(execClient);
               // 2. Add network alias for docker DNS
-              // TODO: Check if this is correct
               ethereumClient.updateFullnodeAlias({
                 prevExecClientDnpName: multiClientArgs?.prevExecClientDnpName,
                 newExecClientDnpName: client,

--- a/packages/dappmanager/src/daemons/ethMultiClient/index.ts
+++ b/packages/dappmanager/src/daemons/ethMultiClient/index.ts
@@ -195,9 +195,10 @@ export function startEthMultiClientDaemon(signal: AbortSignal): void {
               // 1. Domain for BIND package
               db.fullnodeDomainTarget.set(execClient);
               // 2. Add network alias for docker DNS
-              ethereumClient.setDefaultEthClientFullNode({
-                dnpName: execClient,
-                removeAlias: true
+              // TODO: Check if this is correct
+              ethereumClient.updateFullnodeAlias({
+                newExecClientDnpName: execClient,
+                network: "mainnet"
               });
             }
           }

--- a/packages/dappmanager/src/modules/ethClient/ethereumClient.ts
+++ b/packages/dappmanager/src/modules/ethClient/ethereumClient.ts
@@ -3,7 +3,7 @@ import { Eth2ClientTarget, EthClientRemote, ExecutionClient, InstalledPackageDet
 import * as db from "@dappnode/db";
 import { eventBus } from "@dappnode/eventbus";
 import { logs } from "@dappnode/logger";
-import { getConsensusUserSettings, getStakerConfigByNetwork } from "../stakerConfig/utils.js";
+import { getConsensusUserSettings } from "../stakerConfig/utils.js";
 import { packageGet } from "../../calls/packageGet.js";
 import { packageInstall } from "../../calls/packageInstall.js";
 import { packageRemove } from "../../calls/packageRemove.js";
@@ -360,14 +360,15 @@ export class EthereumClient {
     compose.write();
   }
 
-  private removeFullnodeAliasFromCompose<T extends Network>({
+  // TODO: Function should be private
+  public removeFullnodeAliasFromCompose<T extends Network>({
     execClientDnpName,
     execClientServiceName,
     fullnodeAlias = params.FULLNODE_ALIAS,
   }: {
     execClientDnpName: ExecutionClient<T>,
     execClientServiceName: string,
-    fullnodeAlias: string,
+    fullnodeAlias?: string,
   }): void {
     this.editFullnodeAliasInCompose({
       action: ComposeEditorAction.REMOVE,
@@ -377,14 +378,15 @@ export class EthereumClient {
     });
   }
 
-  private addFullnodeAliasToCompose<T extends Network>({
+  // TODO: Function should be private
+  public addFullnodeAliasToCompose<T extends Network>({
     execClientDnpName,
     execClientServiceName,
     fullnodeAlias = params.FULLNODE_ALIAS,
   }: {
     execClientDnpName: ExecutionClient<T>,
     execClientServiceName: string,
-    fullnodeAlias: string,
+    fullnodeAlias?: string,
   }): void {
     this.editFullnodeAliasInCompose({
       action: ComposeEditorAction.ADD,

--- a/packages/dappmanager/src/modules/ethClient/index.ts
+++ b/packages/dappmanager/src/modules/ethClient/index.ts
@@ -1,4 +1,5 @@
 import { EthereumClient } from "./ethereumClient.js";
 export * from "./ethersProvider.js";
 export * from "./localFallbackVersions.js";
+export { ComposeAliasEditorAction } from "./ethereumClient.js";
 export const ethereumClient = new EthereumClient();

--- a/packages/dappmanager/src/modules/migrations/addAliasToRunningContainers.ts
+++ b/packages/dappmanager/src/modules/migrations/addAliasToRunningContainers.ts
@@ -13,8 +13,7 @@ import {
 } from "@dappnode/dockercompose";
 import {
   dockerComposeUp,
-  dockerNetworkDisconnect,
-  dockerNetworkConnect,
+  dockerNetworkReconnect,
   listPackageContainers,
   getDnCoreNetworkContainerConfig
 } from "@dappnode/dockerapi";
@@ -185,8 +184,7 @@ async function updateContainerNetwork(
       getDockerComposePath(container.dnpName, container.isCore)
     );
   } else {
-    await dockerNetworkDisconnect(networkName, containerName);
-    await dockerNetworkConnect(networkName, containerName, endpointConfig);
+    await dockerNetworkReconnect(networkName, containerName, endpointConfig);
     logs.info(`Added new alias to ${containerName} in ${networkName} network`);
   }
 }

--- a/packages/dappmanager/src/modules/stakerConfig/set/setStakerConfig.ts
+++ b/packages/dappmanager/src/modules/stakerConfig/set/setStakerConfig.ts
@@ -24,6 +24,7 @@ import { setSigner } from "./setSigner.js";
 import { setMevBoost } from "./setMevBoost.js";
 import { ensureSetRequirements } from "./ensureSetRequirements.js";
 import { listPackages } from "@dappnode/dockerapi";
+import { EthereumClient } from "../../ethClient/ethereumClient.js";
 
 /**
  *  Sets a new staker configuration based on user selection:
@@ -91,6 +92,7 @@ export async function setStakerConfig<T extends Network>({
       targetExecutionClient: executionClient,
       currentExecClientPkg
     }),
+
     // CONSENSUS CLIENT (+ Fee recipient address + Graffiti + Checkpointsync)
     setConsensusClient<T>({
       network: network,
@@ -114,6 +116,12 @@ export async function setStakerConfig<T extends Network>({
     consensusClient?.dnpName,
     mevBoost?.dnpName
   );
+
+  await new EthereumClient().updateFullnodeAlias({
+    network,
+    newExecClientDnpName: executionClient?.dnpName,
+    prevExecClientDnpName: currentExecutionClient || undefined
+  });
 
   // WEB3SIGNER
   // The web3signer deppends on the global envs EXECUTION_CLIENT and CONSENSUS_CLIENT

--- a/packages/dappmanager/test/unit/modules/ethClient/fullNodeEdit.test.ts
+++ b/packages/dappmanager/test/unit/modules/ethClient/fullNodeEdit.test.ts
@@ -2,7 +2,8 @@ import "mocha";
 import { expect } from "chai";
 import { shellSafe } from "../../../testUtils.js";
 import fs from "fs";
-import { ethereumClient } from "../../../../src/modules/ethClient/index.js";
+import { ethereumClient, ComposeAliasEditorAction } from "../../../../src/modules/ethClient/index.js";
+import { params } from "@dappnode/params";
 
 // The following test will wite a compose with the alias fullnode.dappnode:
 // 1. Then will remove such aslias and test it
@@ -97,7 +98,12 @@ networks:
 
   it("Should remove alias: fullnode.dappnode", () => {
     // Edit existing compose
-    ethereumClient.removeFullnodeAliasFromCompose({ execClientDnpName: dnpName, execClientServiceName: serviceName });
+    ethereumClient.editFullnodeAliasInCompose({
+      action: ComposeAliasEditorAction.REMOVE,
+      execClientDnpName: dnpName,
+      execClientServiceName: serviceName,
+      alias: params.FULLNODE_ALIAS,
+    });
 
     // Get edited compose
     const composeAfter = fs.readFileSync(
@@ -110,7 +116,12 @@ networks:
 
   it("Should add alias: fullnode.dappnode", () => {
     // Edit existing compose
-    ethereumClient.addFullnodeAliasToCompose({ execClientDnpName: dnpName, execClientServiceName: serviceName });
+    ethereumClient.editFullnodeAliasInCompose({
+      action: ComposeAliasEditorAction.ADD,
+      execClientDnpName: dnpName,
+      execClientServiceName: serviceName,
+      alias: params.FULLNODE_ALIAS,
+    });
 
     // Get edited compose
     const composeAfter = fs.readFileSync(

--- a/packages/dappmanager/test/unit/modules/ethClient/fullNodeEdit.test.ts
+++ b/packages/dappmanager/test/unit/modules/ethClient/fullNodeEdit.test.ts
@@ -12,12 +12,12 @@ describe("Edit fullnode in eth client", () => {
   const composeWithFullnodeAlias = `
 version: '3.5'
 services:
-  goerli-geth.dnp.dappnode.eth:
-    container_name: DAppNodePackage-goerli-geth.dnp.dappnode.eth
+  geth.dnp.dappnode.eth:
+    container_name: DAppNodePackage-geth.dnp.dappnode.eth
     dns: 172.33.1.2
     environment:
       - 'EXTRA_OPTIONS=--http.api eth,net,web3,txpool'
-    image: 'goerli-geth.dnp.dappnode.eth:0.4.12'
+    image: 'geth.dnp.dappnode.eth:0.4.12'
     logging:
       driver: json-file
       options:
@@ -26,7 +26,7 @@ services:
     networks:
       dncore_network:
         aliases:
-          - goerli-geth.dappnode
+          - geth.dappnode
           - fullnode.dappnode
     ports:
       - '30303'
@@ -34,12 +34,12 @@ services:
       - 30304/udp
     restart: always
     volumes:
-      - 'goerli:/goerli'
+      - 'data:/data'
     labels:
-      dappnode.dnp.dnpName: goerli-geth.dnp.dappnode.eth
+      dappnode.dnp.dnpName: geth.dnp.dappnode.eth
       dappnode.dnp.version: 0.4.12
 volumes:
-  goerli: {}
+  data: {}
 networks:
   dncore_network:
     external: true
@@ -48,12 +48,12 @@ networks:
   const composeWithOutFullnodeAlias = `
 version: '3.5'
 services:
-  goerli-geth.dnp.dappnode.eth:
-    container_name: DAppNodePackage-goerli-geth.dnp.dappnode.eth
+  geth.dnp.dappnode.eth:
+    container_name: DAppNodePackage-geth.dnp.dappnode.eth
     dns: 172.33.1.2
     environment:
       - 'EXTRA_OPTIONS=--http.api eth,net,web3,txpool'
-    image: 'goerli-geth.dnp.dappnode.eth:0.4.12'
+    image: 'geth.dnp.dappnode.eth:0.4.12'
     logging:
       driver: json-file
       options:
@@ -62,28 +62,28 @@ services:
     networks:
       dncore_network:
         aliases:
-          - goerli-geth.dappnode
+          - geth.dappnode
     ports:
       - '30303'
       - 30303/udp
       - 30304/udp
     restart: always
     volumes:
-      - 'goerli:/goerli'
+      - 'data:/data'
     labels:
-      dappnode.dnp.dnpName: goerli-geth.dnp.dappnode.eth
+      dappnode.dnp.dnpName: geth.dnp.dappnode.eth
       dappnode.dnp.version: 0.4.12
 volumes:
-  goerli: {}
+  data: {}
 networks:
   dncore_network:
     external: true
 `;
 
   // Example package
-  const dnpName = "example";
-  const serviceName = "goerli-geth.dnp.dappnode.eth";
-  const dnpRepoExamplePath = process.cwd() + "/dnp_repo/example";
+  const dnpName = "geth.dnp.dappnode.eth";
+  const serviceName = "geth.dnp.dappnode.eth";
+  const dnpRepoExamplePath = `${process.cwd()}/dnp_repo/${dnpName}`;
 
   before("Create random compose to be edited", async () => {
     // Create necessary dir
@@ -97,7 +97,7 @@ networks:
 
   it("Should remove alias: fullnode.dappnode", () => {
     // Edit existing compose
-    ethereumClient.removeFullnodeAliasFromCompose(dnpName, serviceName);
+    ethereumClient.removeFullnodeAliasFromCompose({ execClientDnpName: dnpName, execClientServiceName: serviceName });
 
     // Get edited compose
     const composeAfter = fs.readFileSync(
@@ -110,7 +110,7 @@ networks:
 
   it("Should add alias: fullnode.dappnode", () => {
     // Edit existing compose
-    ethereumClient.addFullnodeAliasToCompose(dnpName, serviceName);
+    ethereumClient.addFullnodeAliasToCompose({ execClientDnpName: dnpName, execClientServiceName: serviceName });
 
     // Get edited compose
     const composeAfter = fs.readFileSync(

--- a/packages/dockerApi/src/api/network.ts
+++ b/packages/dockerApi/src/api/network.ts
@@ -40,6 +40,21 @@ export async function dockerNetworkDisconnect(
 }
 
 /**
+ * Disconnects and reconnects a container to a network
+ * @param networkName "dncore_network"
+ * @param containerName "3613f73ba0e4" or "fullcontainername"
+ * @param aliases `["network-alias"]`
+ */
+export async function dockerNetworkReconnect(
+  networkName: string,
+  containerName: string,
+  endpointConfig?: Partial<Dockerode.NetworkInfo>
+): Promise<void> {
+  await dockerNetworkDisconnect(networkName, containerName);
+  await dockerNetworkConnect(networkName, containerName, endpointConfig);
+}
+
+/**
  * Create a new docker network
  */
 export async function dockerCreateNetwork(networkName: string): Promise<void> {

--- a/packages/eventBus/src/eventBus.ts
+++ b/packages/eventBus/src/eventBus.ts
@@ -8,6 +8,7 @@ import {
   PackageNotification,
   DirectoryItem,
 } from "@dappnode/common";
+import { ExecutionClientMainnet } from "@dappnode/types";
 
 interface EventTypes {
   chainData: ChainData[];
@@ -26,7 +27,7 @@ interface EventTypes {
   requestDevices: void;
   requestPackages: void;
   requestSystemInfo: void;
-  runEthClientInstaller: { useCheckpointSync?: boolean };
+  runEthClientInstaller: { useCheckpointSync?: boolean, prevExecClientDnpName?: ExecutionClientMainnet };
   runEthicalMetricsInstaller: void;
   runNatRenewal: void;
   runStakerCacheUpdate: { dnpName: string };


### PR DESCRIPTION
`fullnode.dappnode` domain should point to the mainnet execution selected by the user, if any

Also, each network (prater, gnosis and lukso) has its own fullnode domain, following this pattern: `<network>.fullnode.dappnode`