### PR TITLE
Remove unnecessary function

### DIFF
--- a/packages/migrations/src/ensureDockerNetworkConfig/connectContainersToNetworkWithPrio.ts
+++ b/packages/migrations/src/ensureDockerNetworkConfig/connectContainersToNetworkWithPrio.ts
@@ -30,49 +30,25 @@ export async function connectContainersToNetworkWithPrio({
     .map((pkg) => pkg.containers.map((c) => c.containerName))
     .flat();
 
-  const { dappmanagerContainerName, bindContainerName } =
-    getDappmanagerAndBindContainerNames(containerNames);
-
   // connect first dappmanager and bind
   // dappmanager must resolve to the hardcoded ip to use the ip as fallback ot access UI
   await connectContaierRetryOnIpInUsed({
     networkName,
-    containerName: dappmanagerContainerName,
+    containerName: params.dappmanagerContainerName,
     maxAttempts: containerNames.length,
     ip: dappmanagerIp,
   });
   // bind must resolve to hardcoded ip cause its used as dns in vpn creds
   await connectContaierRetryOnIpInUsed({
     networkName,
-    containerName: bindContainerName,
+    containerName: params.bindContainerName,
     maxAttempts: containerNames.length,
     ip: bindIp,
   });
   // connect rest of containers
   await Promise.all(
     containerNames
-      .filter((c) => c !== bindContainerName && c !== dappmanagerContainerName)
+      .filter((c) => c !== params.bindContainerName && c !== params.dappmanagerContainerName)
       .map((c) => dockerNetworkConnectNotThrow(networkName, c))
   );
-}
-
-export function getDappmanagerAndBindContainerNames(containerNames: string[]): {
-  dappmanagerContainerName: string;
-  bindContainerName: string;
-} {
-  const dappmanagerContainerName = containerNames.find(
-    (c) => c === params.dappmanagerContainerName
-  );
-  if (!dappmanagerContainerName)
-    throw Error("dappmanager container could not be found");
-
-  const bindContainerName = containerNames.find(
-    (c) => c === params.bindContainerName
-  );
-  if (!bindContainerName) throw Error("bind container could not be found");
-
-  return {
-    dappmanagerContainerName,
-    bindContainerName,
-  };
 }


### PR DESCRIPTION
The function `getDappmanagerAndBindContainerNames` is not necessary as we already have the container names defined as `params`. Also, in the case the params were not well-defined, this function would not help either