### PR TITLE
Fix injecting opt dependencies when dependencies does not exist

### DIFF
--- a/packages/installer/src/dappGet/fetch/DappGetFetcher.ts
+++ b/packages/installer/src/dappGet/fetch/DappGetFetcher.ts
@@ -33,7 +33,7 @@ export class DappGetFetcher {
       }
     }
 
-    return manifest.dependencies || {};
+    return dependencies;
   }
 
   /**


### PR DESCRIPTION
Fix injecting opt dependencies when dependencies does not exist. This issue happened when installing package without dependencies and with optional dependencies