### PR TITLE
Add MEV-Boost package to Stakers Holesky

### DIFF
--- a/packages/admin-ui/src/pages/stakers/components/StakerNetwork.tsx
+++ b/packages/admin-ui/src/pages/stakers/components/StakerNetwork.tsx
@@ -233,7 +233,7 @@ export default function StakerNetwork<T extends Network>({
                   isSelected={newEnableWeb3signer}
                 />
               </Col>
-              {(network === "prater" || network === "mainnet") && (
+              {(network === "prater" || network === "mainnet" || network === "holesky") && (
                 <Col>
                   <SubTitle>Mev Boost</SubTitle>
                   <MevBoost

--- a/packages/admin-ui/src/pages/stakers/components/StakerNetwork.tsx
+++ b/packages/admin-ui/src/pages/stakers/components/StakerNetwork.tsx
@@ -233,7 +233,7 @@ export default function StakerNetwork<T extends Network>({
                   isSelected={newEnableWeb3signer}
                 />
               </Col>
-              {(network === "prater" || network === "mainnet" || network === "holesky") && (
+              {["prater", "mainnet", "holesky"].includes(network) && (
                 <Col>
                   <SubTitle>Mev Boost</SubTitle>
                   <MevBoost
@@ -242,18 +242,13 @@ export default function StakerNetwork<T extends Network>({
                     newMevBoost={newMevBoost}
                     setNewMevBoost={setNewMevBoost}
                     isSelected={
-                      currentStakerConfigReq.data.mevBoost.dnpName ===
-                        newMevBoost?.dnpName
-                        ? true
-                        : false
+                      currentStakerConfigReq.data.mevBoost.dnpName === newMevBoost?.dnpName
                     }
                   />
                 </Col>
               )}
             </Row>
-
             <hr />
-
             <div>
               <div className="staker-buttons">
                 <Button

--- a/packages/admin-ui/src/pages/stakers/components/columns/MevBoost.tsx
+++ b/packages/admin-ui/src/pages/stakers/components/columns/MevBoost.tsx
@@ -177,8 +177,8 @@ function Relay<T extends Network>({
         {relay.ofacCompliant === undefined
           ? "-"
           : relay.ofacCompliant
-          ? "Yes"
-          : "No"}
+            ? "Yes"
+            : "No"}
       </td>
       <td>
         <Form.Check
@@ -286,6 +286,27 @@ const getDefaultRelays = <T extends Network>(network: T): RelayIface[] => {
           docs: "https://securerpc.com/",
           url:
             "https://0x8a72a5ec3e2909fff931c8b42c9e0e6c6e660ac48a98016777fc63a73316b3ffb5c622495106277f8dbcc17a06e92ca3@goerli-relay.securerpc.com/"
+        }
+      ];
+    case "holesky":
+      return [
+        {
+          operator: "Flashbots",
+          docs: "https://www.flashbots.net/",
+          url:
+            "https://0xafa4c6985aa049fb79dd37010438cfebeb0f2bd42b115b89dd678dab0670c1de38da0c4e9138c9290a398ecd9a0b3110@boost-relay-holesky.flashbots.net"
+        },
+        {
+          operator: "Aestus",
+          docs: "https://flashbots.notion.site/Relay-API-Documentation-5fb0819366954962bc02e81cb33840f5#417abe417dde45caaff3dc15aaae65dd",
+          url:
+            "https://0xab78bf8c781c58078c3beb5710c57940874dd96aef2835e7742c866b4c7c0406754376c2c8285a36c630346aa5c5f833@holesky.aestus.live"
+        },
+        {
+          operator: "Ultrasound",
+          docs: "https://github.com/ultrasoundmoney/frontend",
+          url:
+            "https://0xb1559beef7b5ba3127485bbbb090362d9f497ba64e177ee2c8e7db74746306efad687f2cf8574e38d70067d40ef136dc@relay-stag.ultrasound.money"
         }
       ];
     default:

--- a/packages/db/src/globalEnvs.ts
+++ b/packages/db/src/globalEnvs.ts
@@ -15,6 +15,7 @@ import {
   mevBoostLukso,
   mevBoostMainnet,
   mevBoostPrater,
+  mevBoostHolesky,
   consensusClientHolesky,
   executionClientHolesky,
 } from "./stakerConfig.js";
@@ -55,6 +56,7 @@ export function computeGlobalEnvsFromDb<B extends boolean>(
     [`${prefix}MEVBOOST_PRATER`]: mevBoostPrater.get(),
     [`${prefix}CONSENSUS_CLIENT_HOLESKY`]: consensusClientHolesky.get(),
     [`${prefix}EXECUTION_CLIENT_HOLESKY`]: executionClientHolesky.get(),
+    [`${prefix}MEVBOOST_HOLESKY`]: mevBoostHolesky.get(),
     [`${prefix}CONSENSUS_CLIENT_LUKSO`]: consensusClientLukso.get(),
     [`${prefix}EXECUTION_CLIENT_LUKSO`]: executionClientLukso.get(),
     [`${prefix}MEVBOOST_LUKSO`]: mevBoostLukso.get(),

--- a/packages/db/src/stakerConfig.ts
+++ b/packages/db/src/stakerConfig.ts
@@ -114,6 +114,7 @@ export const mevBoostPrater = interceptGlobalEnvOnSet(
 
 const CONSENSUS_CLIENT_HOLESKY = "consensus-client-holesky";
 const EXECUTION_CLIENT_HOLESKY = "execution-client-holesky";
+const MEVBOOST_HOLESKY = "mevboost-holesky";
 
 // Null means not set
 // Undefined means its set but the user has not selected any value
@@ -133,6 +134,11 @@ export const executionClientHolesky = interceptGlobalEnvOnSet(
     null
   ),
   Object.keys({ EXECUTION_CLIENT_HOLESKY })[0]
+);
+
+export const mevBoostHolesky = interceptGlobalEnvOnSet(
+  dbMain.staticKey<boolean>(MEVBOOST_HOLESKY, false),
+  Object.keys({ MEVBOOST_HOLESKY })[0]
 );
 
 // LUKSO

--- a/packages/installer/src/calls/packageRemove.ts
+++ b/packages/installer/src/calls/packageRemove.ts
@@ -12,7 +12,7 @@ import {
 } from "@dappnode/dockerapi";
 import { httpsPortal } from "@dappnode/httpsportal";
 import * as db from "@dappnode/db";
-import { mevBoostMainnet, mevBoostPrater, stakerPkgs } from "@dappnode/types";
+import { mevBoostMainnet, mevBoostPrater, mevBoostHolesky, stakerPkgs } from "@dappnode/types";
 import { ethicalMetricsDnpName, unregister } from "@dappnode/ethicalmetrics";
 
 /**
@@ -160,6 +160,9 @@ async function removeStakerPkgFromDbIfSelected({
       break;
     case mevBoostPrater:
       await db.mevBoostPrater.set(false);
+      break;
+    case mevBoostHolesky:
+      await db.mevBoostHolesky.set(false);
       break;
     default:
       return;

--- a/packages/stakers/src/get/getStakerDnpNamesByNetwork.ts
+++ b/packages/stakers/src/get/getStakerDnpNamesByNetwork.ts
@@ -10,6 +10,7 @@ import {
   executionClientsLukso,
   mevBoostMainnet,
   mevBoostPrater,
+  mevBoostHolesky,
   signerGnosis,
   signerMainnet,
   signerPrater,
@@ -49,7 +50,7 @@ export function getStakerDnpNamesByNetwork(
         executionClients: executionClientsHolesky,
         consensusClients: consensusClientsHolesky,
         signer: signerHolesky,
-        mevBoost: "",
+        mevBoost: mevBoostHolesky,
       };
     case "gnosis":
       return {

--- a/packages/stakers/src/set/getStakerCompatibleVersionsByNetwork.ts
+++ b/packages/stakers/src/set/getStakerCompatibleVersionsByNetwork.ts
@@ -179,23 +179,23 @@ export function getStakerCompatibleVersionsByNetwork<T extends Network>(
           {
             dnpName:
               "lighthouse-holesky.dnp.dappnode.eth" as ConsensusClient<T>,
-            minVersion: "0.1.0",
+            minVersion: "0.1.2",
           },
           {
             dnpName: "prysm-holesky.dnp.dappnode.eth" as ConsensusClient<T>,
-            minVersion: "0.1.0",
+            minVersion: "0.1.3",
           },
           {
             dnpName: "teku-holesky.dnp.dappnode.eth" as ConsensusClient<T>,
-            minVersion: "0.1.0",
+            minVersion: "0.1.2",
           },
           {
             dnpName: "nimbus-holesky.dnp.dappnode.eth" as ConsensusClient<T>,
-            minVersion: "0.1.0",
+            minVersion: "0.1.2",
           },
           {
             dnpName: "lodestar-holesky.dnp.dappnode.eth" as ConsensusClient<T>,
-            minVersion: "0.1.0",
+            minVersion: "0.1.3",
           },
         ],
         compatibleSigner: {

--- a/packages/stakers/src/set/setMevBoost.ts
+++ b/packages/stakers/src/set/setMevBoost.ts
@@ -23,7 +23,7 @@ export async function setMevBoost<T extends Network>({
   currentMevBoostPkg,
 }: {
   dappnodeInstaller: DappnodeInstaller;
-  mevBoost: T extends "mainnet" ? MevBoostMainnet : MevBoostPrater | MevBoostHolesky;
+  mevBoost: T extends "mainnet" ? MevBoostMainnet : (T extends "prater" ? MevBoostPrater : MevBoostHolesky);
   targetMevBoost?: StakerItemOk<T, "mev-boost">;
   currentMevBoostPkg?: InstalledPackageData;
 }): Promise<void> {

--- a/packages/stakers/src/set/setMevBoost.ts
+++ b/packages/stakers/src/set/setMevBoost.ts
@@ -4,6 +4,7 @@ import {
   InstalledPackageData,
   MevBoostMainnet,
   MevBoostPrater,
+  MevBoostHolesky,
   Network,
 } from "@dappnode/types";
 import {
@@ -22,7 +23,7 @@ export async function setMevBoost<T extends Network>({
   currentMevBoostPkg,
 }: {
   dappnodeInstaller: DappnodeInstaller;
-  mevBoost: T extends "mainnet" ? MevBoostMainnet : MevBoostPrater;
+  mevBoost: T extends "mainnet" ? MevBoostMainnet : MevBoostPrater | MevBoostHolesky;
   targetMevBoost?: StakerItemOk<T, "mev-boost">;
   currentMevBoostPkg?: InstalledPackageData;
 }): Promise<void> {

--- a/packages/stakers/src/set/setStakerConfig.ts
+++ b/packages/stakers/src/set/setStakerConfig.ts
@@ -190,6 +190,8 @@ async function setStakerConfigOnDb<T extends Network>(
         await db.consensusClientHolesky.set(
           consensusClient as ConsensusClientHolesky
         );
+      if (db.mevBoostHolesky.get() !== Boolean(mevBoost))
+        await db.mevBoostHolesky.set(mevBoost ? true : false);
       break;
 
     case "lukso":

--- a/packages/stakers/src/utils.ts
+++ b/packages/stakers/src/utils.ts
@@ -32,7 +32,7 @@ export function getStakerConfigByNetwork<T extends Network>(
       return {
         executionClient: db.executionClientHolesky.get() as ExecutionClient<T>,
         consensusClient: db.consensusClientHolesky.get() as ConsensusClient<T>,
-        isMevBoostSelected: false, // holesky doesn't support mevBoost
+        isMevBoostSelected: db.mevBoostHolesky.get(),
       };
     case "lukso":
       return {

--- a/packages/types/src/stakers.ts
+++ b/packages/types/src/stakers.ts
@@ -72,6 +72,9 @@ export const executionClientsHolesky = Object.freeze([
 export type SignerHolesky = "web3signer-holesky.dnp.dappnode.eth";
 export const signerHolesky: SignerHolesky =
   "web3signer-holesky.dnp.dappnode.eth";
+  export type MevBoostHolesky = "mev-boost-holesky.dnp.dappnode.eth";
+  export const mevBoostHolesky: MevBoostHolesky =
+    "mev-boost-holesky.dnp.dappnode.eth";
 
 // GNOSIS
 export type ConsensusClientGnosis = (typeof consensusClientsGnosis)[number];
@@ -133,6 +136,7 @@ export const signers = Object.freeze([
 export const mevBoosts = Object.freeze([
   mevBoostMainnet,
   mevBoostPrater,
+  mevBoostHolesky,
   //mevBoostGnosis,
 ] as const);
 
@@ -265,6 +269,8 @@ export type MevBoost<T extends Network> = T extends "mainnet"
   ? MevBoostMainnet
   : T extends "prater"
   ? MevBoostPrater
+  : T extends "holesky"
+  ? MevBoostHolesky
   : never;
 
 export interface StakerConfigByNetwork<T extends Network> {
@@ -301,6 +307,7 @@ export const stakerPkgs = Object.freeze([
   ...executionClientsHolesky,
   ...consensusClientsHolesky,
   signerHolesky,
+  mevBoostHolesky,
   ...executionClientsGnosis,
   ...consensusClientsGnosis,
   signerGnosis,


### PR DESCRIPTION
Please see issue #1865

This pull request adds support for the Holesky testnet to MEV-Boost, including integration of working relays for Flashbots, Aestus, and Ultrasound networks. Additionally, it ensures a consistent user experience across different networks, mirroring the UX of MEV-Boost on other platforms. With Prater nearing deprecation and its relays no longer maintained, this update is crucial for seamless transition and continued functionality.