### PR TITLE
Ethical metrics enhancement modal

### DIFF
--- a/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
+++ b/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
@@ -203,14 +203,18 @@ export default function EnableEthicalMetrics({
               }}
               variant="dappnode"
               disabled={
-                (tgChannelId === "" && mail === "") || // No input provided
-                (tgChannelIdError && mailError) || // Both inputs have errors
-                (tgChannelIdError && mail === "") || // Only tgChannelId has error
-                (tgChannelId === "" && mailError) || // Only mail has error
-                (mail === ethicalMetricsConfig.data?.mail && tgChannelId === "") || // No changes
-                (mail === ethicalMetricsConfig.data?.mail && tgChannelId === ethicalMetricsConfig.data?.tgChannelId) || // No changes
-                (mail === ethicalMetricsConfig.data?.mail && tgChannelIdError) || // No changes with tgChannelId error
-                (validationMessage !== "") // Asynchronous operation in progress
+                // No input provided or both inputs have errors
+                (tgChannelId === "" && mail === "") || (tgChannelIdError && mailError) ||
+                // Only tgChannelId has error or only mail has error
+                (tgChannelIdError && mail === "") || (tgChannelId === "" && mailError) ||
+                // No changes in mail or tgChannelId
+                (mail === ethicalMetricsConfig.data?.mail && (
+                  tgChannelId === "" ||
+                  tgChannelId === ethicalMetricsConfig.data?.tgChannelId ||
+                  tgChannelIdError
+                )) ||
+                // Asynchronous operation in progress
+                (validationMessage !== "")
               }
             >
               Update

--- a/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
+++ b/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
@@ -69,11 +69,22 @@ export default function EnableEthicalMetrics({
       });
       setEthicalMetricsOn(true);
       setValidationMessage("Ethical metrics enabled successfully.");
+      await ethicalMetricsConfig.revalidate()
     } catch (error) {
       setValidationMessage("Error enabling ethical metrics.");
       console.error("Error enabling ethical metrics:", error);
     }
   }
+
+  // clear the success message after 5 seconds
+  useEffect(() => {
+    if (validationMessage === "Ethical metrics enabled successfully.") {
+      const timer = setTimeout(() => {
+        setValidationMessage("");
+      }, 5000);
+      return () => clearTimeout(timer);
+    }
+  }, [validationMessage]);
 
   function toggleEthicalSwitch() {
     if (!ethicalMetricsOn) {
@@ -186,16 +197,20 @@ export default function EnableEthicalMetrics({
           <div className="update-button">
             <Button
               type="submit"
-              onClick={enableEthicalMetricsSync}
+              onClick={async () => {
+                setValidationMessage("");
+                await enableEthicalMetricsSync();
+              }}
               variant="dappnode"
               disabled={
-                (tgChannelId === "" && mail === "") ||
-                (tgChannelIdError && mailError) ||
-                (tgChannelIdError && mail === "") ||
-                (tgChannelId === "" && mailError) ||
-                (mail === ethicalMetricsConfig.data?.mail &&
-                  tgChannelId === "") ||
-                (mail === ethicalMetricsConfig.data?.mail && tgChannelIdError)
+                (tgChannelId === "" && mail === "") || // No input provided
+                (tgChannelIdError && mailError) || // Both inputs have errors
+                (tgChannelIdError && mail === "") || // Only tgChannelId has error
+                (tgChannelId === "" && mailError) || // Only mail has error
+                (mail === ethicalMetricsConfig.data?.mail && tgChannelId === "") || // No changes
+                (mail === ethicalMetricsConfig.data?.mail && tgChannelId === ethicalMetricsConfig.data?.tgChannelId) || // No changes
+                (mail === ethicalMetricsConfig.data?.mail && tgChannelIdError) || // No changes with tgChannelId error
+                (validationMessage !== "") // Asynchronous operation in progress
               }
             >
               Update

--- a/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
+++ b/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
@@ -75,7 +75,6 @@ export default function EnableEthicalMetrics({
     }
   }
 
-
   function toggleEthicalSwitch() {
     if (!ethicalMetricsOn) {
       enableEthicalMetricsSync();
@@ -88,9 +87,10 @@ export default function EnableEthicalMetrics({
       <div className="header">
         <div className="title">Enable System Notifications</div>
         <div className="description">
-          Enable ethical metrics and receive alerts whenever your dappnode is
-          down without losing your privacy.{" "}
-          <a href={docsUrl.ethicalMetricsOverview}>Learn more</a>
+          <p className="description-text">
+            <span className="highlight">Enable ethical metrics</span> and receive alerts whenever your dappnode is down without compromising your privacy.
+            <span className="note"> Note: Ethical Metrics requires the Dappnode Monitoring Service (DMS) as a dependency.</span> <a href={docsUrl.ethicalMetricsOverview} className="learn-more">Learn more</a>
+          </p>
         </div>
       </div>
 
@@ -99,8 +99,8 @@ export default function EnableEthicalMetrics({
         <strong>Telegram Channel ID</strong> to receive reliable alerts
         promptly.
       </p>
-      <em>
-        Advice: We highly recommend using the Telegram channel option (or both)
+      <em className="advice">
+        <strong>Advice: </strong> We highly recommend using the Telegram channel option (or both)
         rather than relying only on email notifications. Email notifications may
         be categorized as spam, potentially causing you to miss important
         notifications!

--- a/packages/admin-ui/src/components/welcome/features/enableEthicalMetrics.scss
+++ b/packages/admin-ui/src/components/welcome/features/enableEthicalMetrics.scss
@@ -33,3 +33,32 @@
     background-color: lightgray;
   }
 }
+
+.description-text {
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+.note {
+  font-size: 14px;
+  color: #666;
+}
+
+.learn-more {
+  font-size: 14px;
+}
+
+.instructions {
+  font-size: 16px;
+}
+
+.instructions strong {
+  font-weight: bold;
+}
+
+.advice {
+  font-size: 14px;
+  font-style: italic;
+  color: #666;
+}
+


### PR DESCRIPTION
- Add a short copy about what the user is about to download and redirect them to the docs
- Disable update button after user clicked on update by fetching content again. Use `await ethicalMetricsConfig.revalidate()`
- Ensured that the update button remains disabled if no changes are made or if validation errors occur
- Added a delay to clear the success message after enabling ethical metrics
- Refactored button disable conditions for clarity and readability