### PR TITLE
Delete hardcoded IP in installer

### DIFF
--- a/packages/dockerCompose/src/setDappnodeComposeDefaults.ts
+++ b/packages/dockerCompose/src/setDappnodeComposeDefaults.ts
@@ -115,21 +115,17 @@ function setServiceNetworksWithAliases(
     };
 
   serviceNetworks = parseServiceNetworks(serviceNetworks);
-
-  // Return the service network dncore_network with the aliases added
-  const privateNetworkConfig = {
-    ...(serviceNetworks[params.DOCKER_PRIVATE_NETWORK_NAME] || {}),
-    aliases: getPrivateNetworkAliases(service),
-  };
-
-  // only allow bind to have ipv4_address hardcoded
-  if (service.dnpName === params.bindDnpName)
-    privateNetworkConfig.ipv4_address = params.BIND_IP;
-  else delete privateNetworkConfig.ipv4_address;
-
+  const dncoreServiceNetwork =
+    serviceNetworks[params.DOCKER_PRIVATE_NETWORK_NAME] || {};
+  // do not allow to set hardcoded IPs
+  // TODO: allow bind in the future, after 0.3.0
+  if (dncoreServiceNetwork.ipv4_address)
+    delete dncoreServiceNetwork.ipv4_address;
   return {
-    ...serviceNetworks,
-    [params.DOCKER_PRIVATE_NETWORK_NAME]: privateNetworkConfig,
+    [params.DOCKER_PRIVATE_NETWORK_NAME]: {
+      ...dncoreServiceNetwork,
+      aliases: getPrivateNetworkAliases(service),
+    },
   };
 }
 

--- a/packages/dockerCompose/src/setDappnodeComposeDefaults.ts
+++ b/packages/dockerCompose/src/setDappnodeComposeDefaults.ts
@@ -122,6 +122,7 @@ function setServiceNetworksWithAliases(
   if (dncoreServiceNetwork.ipv4_address)
     delete dncoreServiceNetwork.ipv4_address;
   return {
+    ...serviceNetworks,
     [params.DOCKER_PRIVATE_NETWORK_NAME]: {
       ...dncoreServiceNetwork,
       aliases: getPrivateNetworkAliases(service),

--- a/packages/migrations/src/ensureCoreComposesHardcodedIpsRange.ts
+++ b/packages/migrations/src/ensureCoreComposesHardcodedIpsRange.ts
@@ -61,7 +61,7 @@ export async function ensureCoreComposesHardcodedIpsRange(): Promise<void> {
           serviceCoreNetwork[params.DOCKER_PRIVATE_NETWORK_NAME];
         if (coreNetwork.ipv4_address) {
           logs.info(`removing ip ${coreNetwork.ipv4_address} from ${core}`);
-          coreNetwork.ipv4_address = undefined;
+          delete coreNetwork.ipv4_address;
           compose.write();
         }
       }


### PR DESCRIPTION
Delete every hardcoded IP in installer.

Consider in the future allowing only bind to have a hardcoded IP
