### PR TITLE
Increase data send arg length to 700

### DIFF
--- a/packages/dappmanager/src/api/routes/dataSend.ts
+++ b/packages/dappmanager/src/api/routes/dataSend.ts
@@ -3,7 +3,7 @@ import { eventBus } from "@dappnode/eventbus";
 import { HttpError, wrapHandler } from "../utils.js";
 import { getDnpFromIp } from "./sign.js";
 
-const MAX_LENGTH = 512;
+const MAX_LENGTH = 700;
 const MAX_KEYS = 20;
 
 /**


### PR DESCRIPTION
Increase the length of the data sent via an HTTP param to the `data-send` endpoint.

This is needed for SSV package, which creates public keys of `612` characters that need to be shown in the package info