### PR TITLE
Add minimumDockerVersion as optional requirement in manifest

### DIFF
--- a/packages/admin-ui/src/__mock-backend__/data/dnpRequest.ts
+++ b/packages/admin-ui/src/__mock-backend__/data/dnpRequest.ts
@@ -46,6 +46,7 @@ function getRequestDnp(dnp: MockDnp): RequestedDnp {
 
     compatible: {
       requiresCoreUpdate: false,
+      requiresDockerUpdate: false,
       resolving: false,
       isCompatible: true,
       error: "",

--- a/packages/admin-ui/src/__mock-backend__/data/sample.ts
+++ b/packages/admin-ui/src/__mock-backend__/data/sample.ts
@@ -21,6 +21,7 @@ export const sampleRequestState: RequestedDnp = {
 
   compatible: {
     requiresCoreUpdate: false,
+    requiresDockerUpdate: false,
     resolving: false,
     isCompatible: true,
     error: "",

--- a/packages/admin-ui/src/pages/installer/components/InstallDnpView.tsx
+++ b/packages/admin-ui/src/pages/installer/components/InstallDnpView.tsx
@@ -6,7 +6,8 @@ import {
   Route,
   useNavigate,
   useLocation,
-  useParams
+  useParams,
+  NavLink
 } from "react-router-dom";
 import { isEmpty, throttle } from "lodash-es";
 import { difference } from "utils/lodashExtended";
@@ -32,6 +33,12 @@ import { enableAutoUpdatesForPackageWithConfirm } from "pages/system/components/
 import Warnings from "./Steps/Warnings";
 import { RequestedDnp, UserSettingsAllDnps } from "@dappnode/types";
 import { diff } from "semver";
+import Button from "components/Button";
+import {
+  pathName as systemPathName,
+  subPaths as systemSubPaths
+} from "pages/system/data";
+import { getDockerVersion } from "@dappnode/dockerapi";
 
 interface InstallDnpViewProps {
   dnp: RequestedDnp;
@@ -75,6 +82,7 @@ const InstallDnpView: React.FC<InstallDnpViewProps> = ({
   const permissions = dnp.specialPermissions;
   const hasPermissions = Object.values(permissions).some(p => p.length > 0);
   const requiresCoreUpdate = dnp.compatible.requiresCoreUpdate;
+  const requiresDockerUpdate = dnp.compatible.requiresDockerUpdate;
   const isWizardEmpty = isSetupWizardEmpty(setupWizard);
   const oldEditorAvailable = Boolean(userSettings);
 
@@ -189,7 +197,8 @@ const InstallDnpView: React.FC<InstallDnpViewProps> = ({
     }
   ].filter(option => option.available);
 
-  const disableInstallation = !isEmpty(progressLogs) || requiresCoreUpdate;
+  const disableInstallation =
+    !isEmpty(progressLogs) || requiresCoreUpdate || requiresDockerUpdate;
 
   const setupSubPath = "setup";
   const permissionsSubPath = "permissions";
@@ -271,6 +280,8 @@ const InstallDnpView: React.FC<InstallDnpViewProps> = ({
     ({ subPath }) => subPath && currentSubRoute.includes(subPath)
   );
 
+  const requiredDockerVersion = manifest.requirements?.minimumDockerVersion;
+
   /**
    * Logic to control which route requires a redirect and when
    * - "install": never okay, redirect to the main page
@@ -323,6 +334,28 @@ const InstallDnpView: React.FC<InstallDnpViewProps> = ({
           <strong>{prettyDnpName(dnpName)}</strong> requires a more recent
           version of DAppNode. <strong>Update your DAppNode</strong> before
           continuing the installation.
+        </div>
+      )}
+
+      {requiresDockerUpdate && (
+        <div
+          className="alert alert-danger"
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center"
+          }}
+        >
+          <div>
+            <strong>{prettyDnpName(dnpName)}</strong> requires at least the
+            <strong>{requiredDockerVersion}</strong> version of Docker.{" "}
+            <strong>Update your DAppNode</strong> before continuing the
+            installation. You can do it with our update Docker button in{" "}
+            <strong> System / Advanced</strong> tab.
+          </div>
+          <NavLink to={"/" + systemPathName + "/" + systemSubPaths.advanced}>
+            <Button variant="danger">{"Navigate there"}</Button>
+          </NavLink>
         </div>
       )}
 

--- a/packages/admin-ui/src/pages/installer/components/InstallDnpView.tsx
+++ b/packages/admin-ui/src/pages/installer/components/InstallDnpView.tsx
@@ -38,7 +38,6 @@ import {
   pathName as systemPathName,
   subPaths as systemSubPaths
 } from "pages/system/data";
-import { getDockerVersion } from "@dappnode/dockerapi";
 
 interface InstallDnpViewProps {
   dnp: RequestedDnp;

--- a/packages/dappmanager/src/calls/fetchDnpRequest.ts
+++ b/packages/dappmanager/src/calls/fetchDnpRequest.ts
@@ -151,8 +151,7 @@ function getRequiresCoreUpdate(
     ? manifest.requirements.minimumDappnodeVersion
     : "";
   return Boolean(
-    manifest.requirements &&
-      minDnVersion &&
+    minDnVersion &&
       valid(minDnVersion) &&
       valid(coreVersion) &&
       gt(minDnVersion, coreVersion)
@@ -167,8 +166,7 @@ async function getRequiresDockerUpdate({
   if (!minDockerVersion) return false;
   const currentDockerVersion = await getDockerVersion();
   return Boolean(
-    manifest.requirements &&
-      minDockerVersion &&
+    minDockerVersion &&
       valid(minDockerVersion) &&
       valid(currentDockerVersion) &&
       gt(minDockerVersion, currentDockerVersion)

--- a/packages/dappmanager/src/calls/fetchDnpRequest.ts
+++ b/packages/dappmanager/src/calls/fetchDnpRequest.ts
@@ -8,7 +8,11 @@ import {
   getIsInstalled
 } from "@dappnode/utils";
 import { dappnodeInstaller } from "../index.js";
-import { dockerInfoArchive, listPackages } from "@dappnode/dockerapi";
+import {
+  dockerInfoArchive,
+  listPackages,
+  getDockerVersion
+} from "@dappnode/dockerapi";
 import {
   ComposeEditor,
   ComposeFileEditor,
@@ -120,6 +124,7 @@ export async function fetchDnpRequest({
     compatible: {
       // Compute version metadata
       requiresCoreUpdate: getRequiresCoreUpdate(mainRelease, dnpList),
+      requiresDockerUpdate: await getRequiresDockerUpdate(mainRelease),
       resolving: false,
       isCompatible: !compatibleError,
       error: compatibleError,
@@ -147,9 +152,26 @@ function getRequiresCoreUpdate(
     : "";
   return Boolean(
     manifest.requirements &&
+      minDnVersion &&
       valid(minDnVersion) &&
       valid(coreVersion) &&
       gt(minDnVersion, coreVersion)
+  );
+}
+async function getRequiresDockerUpdate({
+  manifest
+}: {
+  manifest: Manifest;
+}): Promise<boolean> {
+  const minDockerVersion = manifest.requirements?.minimumDockerVersion;
+  if (!minDockerVersion) return false;
+  const currentDockerVersion = await getDockerVersion();
+  return Boolean(
+    manifest.requirements &&
+      minDockerVersion &&
+      valid(minDockerVersion) &&
+      valid(currentDockerVersion) &&
+      gt(minDockerVersion, currentDockerVersion)
   );
 }
 

--- a/packages/dappmanager/src/calls/getIsConnectedToInternet.ts
+++ b/packages/dappmanager/src/calls/getIsConnectedToInternet.ts
@@ -8,7 +8,6 @@ import { getPublicIpFromUrls } from "@dappnode/utils";
  * @returns Whether or not if the dappnode is connected to internet
  */
 export async function getIsConnectedToInternet(): Promise<boolean> {
-  logs.error(`Checking internet connectivity`);
   try {
     await getPublicIpFromUrls({
       timeout: 3 * 1000,

--- a/packages/dockerApi/src/api/getDockerVersion.ts
+++ b/packages/dockerApi/src/api/getDockerVersion.ts
@@ -1,0 +1,10 @@
+import { docker } from "./docker.js";
+
+/**
+ * Get docker version
+ *
+ */
+export async function getDockerVersion(): Promise<string> {
+  const dockerVersion = await docker.version();
+  return dockerVersion.Version;
+}

--- a/packages/dockerApi/src/api/index.ts
+++ b/packages/dockerApi/src/api/index.ts
@@ -1,6 +1,7 @@
 export * from "./container.js";
 export * from "./df.js";
 export * from "./getArchive.js";
+export * from "./getDockerVersion.js";
 export * from "./imageRemove.js";
 export * from "./infoArchive.js";
 export * from "./listContainers.js";

--- a/packages/schemas/src/schemas/manifest.schema.json
+++ b/packages/schemas/src/schemas/manifest.schema.json
@@ -166,6 +166,13 @@
           "examples": ["0.2.0"],
           "pattern": "^((([0-9]+).([0-9]+).([0-9]+)))$",
           "errorMessage": "should be a semantic version in the format x.y.z"
+        },
+        "minimumDockerVersion": {
+          "type": "string",
+          "description": "Minimum Docker version that includes all the features necessary to run this DAppNode Package.",
+          "examples": ["23.0.3"],
+          "pattern": "^((([0-9]+).([0-9]+).([0-9]+)))$",
+          "errorMessage": "should be a semantic version in the format x.y.z"
         }
       }
     },

--- a/packages/types/src/calls.ts
+++ b/packages/types/src/calls.ts
@@ -285,6 +285,7 @@ export interface RequestedDnp {
   // Request status and dependencies
   compatible: {
     requiresCoreUpdate: boolean;
+    requiresDockerUpdate: boolean;
     resolving: boolean;
     isCompatible: boolean; // false;
     error: string; // "LN requires incompatible dependency";

--- a/packages/types/src/manifest.ts
+++ b/packages/types/src/manifest.ts
@@ -45,7 +45,8 @@ export interface Manifest {
   dependencies?: Dependencies;
   optionalDependencies?: Dependencies;
   requirements?: {
-    minimumDappnodeVersion: string;
+    minimumDappnodeVersion?: string;
+    minimumDockerVersion?: string;
   };
   globalEnvs?:
     | {


### PR DESCRIPTION
When trying to install a package whose ```minimumDockerVersion``` in manifest is higher than the current docker version, the installation will be blocked and an alert with a btn will redirect to "Docker update" in "System / advanced"