### PR TITLE
Set static network for all JSON RPC providers

### DIFF
--- a/packages/chains/src/drivers/ethereum.ts
+++ b/packages/chains/src/drivers/ethereum.ts
@@ -52,7 +52,12 @@ export async function ethereum(
 
   const apiUrl = `http://${containerDomain}:${port}`;
 
-  const provider = new ethers.JsonRpcProvider(apiUrl, undefined, { staticNetwork: true });
+  const network = await new ethers.JsonRpcProvider(apiUrl).getNetwork();
+
+  const provider = new ethers.JsonRpcProvider(apiUrl, network, {
+    staticNetwork: network,
+  });
+
   const [syncing, peersCount, blockNumber] = await Promise.all([
     provider.send("eth_syncing", []).then(parseEthersSyncing),
     // net_peerCount is not always available. OP Erigon does not support it

--- a/packages/chains/src/drivers/ethereum.ts
+++ b/packages/chains/src/drivers/ethereum.ts
@@ -52,7 +52,7 @@ export async function ethereum(
 
   const apiUrl = `http://${containerDomain}:${port}`;
 
-  const provider = new ethers.JsonRpcProvider(apiUrl);
+  const provider = new ethers.JsonRpcProvider(apiUrl, undefined, { staticNetwork: true });
   const [syncing, peersCount, blockNumber] = await Promise.all([
     provider.send("eth_syncing", []).then(parseEthersSyncing),
     // net_peerCount is not always available. OP Erigon does not support it

--- a/packages/dappmanager/src/api/middlewares/ethForward/resolveDomain.ts
+++ b/packages/dappmanager/src/api/middlewares/ethForward/resolveDomain.ts
@@ -61,7 +61,7 @@ export function ResolveDomainWithCache(): (domain: string) => Promise<Content> {
   return async function (domain: string): Promise<Content> {
     const network = parseNetworkFromDomain(domain);
     const providerUrl = await _getEthersProviderByNetwork(network);
-    const provider = new ethers.JsonRpcProvider(providerUrl);
+    const provider = new ethers.JsonRpcProvider(providerUrl, "mainnet", { staticNetwork: true });
     return _resolveDomain(domain, provider);
   };
 }

--- a/packages/installer/src/ethClient/clientStatus.ts
+++ b/packages/installer/src/ethClient/clientStatus.ts
@@ -218,7 +218,7 @@ async function isSyncedWithRemoteExecution(localUrl: string): Promise<boolean> {
  * @param url "http://geth.dappnode:8545"
  */
 async function isSyncing(url: string): Promise<boolean> {
-  const provider = new ethers.JsonRpcProvider(url, undefined, {
+  const provider = new ethers.JsonRpcProvider(url, "mainnet", {
     staticNetwork: true,
   });
   const syncing = await provider

--- a/packages/installer/src/ethClient/clientStatus.ts
+++ b/packages/installer/src/ethClient/clientStatus.ts
@@ -14,6 +14,7 @@ import { parseEthersBlock, parseEthersSyncing } from "@dappnode/utils";
 import { logs } from "@dappnode/logger";
 import fetch from "node-fetch";
 import { params } from "@dappnode/params";
+import { isNullOrUndefined } from "util";
 
 /**
  * 7200 is the average blocks per day in Ethereum as Mon Nov 28 2022
@@ -188,7 +189,7 @@ export async function getMultiClientStatus(
 async function isSyncedWithRemoteExecution(localUrl: string): Promise<boolean> {
   if (db.ethClientFallback.get() === "off") return true;
   // Check is synced with remote execution
-  const latestLocalBlock = await new ethers.JsonRpcProvider(localUrl)
+  const latestLocalBlock = await new ethers.JsonRpcProvider(localUrl, undefined, { staticNetwork: true })
     .send("eth_blockNumber", [])
     .then(parseEthersBlock);
 
@@ -208,7 +209,7 @@ async function isSyncedWithRemoteExecution(localUrl: string): Promise<boolean> {
  * @param url "http://geth.dappnode:8545"
  */
 async function isSyncing(url: string): Promise<boolean> {
-  const provider = new ethers.JsonRpcProvider(url);
+  const provider = new ethers.JsonRpcProvider(url, undefined, { staticNetwork: true });
   const syncing = await provider
     .send("eth_syncing", [])
     .then(parseEthersSyncing);
@@ -240,7 +241,7 @@ async function isApmStateCorrect(url: string): Promise<boolean> {
   const result =
     "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000b000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000342f697066732f516d63516958454c42745363646278464357454a517a69664d54736b4e5870574a7a7a5556776d754e336d4d4361000000000000000000000000";
 
-  const provider = new ethers.JsonRpcProvider(url);
+  const provider = new ethers.JsonRpcProvider(url, "mainnet", { staticNetwork: true });
 
   const res = await provider.send("eth_call", [testTxData, "latest"]);
   return res === result;
@@ -257,7 +258,7 @@ async function isSyncedWithConsensus(
   execUrl: string,
   consUrl: string
 ): Promise<boolean> {
-  const provider = new ethers.JsonRpcProvider(execUrl);
+  const provider = new ethers.JsonRpcProvider(execUrl, undefined, { staticNetwork: true });
   const execBlockNumber = await provider.getBlockNumber();
   const execBlockHeadersResponse = await fetch(
     consUrl + "/eth/v2/beacon/blocks/head"

--- a/packages/installer/src/ethClient/clientStatus.ts
+++ b/packages/installer/src/ethClient/clientStatus.ts
@@ -14,7 +14,6 @@ import { parseEthersBlock, parseEthersSyncing } from "@dappnode/utils";
 import { logs } from "@dappnode/logger";
 import fetch from "node-fetch";
 import { params } from "@dappnode/params";
-import { isNullOrUndefined } from "util";
 
 /**
  * 7200 is the average blocks per day in Ethereum as Mon Nov 28 2022
@@ -189,12 +188,22 @@ export async function getMultiClientStatus(
 async function isSyncedWithRemoteExecution(localUrl: string): Promise<boolean> {
   if (db.ethClientFallback.get() === "off") return true;
   // Check is synced with remote execution
-  const latestLocalBlock = await new ethers.JsonRpcProvider(localUrl, undefined, { staticNetwork: true })
+  const latestLocalBlock = await new ethers.JsonRpcProvider(
+    localUrl,
+    "mainnet",
+    {
+      staticNetwork: true,
+    }
+  )
     .send("eth_blockNumber", [])
     .then(parseEthersBlock);
 
   const latestRemoteBlock = await new ethers.JsonRpcProvider(
-    params.ETH_MAINNET_RPC_URL_REMOTE
+    params.ETH_MAINNET_RPC_URL_REMOTE,
+    "mainnet",
+    {
+      staticNetwork: true,
+    }
   )
     .send("eth_blockNumber", [])
     .then(parseEthersBlock);
@@ -209,7 +218,9 @@ async function isSyncedWithRemoteExecution(localUrl: string): Promise<boolean> {
  * @param url "http://geth.dappnode:8545"
  */
 async function isSyncing(url: string): Promise<boolean> {
-  const provider = new ethers.JsonRpcProvider(url, undefined, { staticNetwork: true });
+  const provider = new ethers.JsonRpcProvider(url, undefined, {
+    staticNetwork: true,
+  });
   const syncing = await provider
     .send("eth_syncing", [])
     .then(parseEthersSyncing);
@@ -241,7 +252,9 @@ async function isApmStateCorrect(url: string): Promise<boolean> {
   const result =
     "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000b000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000342f697066732f516d63516958454c42745363646278464357454a517a69664d54736b4e5870574a7a7a5556776d754e336d4d4361000000000000000000000000";
 
-  const provider = new ethers.JsonRpcProvider(url, "mainnet", { staticNetwork: true });
+  const provider = new ethers.JsonRpcProvider(url, "mainnet", {
+    staticNetwork: true,
+  });
 
   const res = await provider.send("eth_call", [testTxData, "latest"]);
   return res === result;
@@ -258,7 +271,9 @@ async function isSyncedWithConsensus(
   execUrl: string,
   consUrl: string
 ): Promise<boolean> {
-  const provider = new ethers.JsonRpcProvider(execUrl, undefined, { staticNetwork: true });
+  const provider = new ethers.JsonRpcProvider(execUrl, "mainnet", {
+    staticNetwork: true,
+  });
   const execBlockNumber = await provider.getBlockNumber();
   const execBlockHeadersResponse = await fetch(
     consUrl + "/eth/v2/beacon/blocks/head"


### PR DESCRIPTION
This PR aims to avoid the errors:
```
JsonRpcProvider failed to detect network and cannot start up; retry in 1s (perhaps the URL is wrong or the node is not started)
JsonRpcProvider failed to detect network and cannot start up; retry in 1s (perhaps the URL is wrong or the node is not started)
JsonRpcProvider failed to detect network and cannot start up; retry in 1s (perhaps the URL is wrong or the node is not started)
JsonRpcProvider failed to detect network and cannot start up; retry in 1s (perhaps the URL is wrong or the node is not started)
JsonRpcProvider failed to detect network and cannot start up; retry in 1s (perhaps the URL is wrong or the node is not started)
JsonRpcProvider failed to detect network and cannot start up; retry in 1s (perhaps the URL is wrong or the node is not started)
JsonRpcProvider failed to detect network and cannot start up; retry in 1s (perhaps the URL is wrong or the node is not started)
JsonRpcProvider failed to detect network and cannot start up; retry in 1s (perhaps the URL is wrong or the node is not started)
```