### PR TITLE
Disconnected host alert while loading fixed

### DIFF
--- a/packages/admin-ui/src/components/NotificationsMain.tsx
+++ b/packages/admin-ui/src/components/NotificationsMain.tsx
@@ -55,7 +55,7 @@ export default function NotificationsView() {
       linkText: "Navigate",
       linkPath: "support/auto-diagnose",
       body: `**Dappnode host is not connected to internet.** Click **Navigate** to autodiagnose and check the dappnode health.`,
-      active: !isConnectedToInternet
+      active: isConnectedToInternet === false
     },
     /**
      * [HOST-REBOOT]


### PR DESCRIPTION
While waiting for the api response and dispatching the new state, the property active was "!null", displaying that way the alert. 