### PR TITLE
Remove intermedium container if any

### DIFF
--- a/packages/daemons/src/bind/ensureBindContainerIpAndRunning.ts
+++ b/packages/daemons/src/bind/ensureBindContainerIpAndRunning.ts
@@ -31,41 +31,60 @@ async function disconnectConflictingContainerAndStartBind(): Promise<void> {
 }
 
 export async function ensureBindContainerIpAndRunning(): Promise<void> {
-  const isBindRunning = (
-    await docker.getContainer(params.bindContainerName).inspect()
-  ).State.Running;
+  try {
+    const isBindRunning = (
+      await docker.getContainer(params.bindContainerName).inspect()
+    ).State.Running;
 
-  // check if the bind container is running
-  if (!isBindRunning) {
-    logs.info(`${params.bindContainerName} container is not running`);
-    await disconnectConflictingContainerAndStartBind();
-  } else {
-    // check is connected to dncore_network
-    const isConnectedToNetwork = Object.values(
-      (
-        (await docker
-          .getNetwork(params.DOCKER_PRIVATE_NETWORK_NAME)
-          .inspect()) as Dockerode.NetworkInspectInfo
-      ).Containers ?? []
-    ).some((container) => container.Name === params.bindContainerName);
-
-    if (!isConnectedToNetwork) {
-      logs.info(
-        `${params.bindContainerName} container is not connected to ${params.DOCKER_PRIVATE_NETWORK_NAME} network`
-      );
+    // check if the bind container is running
+    if (!isBindRunning) {
+      logs.info(`${params.bindContainerName} container is not running`);
       await disconnectConflictingContainerAndStartBind();
     } else {
-      // check it has the right IP
-      const hasRightIp =
-        (await docker.getContainer(params.bindContainerName).inspect())
-          .NetworkSettings.Networks[params.DOCKER_PRIVATE_NETWORK_NAME]
-          .IPAddress === params.BIND_IP;
-      if (hasRightIp) {
-        logs.info(`${params.bindContainerName} container has right IP`);
-      } else {
-        logs.info(`${params.bindContainerName} container has wrong IP`);
+      // check is connected to dncore_network
+      const isConnectedToNetwork = Object.values(
+        (
+          (await docker
+            .getNetwork(params.DOCKER_PRIVATE_NETWORK_NAME)
+            .inspect()) as Dockerode.NetworkInspectInfo
+        ).Containers ?? []
+      ).some((container) => container.Name === params.bindContainerName);
+
+      if (!isConnectedToNetwork) {
+        logs.info(
+          `${params.bindContainerName} container is not connected to ${params.DOCKER_PRIVATE_NETWORK_NAME} network`
+        );
         await disconnectConflictingContainerAndStartBind();
+      } else {
+        // check it has the right IP
+        const hasRightIp =
+          (await docker.getContainer(params.bindContainerName).inspect())
+            .NetworkSettings.Networks[params.DOCKER_PRIVATE_NETWORK_NAME]
+            .IPAddress === params.BIND_IP;
+        if (hasRightIp) {
+          logs.info(`${params.bindContainerName} container has right IP`);
+        } else {
+          logs.info(`${params.bindContainerName} container has wrong IP`);
+          await disconnectConflictingContainerAndStartBind();
+        }
       }
     }
+  } catch (e) {
+    // check if container does not exist 404
+    if (e.statusCode === 404) {
+      logs.warn(
+        `container ${params.bindContainerName} not found and it might be in an intermedium state`
+      );
+      // the container might be in intermedium state with different name
+      // TODO: what if there is a docker container already using this IP.
+      // This would be extremley dangerous once the migration to the private ip range is done
+      // and less ips are available.
+      logs.info(
+        `recreating container ${params.bindContainerName} with compose up`
+      );
+      await dockerComposeUp(getDockerComposePath(params.bindDnpName, true), {
+        forceRecreate: true,
+      });
+    } else throw e;
   }
 }

--- a/packages/migrations/src/migrateDockerNetworkIpRange/connectContainersToNetworkWithPrio/connectContainersToNetworkWithPrio.ts
+++ b/packages/migrations/src/migrateDockerNetworkIpRange/connectContainersToNetworkWithPrio/connectContainersToNetworkWithPrio.ts
@@ -49,7 +49,11 @@ export async function connectContainersToNetworkWithPrio({
     containerName: dappmanagerContainer.name,
     containerIp: dappmanagerContainer.ip,
     aliasesIpsMap,
-  });
+  }).catch((e) =>
+    logs.error(
+      `Failed to connect container ${dappmanagerContainer.name} to network ${network.id}: ${e}`
+    )
+  );
 
   // 2. Connect bind container
   await connectContainerWithIp({
@@ -57,12 +61,18 @@ export async function connectContainersToNetworkWithPrio({
     containerName: bindContainer.name,
     containerIp: bindContainer.ip,
     aliasesIpsMap,
-  });
+  }).catch((e) =>
+    logs.error(
+      `Failed to connect container ${bindContainer.name} to network ${network.id}: ${e}`
+    )
+  );
 
   await restoreContainersToNetworkNotThrow({
     containersToRestart,
     network,
     aliasesIpsMap,
     containersToRecreate,
-  });
+  }).catch((e) =>
+    logs.error(`Failed to restore containers to network ${network.id}: ${e}`)
+  );
 }


### PR DESCRIPTION
Remove intermedium container if any. There has been detected issues when updating other core packages that has an intermedium container with a name prefixed with the container ID that conflicts with the existing container