### PR TITLE
Warning about OpenVPN deprecation

### DIFF
--- a/packages/admin-ui/src/components/NotificationsMain.tsx
+++ b/packages/admin-ui/src/components/NotificationsMain.tsx
@@ -12,12 +12,14 @@ import {
 import {
   getWifiStatus,
   getPasswordIsSecure,
-  getRebootIsRequired
+  getRebootIsRequired,
+  getIsOpenVpnActive
 } from "services/dappnodeStatus/selectors";
 import {
   pathName as systemPathName,
   subPaths as systemSubPaths
 } from "pages/system/data";
+import { relativePath as vpnPathName } from "pages/vpn/data";
 import Button from "components/Button";
 // Style
 import "./notificationsMain.scss";
@@ -34,6 +36,7 @@ export default function NotificationsView() {
   const wifiStatus = useSelector(getWifiStatus);
   const passwordIsSecure = useSelector(getPasswordIsSecure);
   const rebootHostIsRequired = useSelector(getRebootIsRequired);
+  const isOpenVpnActive = useSelector(getIsOpenVpnActive);
 
   // Check is auto updates are enabled for the core
   const autoUpdateSettingsReq = useApi.autoUpdateDataGet();
@@ -94,6 +97,17 @@ export default function NotificationsView() {
       body:
         "**Change the host 'dappnode' user password**, it's an insecure default.",
       active: passwordIsSecure === false
+    },
+    /**
+     * [VPN-MIGRATION-TO-WIREGUARD]
+     */
+    {
+      id: "vpnMigrationToWireguard",
+      linkText: "Migrate",
+      linkPath: vpnPathName,
+      body:
+        "**Migrate to WireGuard VPN**. OpenVPN is about to be deprecated by Dappnode. Click **Migrate** to get the WireGuard credentials.",
+      active: isOpenVpnActive
     }
   ];
 

--- a/packages/admin-ui/src/services/dappnodeStatus/selectors.ts
+++ b/packages/admin-ui/src/services/dappnodeStatus/selectors.ts
@@ -6,7 +6,7 @@ import {
 import { ChainData } from "@dappnode/common";
 import { activateFallbackPath } from "pages/system/data";
 import { getDnpInstalled } from "services/dnpInstalled/selectors";
-import { wifiDnpName } from "params";
+import { wifiDnpName, vpnDnpName } from "params";
 
 // Service > dappnodeStatus
 
@@ -90,6 +90,19 @@ export const getWifiStatus = (state: RootState) => ({
   ssid: state.dappnodeStatus.wifiCredentials?.ssid
 });
 
+function isOpenVpnContainerRunning(state: RootState): boolean {
+  const installedPackages = getDnpInstalled(state);
+  const openVpnDnp = installedPackages.find(dnp => dnp.dnpName === vpnDnpName);
+  if (!openVpnDnp) return false;
+
+  const openVpnContainer = openVpnDnp.containers[0];
+  if (!openVpnContainer) return false;
+
+  return openVpnContainer.running;
+}
+
+export const getIsOpenVpnActive = (state: RootState) => { return isOpenVpnContainerRunning(state); }
+
 /**
  * Returns a partial ChainData object with repository source status
  * To be shown alongside other chain data
@@ -101,11 +114,11 @@ export function getRepositorySourceChainItem(
   const repositoryResult = _getRepositorySourceChainItem(state);
   return repositoryResult
     ? {
-        ...repositoryResult,
-        dnpName: "repository-source",
-        name: "Repository source",
-        help: activateFallbackPath
-      }
+      ...repositoryResult,
+      dnpName: "repository-source",
+      name: "Repository source",
+      help: activateFallbackPath
+    }
     : null;
 }
 


### PR DESCRIPTION
OpenVPN is about to be deprecated in favour of WireGuard. Here we show a warning for the users to migrate to the new VPN client
![image](https://github.com/dappnode/DNP_DAPPMANAGER/assets/144998261/0ef49f09-fd7d-43a3-9184-33c0b7801fb1)
