### PR TITLE
Eth repository config persistence during remote switch in EthMultiClients component

### DIFF
--- a/packages/admin-ui/src/components/EthMultiClient.tsx
+++ b/packages/admin-ui/src/components/EthMultiClient.tsx
@@ -19,6 +19,8 @@ import Switch from "./Switch";
 import Alert from "react-bootstrap/Alert";
 import { prettyDnpName } from "utils/format";
 import Input from "./Input";
+import { useSelector } from "react-redux";
+import { getEthClientTarget } from "services/dappnodeStatus/selectors";
 
 export const fallbackToBoolean = (fallback: EthClientFallback): boolean =>
   fallback === "on" ? true : fallback === "off" ? false : false;
@@ -90,11 +92,11 @@ interface EthClientData {
   title: string;
   description: string;
   options:
-    | "remote"
-    | {
-        execClients: ExecutionClientMainnet[];
-        consClients: ConsensusClientMainnet[];
-      };
+  | "remote"
+  | {
+    execClients: ExecutionClientMainnet[];
+    consClients: ConsensusClientMainnet[];
+  };
   stats: EthClientDataStats;
   highlights: (keyof EthClientDataStats)[];
 }
@@ -126,6 +128,8 @@ function EthMultiClients({
   showStats?: boolean;
   useCheckpointSync?: boolean;
 }) {
+  const ethClientTarget = useSelector(getEthClientTarget);
+
   const clients: EthClientData[] = [
     {
       title: "Remote",
@@ -157,22 +161,30 @@ function EthMultiClients({
   return (
     <div className="eth-multi-clients">
       {clients.map(({ title, description, options, stats, highlights }) => {
-        const defaultTarget: Eth2ClientTarget =
-          options === "remote"
-            ? options
-            : {
-                execClient: options.execClients[0],
-                consClient: options.consClients[0]
-              };
+        let defaultTarget: Eth2ClientTarget;
+        if (options === "remote") {
+          defaultTarget = options;
+        } else if (ethClientTarget && ethClientTarget !== "remote") {
+          defaultTarget = {
+            execClient: ethClientTarget.execClient,
+            consClient: ethClientTarget.consClient
+          };
+        } else {
+          defaultTarget = {
+            execClient: options.execClients[0],
+            consClient: options.consClients[0]
+          };
+        }
+
         let selected: boolean;
         if (options === "remote") {
           selected = selectedTarget === options ? true : false;
         } else {
           selected =
             selectedTarget &&
-            selectedTarget !== "remote" &&
-            options.execClients.includes(selectedTarget.execClient) &&
-            options.consClients.includes(selectedTarget.consClient)
+              selectedTarget !== "remote" &&
+              options.execClients.includes(selectedTarget.execClient) &&
+              options.consClients.includes(selectedTarget.consClient)
               ? true
               : false;
         }

--- a/packages/admin-ui/src/components/EthMultiClient.tsx
+++ b/packages/admin-ui/src/components/EthMultiClient.tsx
@@ -231,47 +231,34 @@ function EthMultiClients({
               options !== "remote" && (
                 <>
                   <Select
-                    value={
-                      selectedTarget
-                        ? prettyDnpName(selectedTarget.execClient)
-                        : undefined
-                    }
-                    options={options.execClients
-                      .filter(ec => ec)
-                      .map(ec => prettyDnpName(ec))}
+                    value={selectedTarget && prettyDnpName(selectedTarget.execClient)}
+                    options={options.execClients.filter(Boolean).map(prettyDnpName)}
                     onValueChange={(newOpt: string) => {
-                      const newEc = executionClientsMainnet.find(
-                        ec => prettyDnpName(ec) === newOpt
-                      );
-                      if (newEc)
+                      const newEc = executionClientsMainnet.find(ec => prettyDnpName(ec) === newOpt);
+                      if (newEc) {
                         onTargetChange({
-                          ...selectedTarget,
+                          ...(selectedTarget || {}),
                           execClient: newEc
                         });
+                      }
                     }}
                     prepend="Execution client"
-                  ></Select>
+                  />
+
                   <Select
-                    value={
-                      selectedTarget
-                        ? prettyDnpName(selectedTarget.consClient)
-                        : undefined
-                    }
-                    options={options.consClients
-                      .filter(ec => ec)
-                      .map(ec => prettyDnpName(ec))}
+                    value={selectedTarget && prettyDnpName(selectedTarget.consClient)}
+                    options={options.consClients.filter(Boolean).map(prettyDnpName)}
                     onValueChange={(newOpt: string) => {
-                      const newCc = consensusClientsMainnet.find(
-                        ec => prettyDnpName(ec) === newOpt
-                      );
-                      if (newCc)
+                      const newCc = consensusClientsMainnet.find(ec => prettyDnpName(ec) === newOpt);
+                      if (newCc) {
                         onTargetChange({
-                          ...selectedTarget,
+                          ...(selectedTarget || {}),
                           consClient: newCc
                         });
+                      }
                     }}
                     prepend="Consensus client"
-                  ></Select>
+                  />
                 </>
               )}
           </Card>

--- a/packages/admin-ui/src/pages/packages/components/Info/VolumesList.tsx
+++ b/packages/admin-ui/src/pages/packages/components/Info/VolumesList.tsx
@@ -79,10 +79,8 @@ export const VolumesList = ({ dnp }: { dnp: InstalledPackageDetailData }) => {
     return null;
   }
 
-  const isTotalVolumeSizeIllDefined = volumes.some(v => !v.size);
-
   const totalVolumeSize = volumes.reduce(
-    (total, vol) => total + (vol.size || 0),
+    (total, vol) => (vol.size != null ? total + vol.size : total),
     0
   );
 
@@ -104,7 +102,7 @@ export const VolumesList = ({ dnp }: { dnp: InstalledPackageDetailData }) => {
           </span>
         </span>
         <span>
-          {isTotalVolumeSizeIllDefined ? "-" : prettyBytes(totalVolumeSize)}
+          {prettyBytes(totalVolumeSize)}
         </span>
 
         <BsTrash

--- a/packages/admin-ui/src/pages/packages/components/Info/VolumesList.tsx
+++ b/packages/admin-ui/src/pages/packages/components/Info/VolumesList.tsx
@@ -79,8 +79,10 @@ export const VolumesList = ({ dnp }: { dnp: InstalledPackageDetailData }) => {
     return null;
   }
 
+  const isTotalVolumeSizeIllDefined = volumes.some(v => !v.size);
+
   const totalVolumeSize = volumes.reduce(
-    (total, vol) => (vol.size != null ? total + vol.size : total),
+    (total, vol) => total + (vol.size || 0),
     0
   );
 
@@ -102,7 +104,7 @@ export const VolumesList = ({ dnp }: { dnp: InstalledPackageDetailData }) => {
           </span>
         </span>
         <span>
-          {prettyBytes(totalVolumeSize)}
+          {isTotalVolumeSizeIllDefined ? "-" : prettyBytes(totalVolumeSize)}
         </span>
 
         <BsTrash

--- a/packages/admin-ui/src/pages/repository/components/Eth.tsx
+++ b/packages/admin-ui/src/pages/repository/components/Eth.tsx
@@ -107,8 +107,12 @@ export default function Eth() {
     <Card className="dappnode-identity">
       <SubTitle>Ethereum</SubTitle>
       <div>
-        Dappnode uses smart contracts to access a decentralized repository of
-        DApps. Choose to connect to a remote network or use your own local node
+        <p>
+          Dappnode uses smart contracts to access a decentralized repository of DApps.
+        </p>
+        <p>
+          Choose to connect to a <strong>remote network</strong> or use your own <strong>local node.</strong>
+        </p>
       </div>
       {ethClientTarget && ethClientTarget !== "remote" && (
         <div className="description">


### PR DESCRIPTION
This pull request addresses the issue of persisting the previous Ethereum repository configuration when switching to a remote connection in the EthMultiClients component.

**Changes include:**

- Added logic to ensure that the previous Ethereum repository configuration is preserved when switching to a remote connection.
- Utilized Redux useSelector hook to access the current Ethereum repository target.
- Improved the code structure for better readability and maintainability.

These changes aim to enhance the user experience by maintaining consistency in Ethereum repository configurations when transitioning between local and remote connections.