### PR TITLE
Add `getIsMonoService` checker to adding aliases to docker containers

### DIFF
--- a/packages/dockerCompose/src/setDappnodeComposeDefaults.ts
+++ b/packages/dockerCompose/src/setDappnodeComposeDefaults.ts
@@ -5,6 +5,7 @@ import {
   getIsCore,
   parseEnvironment,
   getImageTag,
+  getIsMonoService,
 } from "@dappnode/utils";
 import { params } from "@dappnode/params";
 import { cleanCompose } from "./clean.js";
@@ -160,11 +161,4 @@ function setNetworks(
  */
 function sortServiceKeys(service: ComposeService): ComposeService {
   return fromPairs(sortBy(toPairs(service), "0")) as ComposeService;
-}
-
-/**
- * Returns true if there is only one service in the compose file
- */
-function getIsMonoService(compose: Compose): boolean {
-  return Object.keys(compose.services).length === 1;
 }

--- a/packages/migrations/src/addAliasToRunningContainers.ts
+++ b/packages/migrations/src/addAliasToRunningContainers.ts
@@ -20,6 +20,7 @@ import {
 import { gte, lt, clean } from "semver";
 import {
   getDockerComposePath,
+  getIsMonoService,
   getPrivateNetworkAliases,
   shell,
 } from "@dappnode/utils";
@@ -50,7 +51,10 @@ export async function addAliasToGivenContainers(
       const service = {
         serviceName: container.serviceName,
         dnpName: container.dnpName,
-        isMainOrMonoservice: container.isMain ?? false, // false if isMain is undefined
+        isMainOrMonoservice:
+          getIsMonoService(
+            new ComposeFileEditor(container.dnpName, container.isCore).compose
+          ) || Boolean(container.isMain),
       };
 
       const aliases = getPrivateNetworkAliases(service);
@@ -204,9 +208,9 @@ function hasAliases(
 ): boolean {
   return Boolean(
     endpointConfig &&
-    endpointConfig.Aliases &&
-    Array.isArray(endpointConfig.Aliases) &&
-    aliases.every((alias) => endpointConfig.Aliases?.includes(alias))
+      endpointConfig.Aliases &&
+      Array.isArray(endpointConfig.Aliases) &&
+      aliases.every((alias) => endpointConfig.Aliases?.includes(alias))
   );
 }
 


### PR DESCRIPTION
Add `getIsMonoService` checker to adding aliases to docker containers