### PR TITLE
Handle container aliases for IP range migration

### DIFF
--- a/packages/dockerApi/package.json
+++ b/packages/dockerApi/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "test": "TEST=true mocha --config ./.mocharc.yaml --recursive ./test/unit",
+    "test:int": "TEST=true mocha --config ./.mocharc.yaml --recursive ./test/int --timeout 10000",
     "dev": "tsc -w",
     "lint": "eslint . --ext .ts --fix src"
   },

--- a/packages/dockerApi/src/api/network.ts
+++ b/packages/dockerApi/src/api/network.ts
@@ -81,7 +81,7 @@ export async function dockerNetworkConnect(
 export async function dockerNetworkConnectNotThrow(
   networkName: string,
   containerName: string,
-  endpointConfig?: Partial<Dockerode.NetworkInfo>
+  endpointConfig?: Partial<Dockerode.NetworkInfo>,
 ): Promise<void> {
   try {
     await dockerNetworkConnect(networkName, containerName, endpointConfig);

--- a/packages/dockerApi/src/api/network.ts
+++ b/packages/dockerApi/src/api/network.ts
@@ -1,6 +1,7 @@
 import Dockerode from "dockerode";
 import { docker } from "./docker.js";
 import { dockerContainerInspect } from "../index.js";
+import { logs } from "@dappnode/logger";
 
 /**
  * Returns a map of container names to their network aliases
@@ -15,7 +16,11 @@ export async function getNetworkAliasesMap(
 
   const containersInfo = Object.values(networkInfo.Containers ?? []);
 
-  return await getContainerAliasesForNetwork(containersInfo, networkName);
+  const aliasesMap = await getContainerAliasesForNetwork(containersInfo, networkName);
+
+  logs.info(`Retrieved current container aliases for network ${networkName}: ${JSON.stringify(aliasesMap)}`);
+
+  return aliasesMap;
 }
 
 async function getContainerAliasesForNetwork(containersInfo: Dockerode.NetworkContainer[], networkName: string): Promise<Map<string, string[]>> {

--- a/packages/dockerApi/src/api/network.ts
+++ b/packages/dockerApi/src/api/network.ts
@@ -1,7 +1,39 @@
 import Dockerode from "dockerode";
 import { docker } from "./docker.js";
 import { dockerContainerInspect } from "../index.js";
-import { params } from "@dappnode/params";
+
+/**
+ * Returns a map of container names to their network aliases
+ * @param networkName "dncore_network"
+ * @returns { "DAppNodeCore-dappmanager.dnp.dappnode.eth": ["my.dappnode", "dappmanager.dappnode", "dappmanager.dnp.dappnode.eth.dappnode", "dappnode.local"] }
+ */
+export async function getNetworkAliasesMap(
+  networkName: string
+): Promise<Map<string, string[]>> {
+  const network = docker.getNetwork(networkName);
+  const networkInfo: Dockerode.NetworkInspectInfo = (await network.inspect() as Dockerode.NetworkInspectInfo);
+
+  const containersInfo = Object.values(networkInfo.Containers ?? []);
+
+  return await getContainerAliasesForNetwork(containersInfo, networkName);
+}
+
+async function getContainerAliasesForNetwork(containersInfo: Dockerode.NetworkContainer[], networkName: string): Promise<Map<string, string[]>> {
+  const fetchAliasesTasks = containersInfo.map(async (containerInfo) => {
+    try {
+      const aliases = (await getNetworkContainerConfig(containerInfo.Name, networkName))?.Aliases ?? [];
+      return { name: containerInfo.Name, aliases };
+    } catch (error) {
+      console.error(`Failed to get aliases for container ${containerInfo.Name}:`, error);
+      return { name: containerInfo.Name, aliases: [] };
+    }
+  });
+
+  const containersAliases = await Promise.all(fetchAliasesTasks);
+  const aliasMap = new Map(containersAliases.map(({ name, aliases }) => [name, aliases]));
+
+  return aliasMap;
+}
 
 /**
  * Disconnect all docker containers from a docker network
@@ -125,13 +157,16 @@ export async function dockerListNetworks(): Promise<
   return await docker.listNetworks();
 }
 
-/** Get endpoint config for DOCKER_PRIVATE_NETWORK_NAME */
-export async function getDnCoreNetworkContainerConfig(
-  containerName: string
+/**
+ * Returns the network configuration for a container in a specific network
+ */
+export async function getNetworkContainerConfig(
+  containerName: string,
+  networkName: string
 ): Promise<Dockerode.NetworkInfo | null> {
   const inspectInfo = await dockerContainerInspect(containerName);
   return (
-    inspectInfo.NetworkSettings.Networks[params.DOCKER_PRIVATE_NETWORK_NAME] ??
+    inspectInfo.NetworkSettings.Networks[networkName] ??
     null
   );
 }

--- a/packages/dockerApi/test/int/getNetworkAliasesMap.int.test.ts
+++ b/packages/dockerApi/test/int/getNetworkAliasesMap.int.test.ts
@@ -1,0 +1,88 @@
+import "mocha";
+import { expect } from "chai";
+import { docker, getNetworkAliasesMap } from "@dappnode/dockerapi";
+
+describe("Ensure docker network config migration => getDockerNetworkNameFromSubnet", () => {
+    const testNetworkName = "docker_network_test";
+    const testNetworkSubnet = "172.40.0.0/16";
+    const testImage = "alpine";
+    const testContainerNames = [
+        "test_container_1",
+        "test_container_2",
+        "test_container_3",
+    ];
+    let testNetwork;
+
+    before(async () => {
+        await removeAll();
+
+        // Create network
+        testNetwork = await docker.createNetwork({
+            Name: testNetworkName,
+            Driver: "bridge",
+            IPAM: {
+                Driver: "default",
+                Config: [{ Subnet: testNetworkSubnet }],
+            },
+        });
+
+        // Pull image and create containers
+        await docker.pull(testImage);
+        const containerPromises = testContainerNames.map(async (cn) => {
+            const container = await docker.createContainer({
+                Image: testImage,
+                Cmd: ["sleep", "infinity"],
+                name: cn,
+            });
+            await container.start();
+
+            return container;
+        });
+
+        // Connect containers to network
+        await Promise.all(containerPromises.map(async (containerPromise) => {
+            const container = await containerPromise;
+            const containerInfo = await container.inspect();
+            const containerName = containerInfo.Name.replace(/^\//, ''); // Removing leading slash
+
+            await testNetwork.connect({
+                Container: container.id,
+                EndpointConfig: {
+                    Aliases: [`alias_${containerName}`],
+                },
+            });
+        }));
+    });
+
+    it("should return a map of the containers and aliases connected to the test network", async () => {
+        const aliasMap = await getNetworkAliasesMap(testNetworkName);
+
+        expect(aliasMap.size).to.equal(testContainerNames.length);
+        testContainerNames.forEach(containerName => {
+            const expectedAlias = `alias_${containerName}`;
+            const aliases = aliasMap.get(containerName);
+            expect(aliases).to.include(expectedAlias, `Container ${containerName} should have alias ${expectedAlias}`);
+        });
+    });
+
+    after(async () => {
+        await removeAll();
+    });
+
+    async function removeAll() {
+        // Gracefully remove docker containers
+        await Promise.all(testContainerNames.map(async (cn) => {
+            const container = docker.getContainer(cn);
+            if (container) {
+                // eslint-disable-next-line @typescript-eslint/no-empty-function
+                await container.remove({ force: true }).catch(() => { });
+            }
+        }));
+
+        // Remove docker network
+        if (testNetwork) {
+            // eslint-disable-next-line @typescript-eslint/no-empty-function
+            await testNetwork.remove().catch(() => { });
+        }
+    }
+});

--- a/packages/installer/src/ethClient/ethereumClient.ts
+++ b/packages/installer/src/ethClient/ethereumClient.ts
@@ -19,7 +19,7 @@ import {
   dockerComposeUpPackage,
   dockerNetworkReconnect,
   listPackageNoThrow,
-  getDnCoreNetworkContainerConfig,
+  getNetworkContainerConfig,
 } from "@dappnode/dockerapi";
 import {
   ExecutionClientMainnet,
@@ -260,8 +260,9 @@ export class EthereumClient {
     containerName: string;
     aliasToRemove: string;
   }): Promise<void> {
-    const currentEndpointConfig = await getDnCoreNetworkContainerConfig(
-      containerName
+    const currentEndpointConfig = await getNetworkContainerConfig(
+      containerName,
+      params.DOCKER_PRIVATE_NETWORK_NAME
     );
 
     const updatedAliases = (currentEndpointConfig?.Aliases || []).filter(
@@ -287,8 +288,9 @@ export class EthereumClient {
     containerName: string;
     aliasToAdd: string;
   }): Promise<void> {
-    const currentEndpointConfig = await getDnCoreNetworkContainerConfig(
-      containerName
+    const currentEndpointConfig = await getNetworkContainerConfig(
+      containerName,
+      params.DOCKER_PRIVATE_NETWORK_NAME
     );
 
     const endpointConfig = {

--- a/packages/migrations/src/addAliasToRunningContainers.ts
+++ b/packages/migrations/src/addAliasToRunningContainers.ts
@@ -15,7 +15,7 @@ import {
   dockerComposeUp,
   dockerNetworkReconnect,
   listPackageContainers,
-  getDnCoreNetworkContainerConfig,
+  getNetworkContainerConfig,
 } from "@dappnode/dockerapi";
 import { gte, lt, clean } from "semver";
 import {
@@ -59,8 +59,9 @@ export async function addAliasToGivenContainers(
       migrateCoreNetworkAndAliasInCompose(container, aliases);
 
       // Adds aliases to the container network
-      const currentEndpointConfig = await getDnCoreNetworkContainerConfig(
-        container.containerName
+      const currentEndpointConfig = await getNetworkContainerConfig(
+        container.containerName,
+        params.DOCKER_PRIVATE_NETWORK_NAME
       );
       if (!hasAliases(currentEndpointConfig, aliases)) {
         const updatedConfig = updateEndpointConfig(
@@ -203,9 +204,9 @@ function hasAliases(
 ): boolean {
   return Boolean(
     endpointConfig &&
-      endpointConfig.Aliases &&
-      Array.isArray(endpointConfig.Aliases) &&
-      aliases.every((alias) => endpointConfig.Aliases?.includes(alias))
+    endpointConfig.Aliases &&
+    Array.isArray(endpointConfig.Aliases) &&
+    aliases.every((alias) => endpointConfig.Aliases?.includes(alias))
   );
 }
 

--- a/packages/migrations/src/ensureDockerNetworkConfig/connectContainerRetryOnIpUsed.ts
+++ b/packages/migrations/src/ensureDockerNetworkConfig/connectContainerRetryOnIpUsed.ts
@@ -33,16 +33,17 @@ export async function connectContainerRetryOnIpUsed({
 
   while (attemptCount < maxAttempts) {
     try {
+      const aliases = aliasesMap.get(containerName) ?? [];
       await network.connect({
         Container: containerName,
         EndpointConfig: {
           IPAMConfig: {
             IPv4Address: ip,
           },
-          Aliases: aliasesMap.get(containerName) ?? [],
+          Aliases: aliases,
         },
       });
-      logs.info(`successfully connected ${containerName} with ip ${ip}`);
+      logs.info(`Successfully connected ${containerName} with ip ${ip} and aliases ${aliases}`);
       // If any container was disconnected, reconnect it
       if (disconnectedContainers.length > 0)
         for (const dc of disconnectedContainers)

--- a/packages/migrations/src/ensureDockerNetworkConfig/connectContainerRetryOnIpUsed.ts
+++ b/packages/migrations/src/ensureDockerNetworkConfig/connectContainerRetryOnIpUsed.ts
@@ -9,16 +9,18 @@ import Dockerode from "dockerode";
  * @param endpointConfig Configuration options for the network connection.
  * @param maxAttempts The maximum number of attempts to connect the container.
  */
-export async function connectContaierRetryOnIpInUsed({
+export async function connectContainerRetryOnIpUsed({
   networkName,
   containerName,
   maxAttempts,
   ip,
+  aliasesMap
 }: {
   networkName: string;
   containerName: string;
   maxAttempts: number; // Default to 5 attempts if not specified
   ip: string;
+  aliasesMap: Map<string, string[]>;
 }): Promise<void> {
   // prevent function from running too many times
   if (maxAttempts > 200)
@@ -37,6 +39,7 @@ export async function connectContaierRetryOnIpInUsed({
           IPAMConfig: {
             IPv4Address: ip,
           },
+          Aliases: aliasesMap.get(containerName) ?? [],
         },
       });
       logs.info(`successfully connected ${containerName} with ip ${ip}`);
@@ -46,6 +49,9 @@ export async function connectContaierRetryOnIpInUsed({
           await network
             .connect({
               Container: dc.Name,
+              EndpointConfig: {
+                Aliases: aliasesMap.get(dc.Name) ?? [],
+              },
             })
             // bypass error
             .catch((e) => logs.error(`error connecting ${dc.Name}: ${e}`));

--- a/packages/migrations/src/ensureDockerNetworkConfig/ensureDockerNetworkConfig.ts
+++ b/packages/migrations/src/ensureDockerNetworkConfig/ensureDockerNetworkConfig.ts
@@ -1,6 +1,7 @@
 import {
   disconnectAllContainersFromNetwork,
   docker,
+  getNetworkAliasesMap,
 } from "@dappnode/dockerapi";
 import { logs } from "@dappnode/logger";
 import Dockerode from "dockerode";
@@ -33,6 +34,7 @@ export async function ensureDockerNetworkConfig({
 }): Promise<void> {
   let restartWireguardIsRequired = false;
   const dncoreNetwork = docker.getNetwork(dockerNetworkName);
+  const aliasesMap = await getNetworkAliasesMap(dockerNetworkName);
 
   try {
     // make sure docker network exists
@@ -78,6 +80,7 @@ export async function ensureDockerNetworkConfig({
       networkName: dockerNetworkName,
       dappmanagerIp,
       bindIp,
+      aliasesMap
     });
   } catch (e) {
     // Error: (HTTP code 404) no such network - network dncore_network not found
@@ -105,6 +108,7 @@ export async function ensureDockerNetworkConfig({
           networkName: dockerNetworkName,
           dappmanagerIp,
           bindIp,
+          aliasesMap
         });
       } catch (e) {
         // Error when creating docker network with overlapping address space:
@@ -142,6 +146,7 @@ export async function ensureDockerNetworkConfig({
             networkName: dockerNetworkName,
             dappmanagerIp,
             bindIp,
+            aliasesMap
           });
         } else throw e;
       }

--- a/packages/params/src/params.ts
+++ b/packages/params/src/params.ts
@@ -111,7 +111,7 @@ export const params = {
   WIREGUARD_DEVICES_ENVNAME: "PEERS",
 
   // Docker network parameters
-  DOCKER_NETWORK_SUBNET: "172.33.0.0/16", // "10.20.0.0/24";
+  DOCKER_NETWORK_SUBNET: "172.33.0.0/16", // "172.33.0.0/16";
   DOCKER_PRIVATE_NETWORK_NAME: "dncore_network",
   DOCKER_EXTERNAL_NETWORK_NAME: "dnpublic_network",
   DOCKER_LEGACY_DNS: "172.33.1.2",

--- a/packages/params/src/params.ts
+++ b/packages/params/src/params.ts
@@ -111,7 +111,7 @@ export const params = {
   WIREGUARD_DEVICES_ENVNAME: "PEERS",
 
   // Docker network parameters
-  DOCKER_NETWORK_SUBNET: "172.33.0.0/16", // "172.33.0.0/16";
+  DOCKER_NETWORK_SUBNET: "172.33.0.0/16", // "10.20.0.0/24";
   DOCKER_PRIVATE_NETWORK_NAME: "dncore_network",
   DOCKER_EXTERNAL_NETWORK_NAME: "dnpublic_network",
   DOCKER_LEGACY_DNS: "172.33.1.2",


### PR DESCRIPTION
In order to keep the aliases that each container has inside the `dncore_network`, we need to retrieve them before disconnecting the containers from the network