### PR TITLE
Ethical metrics changes

### DIFF
--- a/packages/admin-ui/src/components/SwitchBig.tsx
+++ b/packages/admin-ui/src/components/SwitchBig.tsx
@@ -2,37 +2,36 @@ import React from "react";
 import Switch from "react-switch";
 import "./switchBig.scss";
 
-const factor = 1.5;
-const height = 28 * factor;
-const width = 64 * factor;
-const fontSize = 16 * factor;
-const onColor = "#00b1f4";
-const offColor = undefined; // "#bc2f39";
-const switchLabelProps = {
-  display: "flex",
-  justifyContent: "center",
-  alignItems: "center",
-  height: "100%",
-  fontSize,
-  color: "white",
-  paddingRight: 2
-};
-
 export default function SwitchBig({
   id,
   label,
   checked,
   onChange,
-  disabled
+  disabled,
+  factor = 1.5
 }: {
   id: string;
   label: string;
   checked: boolean;
   onChange: (bool: boolean) => void;
   disabled?: boolean;
+  factor?: number;
 }) {
-  const labelClass = checked ? 'blue-text' : '';
-
+  const labelClass = checked ? "blue-text" : "";
+  const height = 28 * factor;
+  const width = 64 * factor;
+  const fontSize = 16 * factor;
+  const onColor = "#00b1f4";
+  const offColor = undefined; // "#bc2f39";
+  const switchLabelProps = {
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+    height: "100%",
+    fontSize,
+    color: "white",
+    paddingRight: 2
+  };
   return (
     <label htmlFor={id} className="switch-big">
       <span className={labelClass}>{label}</span>

--- a/packages/admin-ui/src/components/sidebar/sidebar.scss
+++ b/packages/admin-ui/src/components/sidebar/sidebar.scss
@@ -81,7 +81,7 @@
 
   span {
     font-weight: bold;
-    color: #0aa1da;
+    color: var(--dappnode-strong-main-color);
   }
 }
 

--- a/packages/admin-ui/src/pages/system/components/Notifications/EthicalMetrics.tsx
+++ b/packages/admin-ui/src/pages/system/components/Notifications/EthicalMetrics.tsx
@@ -124,10 +124,9 @@ export default function EthicalMetrics() {
   return (
     <Card spacing>
       <div>
-        You will receive a notification if your{" "}
-        <strong>dappnode is down</strong> for atleast 6 hours into your telegram
-        or email. Telemetry is tracked anonymously and no personal data is
-        collected.
+        Receive notifications if your <strong>dappnode remains offline</strong>{" "}
+        for at least 6 hours, sent to either your Telegram or email. Telemetry
+        is collected anonymously to ensure no personal data is retained.
       </div>
       <div>
         <span style={{ fontWeight: "bold" }}>Advice: </span>

--- a/packages/admin-ui/src/pages/system/components/Notifications/EthicalMetrics.tsx
+++ b/packages/admin-ui/src/pages/system/components/Notifications/EthicalMetrics.tsx
@@ -55,9 +55,8 @@ export default function EthicalMetrics() {
   useEffect(() => {
     const ethicalMetricsData = ethicalMetricsConfig.data;
     if (ethicalMetricsData) {
-      ethicalMetricsData.mail && setMail(ethicalMetricsData.mail);
-      ethicalMetricsData.tgChannelId &&
-        setTgChannelId(ethicalMetricsData.tgChannelId);
+      setMail(ethicalMetricsData.mail || "");
+      setTgChannelId(ethicalMetricsData.tgChannelId || "");
       setEthicalMetricsOn(ethicalMetricsData.enabled);
     }
   }, [ethicalMetricsConfig.data]);
@@ -88,7 +87,7 @@ export default function EthicalMetrics() {
         }
       );
       setReqStatusEnable({ result: true });
-      ethicalMetricsConfig.revalidate();
+      await ethicalMetricsConfig.revalidate();
       setEthicalMetricsOn(true);
     } catch (e) {
       setReqStatusEnable({ error: e });
@@ -114,7 +113,7 @@ export default function EthicalMetrics() {
         onSuccess: `Disabled ethical metrics`
       });
       setReqStatusDisable({ result: true });
-      ethicalMetricsConfig.revalidate();
+      await ethicalMetricsConfig.revalidate();
       setEthicalMetricsOn(false);
     } catch (e) {
       setReqStatusDisable({ error: e });

--- a/packages/admin-ui/src/pages/system/components/Notifications/ethicalMetrics.scss
+++ b/packages/admin-ui/src/pages/system/components/Notifications/ethicalMetrics.scss
@@ -7,7 +7,7 @@
     display: flex;
     flex-direction: row;
     align-items: center;
-    color: #3bb1f4;
+    color: var(--dappnode-strong-main-color);
   }
   .header:hover {
     text-decoration: underline;

--- a/packages/daemons/src/ethicalMetrics/checkEthicalMetricsStatus.ts
+++ b/packages/daemons/src/ethicalMetrics/checkEthicalMetricsStatus.ts
@@ -16,7 +16,7 @@ export async function checkEthicalMetricsStatus(
   const dmsDnpName = "dms.dnp.dappnode.eth";
 
   try {
-    const ethicalMetricsConfig = db.ethicalMetrics.get();
+    const ethicalMetricsConfig = db.notifications.get();
     if (!ethicalMetricsConfig) return;
     const { mail, enabled, tgChannelId } = ethicalMetricsConfig;
     if (enabled) {

--- a/packages/dappmanager/src/calls/ethicalMetrics.ts
+++ b/packages/dappmanager/src/calls/ethicalMetrics.ts
@@ -19,7 +19,7 @@ import { dockerContainerStart, dockerContainerStop } from "@dappnode/dockerapi";
  */
 export async function disableEthicalMetrics(): Promise<void> {
   // disable ethical metrics in db for installer daemon
-  db.ethicalMetrics.set({
+  db.notifications.set({
     mail: null,
     tgChannelId: null,
     enabled: false
@@ -59,7 +59,7 @@ export async function enableEthicalMetrics({
   if (!mail && !tgChannelId)
     throw new Error("You must provide an email or a telegram channel id");
 
-  db.ethicalMetrics.set({
+  db.notifications.set({
     mail,
     tgChannelId,
     enabled: true
@@ -96,5 +96,5 @@ export async function enableEthicalMetrics({
  * - email: the email used to register the instance
  */
 export async function getEthicalMetricsConfig(): Promise<EthicalMetricsConfig | null> {
-  return db.ethicalMetrics.get();
+  return db.notifications.get();
 }

--- a/packages/dappmanager/src/initializeDb.ts
+++ b/packages/dappmanager/src/initializeDb.ts
@@ -64,6 +64,23 @@ export async function initializeDb(): Promise<void> {
     db.ipfsGateway.set(params.IPFS_REMOTE);
 
   /**
+   *
+   *
+   */
+
+  if (db.notifications.get() === null) {
+    const mail = db.ethicalMetricsMail.get();
+    const status = db.ethicalMetricsStatus.get();
+    db.notifications.set({
+      enabled: status,
+      mail,
+      tgChannelId: null
+    });
+
+    db.newFeatureStatus.set("enable-ethical-metrics", "pending");
+  }
+
+  /**
    * Migrate data from the VPN db
    * - dyndns identity (including the domain)
    * - staticIp (if set)

--- a/packages/db/src/ethicalMetrics.ts
+++ b/packages/db/src/ethicalMetrics.ts
@@ -1,28 +1,24 @@
 import { EthicalMetricsConfig } from "@dappnode/types";
 import { dbMain } from "./dbFactory.js";
 
-const ETHICAL_METRICS = "ethical-metrics";
+const NOTIFICATIONS = "notifications";
 
 // Deprecated
 const ETHICAL_METRICS_MAIL = "ethical-metrics-mail";
 const ETHICAL_METRICS_STATUS = "ethical-metrics-status";
 
-export const ethicalMetrics = dbMain.staticKey<EthicalMetricsConfig | null>(
-  ETHICAL_METRICS,
-  {
-    enabled: false,
-    mail: null,
-    tgChannelId: null,
-  }
+export const notifications = dbMain.staticKey<EthicalMetricsConfig | null>(
+  NOTIFICATIONS,
+  null
 );
 
-// Deprecated in favor of "ethical-metrics"
+// Deprecated in favor of "notifications"
 export const ethicalMetricsMail = dbMain.staticKey<string | null>(
   ETHICAL_METRICS_MAIL,
   null
 );
 
-// Deprecated in favor of "ethical-metrics"
+// Deprecated in favor of "notifications"
 export const ethicalMetricsStatus = dbMain.staticKey<boolean>(
   ETHICAL_METRICS_STATUS,
   false

--- a/packages/migrations/src/changeEthicalMetricsDbFormat.ts
+++ b/packages/migrations/src/changeEthicalMetricsDbFormat.ts
@@ -22,12 +22,5 @@ import * as db from "@dappnode/db";
  */
 export async function changeEthicalMetricsDbFormat(): Promise<void> {
   // Initial value is null, so if it has a value it means the migration was already done
-  if (db.ethicalMetrics.get()) return;
-  const mail = db.ethicalMetricsMail.get();
-  const status = db.ethicalMetricsStatus.get();
-  db.ethicalMetrics.set({
-    enabled: status,
-    mail,
-    tgChannelId: null, // Important: at the time of this migration the tgChannelId was not implemented
-  });
+  if (db.notifications.get()) return;
 }


### PR DESCRIPTION
- Db key `notifications` instead of `ethical-metrics`
- onboarding ethical metrics modal retriggered 

System / Notifications
- Same switch as used in onboarding modal
- UI data removed when disabling ethical metrics
- Disabling switch when ANY regex validation fails
- Layout changed
- Message displayed when Switch is off to guide the user
- Confirmation popUp when disabling ethical metrics
- Notifications copy updated