### PR TITLE
Add max age to reboot required to reboot script

### DIFF
--- a/packages/hostScriptsServices/src/hostScripts/scripts/rebootRequired.ts
+++ b/packages/hostScriptsServices/src/hostScripts/scripts/rebootRequired.ts
@@ -6,13 +6,17 @@ import { RebootRequiredScript } from "@dappnode/common";
  * Checks weather or not the host machine needs to be rebooted
  * if it does, it returns the list of packages that need to be updated
  */
-export const getRebootRequiredMemoized = memoize(async function(): Promise<
-  RebootRequiredScript
-> {
-  const response = await runScript("reboot_required.sh");
-  const infoParsed = JSON.parse(response);
-  return {
-    rebootRequired: infoParsed.rebootRequired,
-    pkgs: infoParsed.pkgs,
-  };
-});
+export const getRebootRequiredMemoized = memoize(
+  async function(): Promise<RebootRequiredScript> {
+    const response = await runScript("reboot_required.sh");
+    const infoParsed = JSON.parse(response);
+    return {
+      rebootRequired: infoParsed.rebootRequired,
+      pkgs: infoParsed.pkgs,
+    };
+  },
+  {
+    promise: true,
+    maxAge: 60 * 1000 * 5, // 5 minutes
+  }
+);


### PR DESCRIPTION
Add max age to reboot required to reboot script, otherwise the script is executed only once at startup and will not show the reboot required until dappmanager container restarts