### PR TITLE
Ethical metrics - add telegram implementation into backend

### DIFF
--- a/packages/admin-ui/src/__mock-backend__/index.ts
+++ b/packages/admin-ui/src/__mock-backend__/index.ts
@@ -259,7 +259,8 @@ export const otherCalls: Omit<Routes, keyof typeof namedSpacedCalls> = {
   enableEthicalMetrics: async ({ mail }) => {},
   getEthicalMetricsConfig: async () => ({
     mail: "@example.com",
-    isEnabled: true
+    enabled: true,
+    tgChannelId: null
   }),
   disableEthicalMetrics: async () => {},
   optimismConfigGet: async () => ({

--- a/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
+++ b/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
@@ -30,9 +30,11 @@ export default function EnableEthicalMetrics({
 
   function onSetEnanleEthicalMetrics() {
     if (ethicalMetricsOn)
-      api.enableEthicalMetrics({ mail, sync: false }).catch(e => {
-        console.error(`Error on autoUpdateSettingsEdit : ${e.stack}`);
-      });
+      api
+        .enableEthicalMetrics({ mail, tgChannelId: null, sync: false })
+        .catch(e => {
+          console.error(`Error on autoUpdateSettingsEdit : ${e.stack}`);
+        });
     onNext();
   }
 

--- a/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
+++ b/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
@@ -28,7 +28,7 @@ export default function EnableEthicalMetrics({
     }
   }, [mail]);
 
-  function onSetEnanleEthicalMetrics() {
+  function onSetEnabeEthicalMetrics() {
     if (ethicalMetricsOn)
       api
         .enableEthicalMetrics({ mail, tgChannelId: null, sync: false })
@@ -69,7 +69,7 @@ export default function EnableEthicalMetrics({
         />
       </div>
 
-      <BottomButtons onBack={onBack} onNext={onSetEnanleEthicalMetrics} />
+      <BottomButtons onBack={onBack} onNext={onSetEnabeEthicalMetrics} />
     </>
   );
 }

--- a/packages/admin-ui/src/pages/system/components/Notifications/EthicalMetrics.tsx
+++ b/packages/admin-ui/src/pages/system/components/Notifications/EthicalMetrics.tsx
@@ -29,7 +29,7 @@ export default function EthicalMetrics() {
   }, [mail]);
 
   useEffect(() => {
-    if (ethicalMetricsConfig.data) {
+    if (ethicalMetricsConfig.data?.mail) {
       setMail(ethicalMetricsConfig.data.mail);
     }
   }, [ethicalMetricsConfig.data]);
@@ -37,10 +37,13 @@ export default function EthicalMetrics() {
   async function enableEthicalMetricsSync() {
     try {
       setReqStatusEnable({ loading: true });
-      await withToast(() => api.enableEthicalMetrics({ mail, sync: true }), {
-        message: `Enabling ethical metrics with email ${mail}...`,
-        onSuccess: `Enabled ethical metrics`
-      });
+      await withToast(
+        () => api.enableEthicalMetrics({ mail, tgChannelId: null, sync: true }),
+        {
+          message: `Enabling ethical metrics with email ${mail}...`,
+          onSuccess: `Enabled ethical metrics`
+        }
+      );
       setReqStatusEnable({ result: true });
       ethicalMetricsConfig.revalidate();
     } catch (e) {
@@ -120,10 +123,10 @@ export default function EthicalMetrics() {
 
           <Switch
             disabled={mailError}
-            checked={ethicalMetricsConfig.data.isEnabled}
-            label={ethicalMetricsConfig.data.isEnabled ? "On" : "Off"}
+            checked={ethicalMetricsConfig.data.enabled}
+            label={ethicalMetricsConfig.data.enabled ? "On" : "Off"}
             onToggle={
-              ethicalMetricsConfig.data.isEnabled
+              ethicalMetricsConfig.data.enabled
                 ? disableEthicalMetrics
                 : enableEthicalMetricsSync
             }

--- a/packages/dappmanager/src/calls/ethicalMetrics.ts
+++ b/packages/dappmanager/src/calls/ethicalMetrics.ts
@@ -12,8 +12,6 @@ import {
 } from "@dappnode/ethicalmetrics";
 import { dockerContainerStart, dockerContainerStop } from "@dappnode/dockerapi";
 
-// TODO: handle uninstall package to unsubscribe from ethical metrics
-
 /**
  * Disables ethical metrics if enabled:
  * - unregisters instance
@@ -21,7 +19,11 @@ import { dockerContainerStart, dockerContainerStop } from "@dappnode/dockerapi";
  */
 export async function disableEthicalMetrics(): Promise<void> {
   // disable ethical metrics in db for installer daemon
-  db.ethicalMetricsStatus.set(false);
+  db.ethicalMetrics.set({
+    mail: null,
+    tgChannelId: null,
+    enabled: false
+  });
 
   // Unregister instance
   await unregister().catch(() => {
@@ -42,32 +44,34 @@ export async function disableEthicalMetrics(): Promise<void> {
  * - triggers installer if not installed
  * - restarts package if not running
  * @param email email used to register the instance
+ * @param tgChannelId telegram channel id to send notifications
  * @param sync whether to wait for the installer to finish or not
  */
 export async function enableEthicalMetrics({
   mail,
+  tgChannelId,
   sync
 }: {
-  mail: string;
+  mail: string | null;
+  tgChannelId: string | null;
   sync: boolean;
 }): Promise<void> {
-  if (!mail) throw Error("email must exist");
+  if (!mail && !tgChannelId)
+    throw new Error("You must provide an email or a telegram channel id");
 
-  // Set email global env
-  db.ethicalMetricsMail.set(mail);
-  // enable ethical metrics in db for daemon
-  db.ethicalMetricsStatus.set(true);
+  db.ethicalMetrics.set({
+    mail,
+    tgChannelId,
+    enabled: true
+  });
 
   const ethicalMetricsPkg = await listPackageNoThrow({
     dnpName: ethicalMetricsDnpName
   });
 
   if (!ethicalMetricsPkg) {
-    if (sync) {
-      await packageInstall({ name: ethicalMetricsDnpName });
-    } else {
-      eventBus.runEthicalMetricsInstaller.emit();
-    }
+    if (sync) await packageInstall({ name: ethicalMetricsDnpName });
+    else eventBus.runEthicalMetricsInstaller.emit();
   } else {
     // Make sure pkg is running
     for (const container of ethicalMetricsPkg.containers)
@@ -79,7 +83,8 @@ export async function enableEthicalMetrics({
 
     // Make sure the instance is registered
     await register({
-      mail
+      mail,
+      tgChannelId
     });
   }
 }
@@ -90,9 +95,6 @@ export async function enableEthicalMetrics({
  * - isEnabled: weather the ethical metrics notifications are enabled or not
  * - email: the email used to register the instance
  */
-export async function getEthicalMetricsConfig(): Promise<EthicalMetricsConfig> {
-  return {
-    mail: db.ethicalMetricsMail.get() || "",
-    isEnabled: db.ethicalMetricsStatus.get()
-  };
+export async function getEthicalMetricsConfig(): Promise<EthicalMetricsConfig | null> {
+  return db.ethicalMetrics.get();
 }

--- a/packages/db/src/ethicalMetrics.ts
+++ b/packages/db/src/ethicalMetrics.ts
@@ -1,13 +1,28 @@
+import { EthicalMetricsConfig } from "@dappnode/types";
 import { dbMain } from "./dbFactory.js";
 
+const ETHICAL_METRICS = "ethical-metrics";
+
+// Deprecated
 const ETHICAL_METRICS_MAIL = "ethical-metrics-mail";
 const ETHICAL_METRICS_STATUS = "ethical-metrics-status";
 
+export const ethicalMetrics = dbMain.staticKey<EthicalMetricsConfig | null>(
+  ETHICAL_METRICS,
+  {
+    enabled: false,
+    mail: null,
+    tgChannelId: null,
+  }
+);
+
+// Deprecated in favor of "ethical-metrics"
 export const ethicalMetricsMail = dbMain.staticKey<string | null>(
   ETHICAL_METRICS_MAIL,
   null
 );
 
+// Deprecated in favor of "ethical-metrics"
 export const ethicalMetricsStatus = dbMain.staticKey<boolean>(
   ETHICAL_METRICS_STATUS,
   false

--- a/packages/ethicalMetrics/src/register.ts
+++ b/packages/ethicalMetrics/src/register.ts
@@ -5,16 +5,24 @@ import fetch from "node-fetch";
 /**
  * Register the instance in the Ethical Metrics server with the given email
  */
-export async function register({ mail }: { mail: string }): Promise<void> {
-  if (!mail) throw Error("mail must exist");
+export async function register({
+  mail,
+  tgChannelId,
+}: {
+  mail: string | null;
+  tgChannelId: string | null;
+}): Promise<void> {
+  if (!mail && !tgChannelId) throw Error("mail or tgChannelId is required");
+
+  const body: { mail?: string; tgChannelId?: string } = {};
+  if (mail) body["mail"] = mail;
+  if (tgChannelId) body["tgChannelId"] = tgChannelId;
 
   const response = await fetch(
     url.resolve(ethicalMetricsEndpoint, "/targets"),
     {
       method: "POST",
-      body: JSON.stringify({
-        mail: mail,
-      }),
+      body: JSON.stringify(body),
       headers: {
         "Content-Type": "application/json",
       },

--- a/packages/migrations/src/changeEthicalMetricsDbFormat.ts
+++ b/packages/migrations/src/changeEthicalMetricsDbFormat.ts
@@ -1,0 +1,33 @@
+import * as db from "@dappnode/db";
+
+/**
+ * Changes the format of the ethical metrics settings in the database.
+ * it will change the format from:
+ * ```json
+ * {
+ * "ethical-metrics-mail": "mail",
+ * "ethical-metrics-status": "status",
+ * }
+ * ```
+ * to:
+ * ```json
+ * {
+ * "ethical-metrics": {
+ *   "enabled": "status",
+ *   "mail": "mail",
+ *   "tgChannelId": "tgChannelId"
+ *   }
+ * }
+ * ```
+ */
+export async function changeEthicalMetricsDbFormat(): Promise<void> {
+  // Initial value is null, so if it has a value it means the migration was already done
+  if (db.ethicalMetrics.get()) return;
+  const mail = db.ethicalMetricsMail.get();
+  const status = db.ethicalMetricsStatus.get();
+  db.ethicalMetrics.set({
+    enabled: status,
+    mail,
+    tgChannelId: null, // Important: at the time of this migration the tgChannelId was not implemented
+  });
+}

--- a/packages/migrations/src/index.ts
+++ b/packages/migrations/src/index.ts
@@ -9,6 +9,7 @@ import { recreateContainersIfLegacyDns } from "./recreateContainersIfLegacyDns.j
 import { ensureCoreComposesHardcodedIpsRange } from "./ensureCoreComposesHardcodedIpsRange.js";
 import { addDappnodePeerToLocalIpfsNode } from "./addDappnodePeerToLocalIpfsNode.js";
 import { params } from "@dappnode/params";
+import { changeEthicalMetricsDbFormat } from "./changeEthicalMetricsDbFormat.js";
 
 export class MigrationError extends Error {
   migration: string;
@@ -133,6 +134,16 @@ export async function executeMigrations(): Promise<void> {
     migrationErrors.push({
       migration: "add Dappnode peer to local IPFS node",
       coreVersion: "0.2.88",
+      name: "MIGRATION_ERROR",
+      message: e.message,
+      stack: e.stack,
+    })
+  );
+
+  await changeEthicalMetricsDbFormat().catch((e) =>
+    migrationErrors.push({
+      migration: "change ethical metrics db format",
+      coreVersion: "0.2.92",
       name: "MIGRATION_ERROR",
       message: e.message,
       stack: e.stack,

--- a/packages/types/src/calls.ts
+++ b/packages/types/src/calls.ts
@@ -53,9 +53,11 @@ export interface ExposableServiceMapping extends ExposableServiceInfo {
  * Ethical Metrics
  * ===============
  */
+
 export interface EthicalMetricsConfig {
-  isEnabled: boolean;
-  mail: string;
+  enabled: boolean;
+  mail: string | null;
+  tgChannelId: string | null;
 }
 
 /**

--- a/packages/types/src/routes.ts
+++ b/packages/types/src/routes.ts
@@ -239,10 +239,12 @@ export interface Routes {
   /**
    * Enables ethical metrics notifications
    * @param mail
+   * @param tgChannelId
    * @param sync
    */
   enableEthicalMetrics: (kwargs: {
-    mail: string;
+    mail: string | null;
+    tgChannelId: string | null;
     sync: boolean;
   }) => Promise<void>;
 
@@ -259,7 +261,7 @@ export interface Routes {
   /**
    * Returns the current ethical metrics config
    */
-  getEthicalMetricsConfig: () => Promise<EthicalMetricsConfig>;
+  getEthicalMetricsConfig: () => Promise<EthicalMetricsConfig | null>;
 
   /**
    * Returns true if dappnode connected to internet


### PR DESCRIPTION
Implement telegram channel id in the backend:

- Change the ethical metrics settings in the database
- Add migration to database
- Change type
- Add implementation of tgChannelId in ethical metrics register
