### PR TITLE
bump dappnode deps internally: types and schemas

### DIFF
--- a/packages/admin-ui/package.json
+++ b/packages/admin-ui/package.json
@@ -21,7 +21,7 @@
     "dev": "nodemon --ignore \"*.json\" -e ts,tsx --watch src/ --exec \"yarn build\""
   },
   "dependencies": {
-    "@dappnode/types": "^0.1.0",
+    "@dappnode/types": "^0.1.34",
     "@dappnode/common": "^0.1.0",
     "@dappnode/dappmanager": "^0.1.0",
     "@dappnode/eventbus": "^0.1.0",

--- a/packages/chains/package.json
+++ b/packages/chains/package.json
@@ -19,7 +19,7 @@
     "lint": "eslint . --ext .ts --fix src"
   },
   "dependencies": {
-    "@dappnode/types": "^0.1.0",
+    "@dappnode/types": "^0.1.34",
     "@dappnode/dockerapi": "^0.1.0",
     "@dappnode/logger": "^0.1.0",
     "@dappnode/utils": "^0.1.0",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -19,7 +19,7 @@
     "lint": "eslint . --ext .ts --fix src"
   },
   "dependencies": {
-    "@dappnode/types": "^0.1.0",
+    "@dappnode/types": "^0.1.34",
     "lodash-es": "^4.17.21"
   },
   "devDependencies": {

--- a/packages/daemons/package.json
+++ b/packages/daemons/package.json
@@ -19,7 +19,7 @@
     "lint": "eslint . --ext .ts --fix src"
   },
   "dependencies": {
-    "@dappnode/types": "^0.1.0",
+    "@dappnode/types": "^0.1.34",
     "@dappnode/upnpc": "^0.1.0",
     "@dappnode/db": "^0.1.0",
     "@dappnode/dockerapi": "^0.1.0",

--- a/packages/dappmanager/package.json
+++ b/packages/dappmanager/package.json
@@ -21,7 +21,7 @@
   },
   "license": "GPL-3.0",
   "dependencies": {
-    "@dappnode/types": "^0.1.0",
+    "@dappnode/types": "^0.1.34",
     "@dappnode/chains": "^0.1.0",
     "@dappnode/common": "^0.1.0",
     "@dappnode/daemons": "^0.1.0",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -19,7 +19,7 @@
     "lint": "eslint . --ext .ts --fix src"
   },
   "dependencies": {
-    "@dappnode/types": "^0.1.0",
+    "@dappnode/types": "^0.1.34",
     "@dappnode/dockerapi": "^0.1.0",
     "@dappnode/dockercompose": "^0.1.0",
     "@dappnode/eventbus": "^0.1.0",

--- a/packages/dockerCompose/package.json
+++ b/packages/dockerCompose/package.json
@@ -19,7 +19,7 @@
     "lint": "eslint . --ext .ts --fix src"
   },
   "dependencies": {
-    "@dappnode/types": "^0.1.0",
+    "@dappnode/types": "^0.1.34",
     "@dappnode/utils": "^0.1.0",
     "lodash-es": "^4.17.21"
   },

--- a/packages/eventBus/package.json
+++ b/packages/eventBus/package.json
@@ -18,7 +18,7 @@
     "lint": "eslint . --ext .ts --fix src"
   },
   "dependencies": {
-    "@dappnode/types": "^0.1.0",
+    "@dappnode/types": "^0.1.34",
     "lodash-es": "^4.17.21"
   },
   "devDependencies": {

--- a/packages/hostScriptsServices/package.json
+++ b/packages/hostScriptsServices/package.json
@@ -19,7 +19,7 @@
     "lint": "eslint . --ext .ts --fix src"
   },
   "dependencies": {
-    "@dappnode/types": "^0.1.0",
+    "@dappnode/types": "^0.1.34",
     "@dappnode/logger": "^0.1.0",
     "@dappnode/utils": "^0.1.0",
     "memoizee": "0.4.14"

--- a/packages/httpsPortal/package.json
+++ b/packages/httpsPortal/package.json
@@ -19,7 +19,7 @@
     "lint": "eslint . --ext .ts --fix src"
   },
   "dependencies": {
-    "@dappnode/types": "^0.1.0",
+    "@dappnode/types": "^0.1.34",
     "@dappnode/dockerapi": "^0.1.0",
     "@dappnode/dockercompose": "^0.1.0",
     "@dappnode/logger": "^0.1.0",

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -19,7 +19,7 @@
     "lint": "eslint . --ext .ts --fix src"
   },
   "dependencies": {
-    "@dappnode/types": "^0.1.0",
+    "@dappnode/types": "^0.1.34",
     "@dappnode/db": "^0.1.0",
     "@dappnode/dockerapi": "^0.1.0",
     "@dappnode/dockercompose": "^0.1.0",
@@ -28,7 +28,7 @@
     "@dappnode/httpsportal": "^0.1.0",
     "@dappnode/logger": "^0.1.0",
     "@dappnode/params": "^0.1.0",
-    "@dappnode/schemas": "^0.1.0",
+    "@dappnode/schemas": "^0.1.11",
     "@dappnode/toolkit": "^0.1.0",
     "@dappnode/utils": "^0.1.0",
     "deepmerge": "2.2.1",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -19,7 +19,7 @@
     "lint": "eslint . --ext .ts --fix src"
   },
   "dependencies": {
-    "@dappnode/types": "^0.1.0",
+    "@dappnode/types": "^0.1.34",
     "@dappnode/eventbus": "^0.1.0",
     "@dappnode/params": "^0.1.0",
     "@dappnode/utils": "^0.1.0",

--- a/packages/migrations/package.json
+++ b/packages/migrations/package.json
@@ -20,7 +20,7 @@
     "lint": "eslint . --ext .ts --fix src"
   },
   "dependencies": {
-    "@dappnode/types": "^0.1.0",
+    "@dappnode/types": "^0.1.34",
     "@dappnode/db": "^0.1.0",
     "@dappnode/dockerapi": "^0.1.0",
     "@dappnode/dockercompose": "^0.1.0",

--- a/packages/optimism/package.json
+++ b/packages/optimism/package.json
@@ -18,7 +18,7 @@
     "lint": "eslint . --ext .ts --fix src"
   },
   "dependencies": {
-    "@dappnode/types": "^0.1.0",
+    "@dappnode/types": "^0.1.34",
     "@dappnode/db": "^0.1.0",
     "@dappnode/dockerapi": "^0.1.0",
     "@dappnode/dockercompose": "^0.1.0",

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dappnode/schemas",
   "type": "module",
-  "version": "0.1.0",
+  "version": "0.1.11",
   "description": "A shared TypeScript JSON schemas and its validation functions for the manifest and setup wizard dappnode files",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -36,7 +36,7 @@
     "@types/node": "^20.6.2"
   },
   "dependencies": {
-    "@dappnode/types": "^0.1.0",
+    "@dappnode/types": "^0.1.34",
     "ajv": "^8.12.0",
     "semver": "^7.5.0"
   }

--- a/packages/stakers/package.json
+++ b/packages/stakers/package.json
@@ -18,7 +18,7 @@
     "lint": "eslint . --ext .ts --fix src"
   },
   "dependencies": {
-    "@dappnode/types": "^0.1.0",
+    "@dappnode/types": "^0.1.34",
     "@dappnode/db": "^0.1.0",
     "@dappnode/dockerapi": "^0.1.0",
     "@dappnode/installer": "^0.1.0",

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -42,7 +42,7 @@
     "typechain": "^8.3.2"
   },
   "dependencies": {
-    "@dappnode/types": "^0.1.0",
+    "@dappnode/types": "^0.1.34",
     "@ipld/car": "^5.1.1",
     "esm": "^3.2.25",
     "ethers": "^6.9.0",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dappnode/types",
   "type": "module",
-  "version": "0.1.0",
+  "version": "0.1.34",
   "license": "GPL-3.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/upnpc/package.json
+++ b/packages/upnpc/package.json
@@ -19,7 +19,7 @@
     "lint": "eslint . --ext .ts --fix src"
   },
   "dependencies": {
-    "@dappnode/types": "^0.1.0",
+    "@dappnode/types": "^0.1.34",
     "@dappnode/dockerapi": "^0.1.0",
     "@dappnode/utils": "^0.1.0",
     "is-ip": "3.0.0"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -20,7 +20,7 @@
     "lint": "eslint . --ext .ts --fix src"
   },
   "dependencies": {
-    "@dappnode/types": "^0.1.0",
+    "@dappnode/types": "^0.1.34",
     "@dappnode/params": "^0.1.0",
     "ajv": "^6.10.2",
     "async-retry": "^1.3.1",


### PR DESCRIPTION
bump dappnode deps internally:
- schemas: 0.1.11
- types: 0.1.34

Since these packages are also npm modules it is required for them to have the proper version in the package.json for those npm modules that has as dependency another npm module
