### PR TITLE
Add engines to package json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "private": true,
   "repository": "git@github.com:dappnode/DNP_DAPPMANAGER.git",
   "license": "GPL-3.0",
+  "engines": {
+    "node": "20.x"
+  },
   "workspaces": {
     "packages": [
       "packages/*"


### PR DESCRIPTION
Add engines to `package.json` so the engine compatible is shown when compiling
