### PR TITLE
bump version number to current for testing pre release

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,6 +1,6 @@
 {
   "name": "dappmanager.dnp.dappnode.eth",
-  "version": "0.2.71",
+  "version": "0.2.79",
   "description": "Dappnode package responsible for providing the Dappnode Package Manager",
   "type": "dncore",
   "architectures": ["linux/amd64", "linux/arm64"],


### PR DESCRIPTION
bumping version number to the current release since the hardcoded version is 8 versions behind current, messing up communication between some packages i.e. core and packages requiring minimum dappmanger versions,  

This is only for testing purposes as when its merged and published it will be bumped to v0.2.80

<!-- For DAppNode core members, once the Pull Request is created, do not forget to:
1.  Link issues to the PR if available
2.  Mention dappnode core members
3.  Add proper labels
-->

## Context

> Provide context of this PR: why it was created? what does it fixes? what new feature does it provides? ...

## Approach

> Define the solution for the issue or feature that this PR aims to fix

## Test instructions

<!-- MANDATORY: please, do not skip this step, it is very importand for DAppNode team to have simple and well defined instructions on how to test this PR.
-->
