### PR TITLE
Changing Swap's StatsCard ProgressBar color

### DIFF
--- a/packages/admin-ui/src/pages/dashboard/components/HostStats.tsx
+++ b/packages/admin-ui/src/pages/dashboard/components/HostStats.tsx
@@ -8,12 +8,15 @@ import Ok from "../../../components/Ok";
 function parseVariant({
   value,
   danger = 90,
-  warning = 75
+  warning = 75,
+  infoCard
 }: {
   value: number;
   danger?: number;
   warning?: number;
+  infoCard: boolean;
 }) {
+  if (infoCard) return "info";
   if (value > danger) return "danger";
   if (value > warning) return "warning";
   return "success";
@@ -40,7 +43,8 @@ function StatsCardOk({
   text,
   max,
   danger,
-  warning
+  warning,
+  infoCard = false
 }: {
   percent: number;
   label: "%" | "ºC";
@@ -48,6 +52,7 @@ function StatsCardOk({
   max?: number;
   danger?: number;
   warning?: number;
+  infoCard?: boolean;
 }) {
   let value: number;
   if (label === "%") value = Math.round(percent);
@@ -56,7 +61,7 @@ function StatsCardOk({
   return (
     <>
       <ProgressBar
-        variant={parseVariant({ value, danger, warning })}
+        variant={parseVariant({ value, danger, warning, infoCard })}
         max={max || 100}
         now={value}
         label={value + label}
@@ -157,6 +162,7 @@ export function HostStats() {
       <StatsCardContainer title={"swap"}>
         {swapStats.data ? (
           <StatsCardOk
+            infoCard
             percent={swapStats.data.usedPercentage}
             label="%"
             text={


### PR DESCRIPTION
Changing Swap's StatsCard ProgressBar color since having a high % memory is not alarming