### PR TITLE
Fix Holesky Nethermind and Holesky Besu in Holesky StakersUI

### DIFF
--- a/packages/stakers/src/set/getStakerCompatibleVersionsByNetwork.ts
+++ b/packages/stakers/src/set/getStakerCompatibleVersionsByNetwork.ts
@@ -158,9 +158,7 @@ export function getStakerCompatibleVersionsByNetwork<T extends Network>(
             minVersion: "0.1.0",
           },
           {
-            dnpName: "holesky-nethermind.dnp.dappnode.eth" as ExecutionClient<
-              T
-            >,
+            dnpName: "holesky-nethermind.dnp.dappnode.eth" as ExecutionClient<T>,
             minVersion: "0.1.0",
           },
           {


### PR DESCRIPTION
# Fix Holesky StakersUI

<!-- For DAppNode core members, once the Pull Request is created, do not forget to:
1.  Link issues to the PR if available
2.  Mention dappnode core members
3.  Add proper labels
-->

## Context

> Provide context of this PR: why it was created? what does it fixes? what new feature does it provides? ...

Fixes Holesky StakersUI, currently it does not allow selecting Holesky Nethermind or Holesky Besu, throwing this error
```
error2Call to stakerConfigSet
Today, 25 min ago
Reply: Invalid execution client [object Object] for network holesky
Error: Invalid execution client [object Object] for network holesky
    at ensureSetRequirements (file:///usr/src/app/packages/dappmanager/src/modules/stakerConfig/set/ensureSetRequirements.ts:48:11)
    at setStakerConfig (file:///usr/src/app/packages/dappmanager/src/modules/stakerConfig/set/setStakerConfig.ts:75:3)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at stakerConfigSet (file:///usr/src/app/packages/dappmanager/src/calls/stakerConfig.ts:17:3)
    at file:///usr/src/app/packages/dappmanager/src/api/handler/index.ts:37:22

{
  "stakerConfig": {
    "network": "holesky",
    "feeRecipient": "0xf8AcdCB5fC3689e63c0d8033eBd986D9XXXXXXXX",
    "executionClient": {
      "status": "ok",
      "dnpName": "holesky-besu.dnp.dappnode.eth",
      "avatarUrl": "https://gateway.ipfs.dappnode.io/ipfs/QmSj4GxAr8CoKsk1b24eUFvAtiZvDtEGGK5ehTRSLMhDe7",
      "isInstalled": true,
      "isUpdated": true,
      "isRunning": true,
      "isSelected": false
    },
    "consensusClient": {
      "status": "ok",
      "dnpName": "lodestar-holesky.dnp.dappnode.eth",
      "avatarUrl": "https://gateway.ipfs.dappnode.io/ipfs/QmQ2nW4ecd63fy5z2JxdwGYKFznQxVkWx4jvyFH1Nmk7Bb",
      "isInstalled": true,
      "isUpdated": true,
      "isRunning": true,
      "isSelected": true,
      "useCheckpointSync": true
    },
    "enableWeb3signer": false
  }
}
```


## Approach

Tracing these logs led me to see that this file i edited in this PR is formatted incorrectly for Holesky nethermind, and in the array of Holesky ELs; Holesky Besu is the only one after Nethermind and thus doesn't work either as the array is not formatted correctly at that point.  I removed the extra newlines making the formatting consistent for Holesky nethermind as every other EL. I then installed this branch on a test Dappnode that previously gave me the above errors (all other nodes of mine and all users have this issue), was first brought to my attention by @chuygarcia92 from user complaints.  When the new branch with this change was installed i attempted to select nethermind and separately besu as ELs in the Holesky stakersUI and both packages installed properly and threw no errors properly setting the new stakers config, resolving the issue.

To better show how and why this bug exists and how this PR fixes it can be seen here:

1.  In current published dappmanager over SSH or direct console access enter the Dappmanager Docker Package using `docker exec -it DAppNodeCore-dappmanager.dnp.dappnode.eth sh` 
2.  Inside the container run `cd /usr/src/app/packages/dappmanager/dist/modules/stakerConfig/set` 
3.  Then run `cat getStakerCompatibleVersionsByNetwork.js` 

**_Note: the file changed in this PR is the source code file `getStakerCompatibleVersionsByNetwork.ts` in TypeScript, which is compiled into the `getStakerCompatibleVersionsByNetwork.js` JavaScript file found in the compiled dappmanager they are not the same file type or even content as the broken holesky nethermind array entry in the source TS file causes the compiled JS file below to only reflect Holesky Geth and Holesky Erigon in its array as shown below (the TS file is formatted and written similarly but not identically to the compiled JS file).  Fixing the broken array in the source TS file as this PR does, makes all 4 Holesky EL clients selectable in the stakers UI in practice and the issue is visibly fixed at the compiled code level as shown in the second output file below of the newly compiled `getStakerCompatibleVersionsByNetwork.js` file from the now fixed `getStakerCompatibleVersionsByNetwork.ts` file_**

- The output of the commands above should show the following the code blocks of the compiled JS file, The relevant snippet that shows the output of the file now is in its own separate code block from the rest of the full file readout code blocks surrounded by notes. You'll see that the array for Holesky Execution clients ends after Geth and Erigon, the next client imported in the array in the source TS file is holesky Nethermind which is formatted incorrectly and it doesn't appear here nor does holesky besu which is formatted correctly but it follows the broken array entry for nethermind and therefore isn't parsed either when its compiled into the execution Javascript.

```
/**
 * Get the current staker config (execution and consensus clients selected) as well as
 * the pkgs available for each network
 */
export function getStakerCompatibleVersionsByNetwork(network) {
    switch (network) {
        case "mainnet":
            return {
                compatibleExecution: [
                    {
                        dnpName: "geth.dnp.dappnode.eth",
                        minVersion: "0.1.37"
                    },
                    {
                        dnpName: "nethermind.public.dappnode.eth",
                        minVersion: "1.0.27"
                    },
                    {
                        dnpName: "erigon.dnp.dappnode.eth",
                        minVersion: "0.1.34"
                    },
                    {
                        dnpName: "besu.public.dappnode.eth",
                        minVersion: "1.2.6"
                    }
                ],
                compatibleConsensus: [
                    {
                        dnpName: "prysm.dnp.dappnode.eth",
                        minVersion: "3.0.4"
                    },
                    {
                        dnpName: "lighthouse.dnp.dappnode.eth",
                        minVersion: "1.0.3"
                    },
                    {
                        dnpName: "teku.dnp.dappnode.eth",
                        minVersion: "2.0.4"
                    },
                    {
                        dnpName: "nimbus.dnp.dappnode.eth",
                        minVersion: "1.0.5"
                    },
                    {
                        dnpName: "lodestar.dnp.dappnode.eth",
                        minVersion: "0.1.0"
                    }
                ],
                compatibleSigner: {
                    dnpName: "web3signer.dnp.dappnode.eth",
                    minVersion: "0.1.4"
                },
                compatibleMevBoost: {
                    dnpName: "mev-boost.dnp.dappnode.eth",
                    minVersion: "0.1.0"
                }
            };
        case "gnosis":
            return {
                compatibleExecution: [
                    {
                        dnpName: "nethermind-xdai.dnp.dappnode.eth",
                        minVersion: "1.0.18"
                    }
                ],
                compatibleConsensus: [
                    {
                        dnpName: "lighthouse-gnosis.dnp.dappnode.eth",
                        minVersion: "0.1.5"
                    },
                    {
                        dnpName: "teku-gnosis.dnp.dappnode.eth",
                        minVersion: "0.1.5"
                    },
                    {
                        dnpName: "lodestar-gnosis.dnp.dappnode.eth",
                        minVersion: "0.1.0"
                    }
                ],
                compatibleSigner: {
                    dnpName: "web3signer-gnosis.dnp.dappnode.eth",
                    minVersion: "0.1.10"
                },
                compatibleMevBoost: null // No MEV-Boost for Gnosis
            };
        case "prater":
            return {
                compatibleExecution: [
                    {
                        dnpName: "goerli-geth.dnp.dappnode.eth",
                        minVersion: "0.4.26"
                    },
                    {
                        dnpName: "goerli-erigon.dnp.dappnode.eth",
                        minVersion: "0.1.0"
                    },
                    {
                        dnpName: "goerli-nethermind.dnp.dappnode.eth",
                        minVersion: "1.0.1"
                    },
                    {
                        dnpName: "goerli-besu.dnp.dappnode.eth",
                        minVersion: "0.1.0"
                    }
                ],
                compatibleConsensus: [
                    {
                        dnpName: "prysm-prater.dnp.dappnode.eth",
                        minVersion: "1.0.15"
                    },
                    {
                        dnpName: "lighthouse-prater.dnp.dappnode.eth",
                        minVersion: "0.1.9"
                    },
                    {
                        dnpName: "teku-prater.dnp.dappnode.eth",
                        minVersion: "0.1.10"
                    },
                    {
                        dnpName: "nimbus-prater.dnp.dappnode.eth",
                        minVersion: "0.1.7"
                    },
                    {
                        dnpName: "lodestar-prater.dnp.dappnode.eth",
                        minVersion: "0.1.0"
                    }
                ],
                compatibleSigner: {
                    dnpName: "web3signer-prater.dnp.dappnode.eth",
                    minVersion: "0.1.11"
                },
                compatibleMevBoost: {
                    dnpName: "mev-boost-goerli.dnp.dappnode.eth",
                    minVersion: "0.1.0"
                }
            };
```
**THIS IS THE ISSUE, RESOLVED BY THIS PR**
```
   case "holesky":
            return {
compatibleExecution: [
                    {
                        dnpName: "holesky-geth.dnp.dappnode.eth",
                        minVersion: "0.1.0"
                    },
                    {
                        dnpName: "holesky-erigon.dnp.dappnode.eth",
                        minVersion: "0.1.0"
                    }
                ],
```
_It ends after Erigon because the next imported client in the source TS file edited in this PR is nethermind and it has extra newlines breaking the array, so it is not parsed nor is Besu which follows the improperly formatted Nethermind entry in the imported array, thus there are only 2 instead of 4 execution clients to choose from using the StakersUI in the current Dappmanager because this compiled file doesnt have all  4 of the clients entered in its source TS file edited in this PR_
```
                compatibleConsensus: [
                    {
                        dnpName: "lighthouse-holesky.dnp.dappnode.eth",
                        minVersion: "0.1.0"
                    },
                    {
                        dnpName: "prysm-holesky.dnp.dappnode.eth",
                        minVersion: "0.1.0"
                    },
                    {
                        dnpName: "teku-holesky.dnp.dappnode.eth",
                        minVersion: "0.1.0"
                    },
                    {
                        dnpName: "nimbus-holesky.dnp.dappnode.eth",
                        minVersion: "0.1.0"
                    },
                    {
                        dnpName: "lodestar-holesky.dnp.dappnode.eth",
                        minVersion: "0.1.0"
                    }
                ],
                compatibleSigner: {
                    dnpName: "web3signer-holesky.dnp.dappnode.eth",
                    minVersion: "0.1.0"
                },
                compatibleMevBoost: {
                    dnpName: "mev-boost-holesky.dnp.dappnode.eth",
                    minVersion: "0.1.0"
                }
            };
        case "lukso":
            return {
                compatibleExecution: [
                    {
                        dnpName: "lukso-geth.dnp.dappnode.eth",
                        minVersion: "0.1.0"
                    }
                    /*{
                      dnpName: "lukso-erigon.dnp.dappnode.eth" as ExecutionClient<T>,
                      minVersion: "0.1.0"
                    }*/
                ],
                compatibleConsensus: [
                    /*{
                      dnpName: "lighthouse-lukso.dnp.dappnode.eth" as ConsensusClient<T>,
                      minVersion: "0.1.0"
                    },*/
                    {
                        dnpName: "prysm-lukso.dnp.dappnode.eth",
                        minVersion: "0.1.0"
                    },
                    {
                        dnpName: "teku-lukso.dnp.dappnode.eth",
                        minVersion: "0.1.0"
                    }
                ],
                compatibleSigner: {
                    dnpName: "web3signer-lukso.dnp.dappnode.eth",
                    minVersion: "0.1.0"
                },
                compatibleMevBoost: null // No MEV-Boost for Lukso
            };
        default:
            throw Error(`Unsupported network: ${network}`);
    }
}
//# sourceMappingURL=getStakerCompatibleVersionsByNetwork.js.map
```

This file cannot be checked the same way after installing this branch or the version bump PR to this branch because it moved in the code in the latest dappmanager branch yet to be released that this is based on, but it can be found the same way as above but instead, after entering the Dappmanager container with a terminal, navigate to its new home here `cd /usr/src/app/packages/stakers/dist/set` then run `cat getStakerCompatibleVersionsByNetwork.js` which will output a very similar file as the one did above before upgrading but this time you'll find that there are all 4 Execution Clients under the Holesky Section as there should be.

```
/**
 * Get the current staker config (execution and consensus clients selected) as well as
 * the pkgs available for each network
 */
export function getStakerCompatibleVersionsByNetwork(network) {
    switch (network) {
        case "mainnet":
            return {
                compatibleExecution: [
                    {
                        dnpName: "geth.dnp.dappnode.eth",
                        minVersion: "0.1.37",
                    },
                    {
                        dnpName: "nethermind.public.dappnode.eth",
                        minVersion: "1.0.27",
                    },
                    {
                        dnpName: "erigon.dnp.dappnode.eth",
                        minVersion: "0.1.34",
                    },
                    {
                        dnpName: "besu.public.dappnode.eth",
                        minVersion: "1.2.6",
                    },
                ],
                compatibleConsensus: [
                    {
                        dnpName: "prysm.dnp.dappnode.eth",
                        minVersion: "3.0.4",
                    },
                    {
                        dnpName: "lighthouse.dnp.dappnode.eth",
                        minVersion: "1.0.3",
                    },
                    {
                        dnpName: "teku.dnp.dappnode.eth",
                        minVersion: "2.0.4",
                    },
                    {
                        dnpName: "nimbus.dnp.dappnode.eth",
                        minVersion: "1.0.5",
                    },
                    {
                        dnpName: "lodestar.dnp.dappnode.eth",
                        minVersion: "0.1.0",
                    },
                ],
                compatibleSigner: {
                    dnpName: "web3signer.dnp.dappnode.eth",
                    minVersion: "0.1.4",
                },
                compatibleMevBoost: {
                    dnpName: "mev-boost.dnp.dappnode.eth",
                    minVersion: "0.1.0",
                },
            };
        case "gnosis":
            return {
                compatibleExecution: [
                    {
                        dnpName: "nethermind-xdai.dnp.dappnode.eth",
                        minVersion: "1.0.18",
                    },
                ],
                compatibleConsensus: [
                    {
                        dnpName: "lighthouse-gnosis.dnp.dappnode.eth",
                        minVersion: "0.1.5",
                    },
                    {
                        dnpName: "teku-gnosis.dnp.dappnode.eth",
                        minVersion: "0.1.5",
                    },
                    {
                        dnpName: "lodestar-gnosis.dnp.dappnode.eth",
                        minVersion: "0.1.0",
                    },
                ],
                compatibleSigner: {
                    dnpName: "web3signer-gnosis.dnp.dappnode.eth",
                    minVersion: "0.1.10",
                },
                compatibleMevBoost: null, // No MEV-Boost for Gnosis
            };
        case "prater":
            return {
                compatibleExecution: [
                    {
                        dnpName: "goerli-geth.dnp.dappnode.eth",
                        minVersion: "0.4.26",
                    },
                    {
                        dnpName: "goerli-erigon.dnp.dappnode.eth",
                        minVersion: "0.1.0",
                    },
                    {
                        dnpName: "goerli-nethermind.dnp.dappnode.eth",
                        minVersion: "1.0.1",
                    },
                    {
                        dnpName: "goerli-besu.dnp.dappnode.eth",
                        minVersion: "0.1.0",
                    },
                ],
                compatibleConsensus: [
                    {
                        dnpName: "prysm-prater.dnp.dappnode.eth",
                        minVersion: "1.0.15",
                    },
                    {
                        dnpName: "lighthouse-prater.dnp.dappnode.eth",
                        minVersion: "0.1.9",
                    },
                    {
                        dnpName: "teku-prater.dnp.dappnode.eth",
                        minVersion: "0.1.10",
                    },
                    {
                        dnpName: "nimbus-prater.dnp.dappnode.eth",
                        minVersion: "0.1.7",
                    },
                    {
                        dnpName: "lodestar-prater.dnp.dappnode.eth",
                        minVersion: "0.1.0",
                    },
                ],
                compatibleSigner: {
                    dnpName: "web3signer-prater.dnp.dappnode.eth",
                    minVersion: "0.1.11",
                },
                compatibleMevBoost: {
                    dnpName: "mev-boost-goerli.dnp.dappnode.eth",
                    minVersion: "0.1.0",
                },
            };
```
**All four ELs are present for Holesky now that the formatting of the source TS file array was resolved and it can parse all 4 clients as shown here**
```        
      case "holesky":
            return {
                compatibleExecution: [
                    {
                        dnpName: "holesky-geth.dnp.dappnode.eth",
                        minVersion: "0.1.0",
                    },
                    {
                        dnpName: "holesky-erigon.dnp.dappnode.eth",
                        minVersion: "0.1.0",
                    },
                    {
                        dnpName: "holesky-nethermind.dnp.dappnode.eth",
                        minVersion: "0.1.0",
                    },
                    {
                        dnpName: "holesky-besu.dnp.dappnode.eth",
                        minVersion: "0.1.0",
                    },
                ],
```
```
                compatibleConsensus: [
                    {
                        dnpName: "lighthouse-holesky.dnp.dappnode.eth",
                        minVersion: "0.1.0",
                    },
                    {
                        dnpName: "prysm-holesky.dnp.dappnode.eth",
                        minVersion: "0.1.0",
                    },
                    {
                        dnpName: "teku-holesky.dnp.dappnode.eth",
                        minVersion: "0.1.0",
                    },
                    {
                        dnpName: "nimbus-holesky.dnp.dappnode.eth",
                        minVersion: "0.1.0",
                    },
                    {
                        dnpName: "lodestar-holesky.dnp.dappnode.eth",
                        minVersion: "0.1.0",
                    },
                ],
                compatibleSigner: {
                    dnpName: "web3signer-holesky.dnp.dappnode.eth",
                    minVersion: "0.1.0",
                },
                compatibleMevBoost: {
                    dnpName: "mev-boost-holesky.dnp.dappnode.eth",
                    minVersion: "0.1.0",
                },
            };
        case "lukso":
            return {
                compatibleExecution: [
                    {
                        dnpName: "lukso-geth.dnp.dappnode.eth",
                        minVersion: "0.1.0",
                    },
                    /*{
                      dnpName: "lukso-erigon.dnp.dappnode.eth" as ExecutionClient<T>,
                      minVersion: "0.1.0"
                    }*/
                ],
                compatibleConsensus: [
                    /*{
                      dnpName: "lighthouse-lukso.dnp.dappnode.eth" as ConsensusClient<T>,
                      minVersion: "0.1.0"
                    },*/
                    {
                        dnpName: "prysm-lukso.dnp.dappnode.eth",
                        minVersion: "0.1.0",
                    },
                    {
                        dnpName: "teku-lukso.dnp.dappnode.eth",
                        minVersion: "0.1.0",
                    },
                ],
                compatibleSigner: {
                    dnpName: "web3signer-lukso.dnp.dappnode.eth",
                    minVersion: "0.1.0",
                },
                compatibleMevBoost: null, // No MEV-Boost for Lukso
            };
        default:
            throw Error(`Unsupported network: ${network}`);
    }
}
//# sourceMappingURL=getStakerCompatibleVersionsByNetwork.js.map
```

> Define the solution for the issue or feature that this PR aims to fix

## Test instructions

<!-- MANDATORY: please, do not skip this step, it is very important for DAppNode team to have simple and well defined instructions on how to test this PR.
-->

1. To confirm the issue first using the current Dappmanager version navigate to the Stakers Tab in the Left NavBar,
2. Select Holesky from the Tabs across the top, and attempt to set a Holesky configuration (no web3signer is needed, but a CL is) with Holesky Nethermind or Holesky Besu as the EL and whatever you want for CL.  
3. It will fail with the above error logs.
4. To test the fix download this PR's IPFS hash and install it bypassing core and signed safe toggles
5. Double check in the Support / Report  that the dappmanager is now the `voss/fix-Holesky-StakersUI` Branch
6. Now return to Holesky Stakers Tab, and from there now attempt to set a new config with Holesky Nethermind and later Holesky Besu as the selected EL and everything should work normally, no errors, it will install the packages if needed and start syncing them with the selected CL.

NOTE: There may be issues testing this way, It works for me but after a day it stopped working due to version mismatch (this PR Hash is Dappamanger version 0.2.71 so anything with dependencies on dappmanger version (lots) and the DNP-Core package expect v0.2.79 and unexpected behaviour can occur, all chains disappearing, all packages disappearing stakers pages not loading, etc, but restart it and it should be fine or better yet just install the hash in this temporary PR #1785 same code as this PR but with the manifest version bumped to match the current released dappmanager.

@pablomendezroyo i tried to mention this to you but i found the issue myself and resolved it here.
Should try and merge this ASAP as it keeps users from using half of the Holesky ELs in its current state.
