### PR TITLE
Fix hostuptime memo

### DIFF
--- a/packages/dappmanager/src/calls/getHostUptime.ts
+++ b/packages/dappmanager/src/calls/getHostUptime.ts
@@ -5,19 +5,22 @@ import memoize from "memoizee";
 /**
  * Returns uptime of the host
  */
-export const getHostUptime = memoize(
-  async function getHostUptime(): Promise<string> {
-    try {
-      const output = await shellHost("uptime -- -p");
-      return output;
-    } catch (error) {
-      error.message += `Unable to retrieve the uptime from te host machine: ${error.message}`;
-      logs.error(error.message);
-      throw error;
-    }
-  },
-  {
-    promise: true,
-    maxAge: 60 * 1000 * 5 // 5 minutes
+export async function getHostUptime(): Promise<string> {
+  return await getHostUptimeMemo();
+}
+
+async function _getHostUptime(): Promise<string> {
+  try {
+    const output = await shellHost("uptime -- -p");
+    return output;
+  } catch (error) {
+    error.message += `Unable to retrieve the uptime from te host machine: ${error.message}`;
+    logs.error(error.message);
+    throw error;
   }
-);
+}
+
+const getHostUptimeMemo = memoize(_getHostUptime, {
+  promise: true,
+  maxAge: 60 * 1000 * 5 // 5 minutes
+});


### PR DESCRIPTION
Fix hostuptime memo by exporting the function instead of the var