### PR TITLE
Updated telegram id regex to allow for groups ids

### DIFF
--- a/packages/admin-ui/src/components/SwitchBig.tsx
+++ b/packages/admin-ui/src/components/SwitchBig.tsx
@@ -2,37 +2,36 @@ import React from "react";
 import Switch from "react-switch";
 import "./switchBig.scss";
 
-const factor = 1.5;
-const height = 28 * factor;
-const width = 64 * factor;
-const fontSize = 16 * factor;
-const onColor = "#00b1f4";
-const offColor = undefined; // "#bc2f39";
-const switchLabelProps = {
-  display: "flex",
-  justifyContent: "center",
-  alignItems: "center",
-  height: "100%",
-  fontSize,
-  color: "white",
-  paddingRight: 2
-};
-
 export default function SwitchBig({
   id,
   label,
   checked,
   onChange,
-  disabled
+  disabled,
+  factor = 1.5
 }: {
   id: string;
   label: string;
   checked: boolean;
   onChange: (bool: boolean) => void;
   disabled?: boolean;
+  factor?: number;
 }) {
-  const labelClass = checked ? 'blue-text' : '';
-
+  const labelClass = checked ? "blue-text" : "";
+  const height = 28 * factor;
+  const width = 64 * factor;
+  const fontSize = 16 * factor;
+  const onColor = "#00b1f4";
+  const offColor = undefined; // "#bc2f39";
+  const switchLabelProps = {
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+    height: "100%",
+    fontSize,
+    color: "white",
+    paddingRight: 2
+  };
   return (
     <label htmlFor={id} className="switch-big">
       <span className={labelClass}>{label}</span>

--- a/packages/admin-ui/src/components/SwitchBig.tsx
+++ b/packages/admin-ui/src/components/SwitchBig.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import Switch from "react-switch";
 import "./switchBig.scss";
 
-const factor = 2;
+const factor = 1.5;
 const height = 28 * factor;
 const width = 64 * factor;
 const fontSize = 16 * factor;
@@ -31,9 +31,11 @@ export default function SwitchBig({
   onChange: (bool: boolean) => void;
   disabled?: boolean;
 }) {
+  const labelClass = checked ? 'blue-text' : '';
+
   return (
     <label htmlFor={id} className="switch-big">
-      <span>{label}</span>
+      <span className={labelClass}>{label}</span>
       <Switch
         disabled={disabled}
         checked={checked}

--- a/packages/admin-ui/src/components/sidebar/sidebar.scss
+++ b/packages/admin-ui/src/components/sidebar/sidebar.scss
@@ -81,7 +81,7 @@
 
   span {
     font-weight: bold;
-    color: #0aa1da;
+    color: var(--dappnode-strong-main-color);
   }
 }
 

--- a/packages/admin-ui/src/components/switchBig.scss
+++ b/packages/admin-ui/src/components/switchBig.scss
@@ -10,3 +10,8 @@ label.switch-big {
     cursor: pointer;
   }
 }
+
+.blue-text {
+  color: #00b1f4;
+}
+

--- a/packages/admin-ui/src/components/switchBig.scss
+++ b/packages/admin-ui/src/components/switchBig.scss
@@ -7,6 +7,9 @@ label.switch-big {
     order: 2;
     font-size: 0.85rem;
     margin-top: 0.15rem;
+  }
+
+  > .react-switch {
     cursor: pointer;
   }
 }
@@ -14,4 +17,3 @@ label.switch-big {
 .blue-text {
   color: #00b1f4;
 }
-

--- a/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
+++ b/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
@@ -59,7 +59,13 @@ export default function EnableEthicalMetrics({
     }
   }, [tgChannelId]);
 
-  async function enableEthicalMetricsSync() {
+  async function enableEthicalMetricsSync({
+    mailValue,
+    tgChannelIdValue
+  }: {
+    mailValue?: string | null;
+    tgChannelIdValue?: string | null;
+  }) {
     try {
       setValidationMessage("Enabling ethical metrics...");
       await api.enableEthicalMetrics({
@@ -188,7 +194,12 @@ export default function EnableEthicalMetrics({
           <div className="update-button">
             <Button
               type="submit"
-              onClick={enableEthicalMetricsSync}
+              onClick={() =>
+                enableEthicalMetricsSync({
+                  tgChannelIdValue: tgChannelId,
+                  mailValue: mail
+                })
+              }
               variant="dappnode"
               disabled={
                 (tgChannelId === "" && mail === "") ||

--- a/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
+++ b/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
@@ -16,20 +16,20 @@ export default function EnableEthicalMetrics({
   const [mail, setMail] = useState("");
   const [mailError, setMailError] = useState(false);
 
-  const [telegramId, setTelegramId] = useState("");
-  const [telegramIdError, setTelegramIdError] = useState(false);
+  const [tgChannelId, setTgChannelId] = useState("");
+  const [tgChannelIdError, setTgChannelIdError] = useState(false);
 
   // regex for Telegram Channel ID validation
   useEffect(() => {
-    const regex = /^-100\d+$/; // Start with -100 followed by digits
-    if (regex.test(telegramId)) {
-      setTelegramIdError(false);
+    const regex = /^-100\d{10}$/; // Start with -100 followed by digits
+    if (regex.test(tgChannelId) || tgChannelId === "") {
+      setTgChannelIdError(false);
       setEthicalMetricsOn(true); // Enable system notifications if Telegram ID is valid
     } else {
-      setTelegramIdError(true); // Show error if Telegram ID is invalid
+      setTgChannelIdError(true); // Show error if Telegram ID is invalid
       setEthicalMetricsOn(false); // Disable system notifications if Telegram ID is invalid
     }
-  }, [telegramId]);
+  }, [tgChannelId]);
 
   // regex for email validation
   useEffect(() => {
@@ -66,18 +66,28 @@ export default function EnableEthicalMetrics({
 
       <p className="instructions">
         <p className="instructions">
-          <strong>Telegram notifications are available!</strong> Enter your <strong>Telegram Channel ID</strong> to receive reliable alerts promptly. If you don't have one, you can <a href="https://telegram.org/" target="_blank">create one now!</a> We highly recommend using the Telegram channel option (or both) rather than relying only on email notifications. Email notifications may be categorized as spam, potentially causing you to miss important notifications!
+          <strong>Telegram notifications are available!</strong> Enter your{" "}
+          <strong>Telegram Channel ID</strong> to receive reliable alerts
+          promptly. If you don't have one, you can{" "}
+          <a href="https://telegram.org/" target="_blank">
+            create one now!
+          </a>{" "}
+          We highly recommend using the Telegram channel option (or both) rather
+          than relying only on email notifications. Email notifications may be
+          categorized as spam, potentially causing you to miss important
+          notifications!
         </p>
         <p className="additional-info">
-          You can edit these settings later in <strong>System</strong> &rarr; <strong>Notifications</strong>.
+          You can edit these settings later in <strong>System</strong> &rarr;{" "}
+          <strong>Notifications</strong>.
         </p>
       </p>
 
       <Input
         prepend="Telegram"
-        value={telegramId}
-        onValueChange={setTelegramId}
-        isInvalid={telegramIdError}
+        value={tgChannelId}
+        onValueChange={setTgChannelId}
+        isInvalid={tgChannelIdError}
         required={true}
         placeholder="Your Telegram Channel ID"
       />
@@ -94,7 +104,7 @@ export default function EnableEthicalMetrics({
       {/* This top div prevents the card from stretching vertically */}
       <div>
         <SwitchBig
-          disabled={!telegramId && mailError && !ethicalMetricsOn}
+          disabled={!tgChannelId && mailError && !ethicalMetricsOn}
           checked={ethicalMetricsOn}
           onChange={setEthicalMetricsOn}
           label="Enable system notifications"

--- a/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
+++ b/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
@@ -59,18 +59,12 @@ export default function EnableEthicalMetrics({
     }
   }, [tgChannelId]);
 
-  async function enableEthicalMetricsSync({
-    mailValue,
-    tgChannelIdValue
-  }: {
-    mailValue?: string | null;
-    tgChannelIdValue?: string | null;
-  }) {
+  async function enableEthicalMetricsSync() {
     try {
       setValidationMessage("Enabling ethical metrics...");
       await api.enableEthicalMetrics({
-        mail: mailValue || mail,
-        tgChannelId: tgChannelIdValue || tgChannelId,
+        mail,
+        tgChannelId,
         sync: true
       });
       setEthicalMetricsOn(true);
@@ -185,12 +179,7 @@ export default function EnableEthicalMetrics({
           <div className="update-button">
             <Button
               type="submit"
-              onClick={() =>
-                enableEthicalMetricsSync({
-                  tgChannelIdValue: tgChannelId,
-                  mailValue: mail
-                })
-              }
+              onClick={enableEthicalMetricsSync}
               variant="dappnode"
               disabled={
                 (tgChannelId === "" && mail === "") ||

--- a/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
+++ b/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
@@ -59,18 +59,12 @@ export default function EnableEthicalMetrics({
     }
   }, [tgChannelId]);
 
-  async function enableEthicalMetricsSync({
-    mailValue,
-    tgChannelIdValue
-  }: {
-    mailValue?: string | null;
-    tgChannelIdValue?: string | null;
-  }) {
+  async function enableEthicalMetricsSync() {
     try {
       setValidationMessage("Enabling ethical metrics...");
       await api.enableEthicalMetrics({
-        mail: mailValue ? mailValue : null,
-        tgChannelId: tgChannelIdValue ? tgChannelIdValue : null,
+        mail: mail ? mail : null,
+        tgChannelId: tgChannelId ? tgChannelId : null,
         sync: true
       });
       setEthicalMetricsOn(true);
@@ -81,12 +75,10 @@ export default function EnableEthicalMetrics({
     }
   }
 
+
   function toggleEthicalSwitch() {
     if (!ethicalMetricsOn) {
-      enableEthicalMetricsSync({
-        tgChannelIdValue: tgChannelId,
-        mailValue: mail
-      });
+      enableEthicalMetricsSync();
     }
     setEthicalMetricsOn(!ethicalMetricsOn);
   }
@@ -194,12 +186,7 @@ export default function EnableEthicalMetrics({
           <div className="update-button">
             <Button
               type="submit"
-              onClick={() =>
-                enableEthicalMetricsSync({
-                  tgChannelIdValue: tgChannelId,
-                  mailValue: mail
-                })
-              }
+              onClick={enableEthicalMetricsSync}
               variant="dappnode"
               disabled={
                 (tgChannelId === "" && mail === "") ||

--- a/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
+++ b/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
@@ -165,7 +165,11 @@ export default function EnableEthicalMetrics({
                 <ol>
                   <li>
                     Open{" "}
-                    <a href="https://web.telegram.org/a/" target="_blank">
+                    <a
+                      href="https://web.telegram.org/a/"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
                       Telegram web
                     </a>
                     .
@@ -187,7 +191,7 @@ export default function EnableEthicalMetrics({
                     <ul>
                       <li>
                         The channel ID always starts with <span>-100</span>.
-                        Ensure to include the <span>-</span> while coping it.
+                        Ensure to include the <span>-</span> when coping it.
                       </li>
                     </ul>
                   </li>

--- a/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
+++ b/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
@@ -4,7 +4,6 @@ import SwitchBig from "components/SwitchBig";
 import { api, useApi } from "api";
 import Input from "components/Input";
 import { docsUrl } from "params";
-import Form from "react-bootstrap/esm/Form";
 import Button from "components/Button";
 import { Accordion } from "react-bootstrap";
 import { BsInfoCircleFill } from "react-icons/bs";

--- a/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
+++ b/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
@@ -31,9 +31,8 @@ export default function EnableEthicalMetrics({
   useEffect(() => {
     const ethicalMetricsData = ethicalMetricsConfig.data;
     if (ethicalMetricsData) {
-      ethicalMetricsData.mail && setMail(ethicalMetricsData.mail);
-      ethicalMetricsData.tgChannelId &&
-        setTgChannelId(ethicalMetricsData.tgChannelId);
+      setMail(ethicalMetricsData.mail || "");
+      setTgChannelId(ethicalMetricsData.tgChannelId || "");
       setEthicalMetricsOn(ethicalMetricsData.enabled);
       setWasEthicalMetricsOn(ethicalMetricsData.enabled);
     }
@@ -117,6 +116,15 @@ export default function EnableEthicalMetrics({
         notifications!
       </em>
 
+      <span>Ethical metrics notifications by telegram channel</span>
+      <Input
+        prepend="Telegram"
+        value={tgChannelId}
+        onValueChange={setTgChannelId}
+        isInvalid={tgChannelIdError}
+        required={true}
+        placeholder="-100XXXXXXXXXX"
+      />
       <Accordion defaultActiveKey={tgAccordionOpen ? "0" : ""}>
         <div className="accordion-modal-wrapper">
           <Accordion.Toggle
@@ -125,7 +133,7 @@ export default function EnableEthicalMetrics({
             className="accordion-modal"
           >
             <div className="header">
-              <BsInfoCircleFill className="links-icon" />
+              <BsInfoCircleFill className="links-icon" style={{ fontSize: "14px" }} />
               How can I get a Telegram channel Id?{" "}
               {tgAccordionOpen ? <IoIosArrowUp /> : <IoIosArrowDown />}{" "}
             </div>
@@ -140,7 +148,7 @@ export default function EnableEthicalMetrics({
                 </li>
                 <li>
                   Open telegram in a web browser{" "}
-                  <a href="https://web.telegram.org/">(Telegram web)</a> and
+                  <a href="https://web.telegram.org/" target="_blank">(Telegram web)</a> and
                   open the channel.
                 </li>
                 <li>
@@ -159,16 +167,6 @@ export default function EnableEthicalMetrics({
           </Accordion.Collapse>
         </div>
       </Accordion>
-
-      <span>Ethical metrics notifications by telegram channel</span>
-      <Input
-        prepend="Telegram"
-        value={tgChannelId}
-        onValueChange={setTgChannelId}
-        isInvalid={tgChannelIdError}
-        required={true}
-        placeholder="-100XXXXXXXXXX"
-      />
       {tgChannelIdError && (
         <span style={{ fontSize: "12px", color: "red" }}>
           Telegram channel Id format is incorrect

--- a/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
+++ b/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
@@ -36,25 +36,24 @@ export default function EnableEthicalMetrics({
     }
   }, [ethicalMetricsConfig.data]);
 
-  // effect and regex for email validation
   useEffect(() => {
-    const regex = /\S+@\S+\.\S+/;
-    if (regex.test(mail) || mail === "") {
+    const emailRegex = /\S+@\S+\.\S+/;
+    const tgChannelIdRegex = /^-100\d{10}(?:_\d{1,3})?$/;
+
+    // Email validation
+    if (emailRegex.test(mail) || mail === "") {
       setMailError(false);
     } else {
       setMailError(true);
     }
-  }, [mail]);
 
-  // effect and regex for telegram channelId validation
-  useEffect(() => {
-    const regex = /^-100\d{10}$/;
-    if (regex.test(tgChannelId) || tgChannelId === "") {
+    // Telegram channel ID validation
+    if (tgChannelIdRegex.test(tgChannelId) || tgChannelId === "") {
       setTgChannelIdError(false);
     } else {
       setTgChannelIdError(true);
     }
-  }, [tgChannelId]);
+  }, [mail, tgChannelId]);
 
   async function enableEthicalMetricsSync() {
     try {
@@ -195,7 +194,6 @@ export default function EnableEthicalMetrics({
                       </li>
                     </ul>
                   </li>
-
                   <li>
                     Paste the ID into the Telegram Channel ID field and enable
                     Ethical Metrics to receive notifications.

--- a/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
+++ b/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
@@ -203,14 +203,18 @@ export default function EnableEthicalMetrics({
               }}
               variant="dappnode"
               disabled={
-                (tgChannelId === "" && mail === "") || // No input provided
-                (tgChannelIdError && mailError) || // Both inputs have errors
-                (tgChannelIdError && mail === "") || // Only tgChannelId has error
-                (tgChannelId === "" && mailError) || // Only mail has error
-                (mail === ethicalMetricsConfig.data?.mail && tgChannelId === "") || // No changes
-                (mail === ethicalMetricsConfig.data?.mail && tgChannelId === ethicalMetricsConfig.data?.tgChannelId) || // No changes
-                (mail === ethicalMetricsConfig.data?.mail && tgChannelIdError) || // No changes with tgChannelId error
-                (validationMessage !== "") // Asynchronous operation in progress
+                // No input provided or both inputs have errors
+                (tgChannelId === "" && mail === "") || (tgChannelIdError && mailError) ||
+                // Only tgChannelId has error or only mail has error
+                (tgChannelIdError && mail === "") || (tgChannelId === "" && mailError) ||
+                // No changes in mail or tgChannelId
+                (mail === ethicalMetricsConfig.data?.mail && (
+                  tgChannelId === "" ||
+                  tgChannelId === ethicalMetricsConfig.data?.tgChannelId ||
+                  tgChannelIdError
+                )) ||
+                // Asynchronous operation in progress
+                (validationMessage !== "")
               }
             >
               Update

--- a/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
+++ b/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
@@ -135,64 +135,76 @@ export default function EnableEthicalMetrics({
         </span>
       )}
       <span>Ethical metrics notifications by telegram channel</span>
-      <Input
-        prepend="Telegram"
-        value={tgChannelId}
-        onValueChange={setTgChannelId}
-        isInvalid={tgChannelIdError}
-        required={true}
-        placeholder="-100XXXXXXXXXX"
-      />
-      <Accordion defaultActiveKey={tgAccordionOpen ? "0" : ""}>
-        <div className="accordion-modal-wrapper">
-          <Accordion.Toggle
-            eventKey="0"
-            onClick={() => setTgAccordionOpen(!tgAccordionOpen)}
-            className="accordion-modal"
-          >
-            <div className="header">
-              <BsInfoCircleFill
-                className="links-icon"
-                style={{ fontSize: "14px" }}
-              />
-              How can I get a Telegram channel Id?{" "}
-              {tgAccordionOpen ? <IoIosArrowUp /> : <IoIosArrowDown />}{" "}
-            </div>
-          </Accordion.Toggle>
-          <Accordion.Collapse eventKey="0">
-            <div>
-              <ol>
-                <li>Create a private channel in your telegram.</li>
-                <li>
-                  Add dappnode bot <span>@ethicalMetricsAlerts_bot</span> to the
-                  channel as an administrator.
-                </li>
-                <li>
-                  Open telegram in a web browser{" "}
-                  <a href="https://web.telegram.org/" target="_blank">
-                    (Telegram web)
-                  </a>{" "}
-                  and open the channel.
-                </li>
-                <li>
-                  Copy the channel id from the url. The channel Id is the number
-                  of 13 digits that comes just after the <span>-</span> in the
-                  url. It always starts with <span>-100</span>. While coping it,
-                  make sure to include the <span>-</span> just before the
-                  number!
-                </li>
-                <li>
-                  Paste it in the Telegram Channel Id field and toggle the
-                  switch <span>ON</span> to start receiving notifications.
-                </li>
-              </ol>
-            </div>
-          </Accordion.Collapse>
-        </div>
-      </Accordion>
+      <div>
+        <Input
+          prepend="Telegram"
+          value={tgChannelId}
+          onValueChange={setTgChannelId}
+          isInvalid={tgChannelIdError}
+          required={true}
+          placeholder="-100XXXXXXXXXX"
+        />
+        <Accordion defaultActiveKey={tgAccordionOpen ? "0" : ""}>
+          <div className="accordion-modal-wrapper">
+            <Accordion.Toggle
+              eventKey="0"
+              onClick={() => setTgAccordionOpen(!tgAccordionOpen)}
+              className="accordion-modal"
+            >
+              <div className="header">
+                <BsInfoCircleFill
+                  className="links-icon"
+                  style={{ fontSize: "14px" }}
+                />
+                How can I get a Telegram channel Id?{" "}
+                {tgAccordionOpen ? <IoIosArrowUp /> : <IoIosArrowDown />}{" "}
+              </div>
+            </Accordion.Toggle>
+            <Accordion.Collapse eventKey="0">
+              <div>
+                <ol>
+                  <li>
+                    Open{" "}
+                    <a href="https://web.telegram.org/a/" target="_blank">
+                      Telegram web
+                    </a>
+                    .
+                    <ul>
+                      <li>
+                        Ensure the URL ends with <span>/a/</span>. If not,
+                        manually add <span>/a/</span> after{" "}
+                        <span>https://web.telegram.org</span>.{" "}
+                      </li>
+                    </ul>
+                  </li>
+                  <li>Create a private channel.</li>
+                  <li>
+                    Add <span>@ethicalMetricsAlerts_bot</span> as an
+                    administrator in the channel.
+                  </li>
+                  <li>
+                    Go to your channel and copy the 13-digit ID from the URL.
+                    <ul>
+                      <li>
+                        The channel ID always starts with <span>-100</span>.
+                        Ensure to include the <span>-</span> while coping it.
+                      </li>
+                    </ul>
+                  </li>
+
+                  <li>
+                    Paste the ID into the Telegram Channel ID field and enable
+                    Ethical Metrics to receive notifications.
+                  </li>
+                </ol>
+              </div>
+            </Accordion.Collapse>
+          </div>
+        </Accordion>
+      </div>
       {tgChannelIdError && (
         <span style={{ fontSize: "12px", color: "red" }}>
-          Telegram channel Id format is incorrect
+          Telegram channel ID format is incorrect
         </span>
       )}
 

--- a/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
+++ b/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
@@ -69,11 +69,22 @@ export default function EnableEthicalMetrics({
       });
       setEthicalMetricsOn(true);
       setValidationMessage("Ethical metrics enabled successfully.");
+      await ethicalMetricsConfig.revalidate()
     } catch (error) {
       setValidationMessage("Error enabling ethical metrics.");
       console.error("Error enabling ethical metrics:", error);
     }
   }
+
+  // clear the success message after 5 seconds
+  useEffect(() => {
+    if (validationMessage === "Ethical metrics enabled successfully.") {
+      const timer = setTimeout(() => {
+        setValidationMessage("");
+      }, 5000);
+      return () => clearTimeout(timer);
+    }
+  }, [validationMessage]);
 
   function toggleEthicalSwitch() {
     if (!ethicalMetricsOn) {
@@ -186,16 +197,20 @@ export default function EnableEthicalMetrics({
           <div className="update-button">
             <Button
               type="submit"
-              onClick={enableEthicalMetricsSync}
+              onClick={async () => {
+                setValidationMessage("");
+                await enableEthicalMetricsSync();
+              }}
               variant="dappnode"
               disabled={
-                (tgChannelId === "" && mail === "") ||
-                (tgChannelIdError && mailError) ||
-                (tgChannelIdError && mail === "") ||
-                (tgChannelId === "" && mailError) ||
-                (mail === ethicalMetricsConfig.data?.mail &&
-                  tgChannelId === "") ||
-                (mail === ethicalMetricsConfig.data?.mail && tgChannelIdError)
+                (tgChannelId === "" && mail === "") || // No input provided
+                (tgChannelIdError && mailError) || // Both inputs have errors
+                (tgChannelIdError && mail === "") || // Only tgChannelId has error
+                (tgChannelId === "" && mailError) || // Only mail has error
+                (mail === ethicalMetricsConfig.data?.mail && tgChannelId === "") || // No changes
+                (mail === ethicalMetricsConfig.data?.mail && tgChannelId === ethicalMetricsConfig.data?.tgChannelId) || // No changes
+                (mail === ethicalMetricsConfig.data?.mail && tgChannelIdError) || // No changes with tgChannelId error
+                (validationMessage !== "") // Asynchronous operation in progress
               }
             >
               Update

--- a/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
+++ b/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
@@ -16,6 +16,21 @@ export default function EnableEthicalMetrics({
   const [mail, setMail] = useState("");
   const [mailError, setMailError] = useState(false);
 
+  const [telegramId, setTelegramId] = useState("");
+  const [telegramIdError, setTelegramIdError] = useState(false);
+
+  // regex for Telegram Channel ID validation
+  useEffect(() => {
+    const regex = /^-100\d+$/; // Start with -100 followed by digits
+    if (regex.test(telegramId)) {
+      setTelegramIdError(false);
+      setEthicalMetricsOn(true); // Enable system notifications if Telegram ID is valid
+    } else {
+      setTelegramIdError(true); // Show error if Telegram ID is invalid
+      setEthicalMetricsOn(false); // Disable system notifications if Telegram ID is invalid
+    }
+  }, [telegramId]);
+
   // regex for email validation
   useEffect(() => {
     const regex = /\S+@\S+\.\S+/;
@@ -39,15 +54,33 @@ export default function EnableEthicalMetrics({
   }
 
   return (
-    <>
+    <div className="ethical-container">
       <div className="header">
-        <div className="title">Enable system notifications</div>
+        <div className="title">Enable System Notifications</div>
         <div className="description">
           Enable ethical metrics and receive alerts whenever your dappnode is
           down without losing your privacy.{" "}
           <a href={docsUrl.ethicalMetricsOverview}>Learn more</a>
         </div>
       </div>
+
+      <p className="instructions">
+        <p className="instructions">
+          <strong>Telegram notifications are available!</strong> Enter your <strong>Telegram Channel ID</strong> to receive reliable alerts promptly. If you don't have one, you can <a href="https://telegram.org/" target="_blank">create one now!</a> We highly recommend using the Telegram channel option (or both) rather than relying only on email notifications. Email notifications may be categorized as spam, potentially causing you to miss important notifications!
+        </p>
+        <p className="additional-info">
+          You can edit these settings later in <strong>System</strong> &rarr; <strong>Notifications</strong>.
+        </p>
+      </p>
+
+      <Input
+        prepend="Telegram"
+        value={telegramId}
+        onValueChange={setTelegramId}
+        isInvalid={telegramIdError}
+        required={true}
+        placeholder="Your Telegram Channel ID"
+      />
 
       <Input
         prepend="Email"
@@ -61,7 +94,7 @@ export default function EnableEthicalMetrics({
       {/* This top div prevents the card from stretching vertically */}
       <div>
         <SwitchBig
-          disabled={mailError}
+          disabled={!telegramId && mailError && !ethicalMetricsOn}
           checked={ethicalMetricsOn}
           onChange={setEthicalMetricsOn}
           label="Enable system notifications"
@@ -70,6 +103,6 @@ export default function EnableEthicalMetrics({
       </div>
 
       <BottomButtons onBack={onBack} onNext={onSetEnabeEthicalMetrics} />
-    </>
+    </div>
   );
 }

--- a/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
+++ b/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
@@ -18,6 +18,7 @@ export default function EnableEthicalMetrics({
   onNext: () => void;
 }) {
   const ethicalMetricsConfig = useApi.getEthicalMetricsConfig();
+  const [wasEthicalMetricsOn, setWasEthicalMetricsOn] = useState(false);
   const [ethicalMetricsOn, setEthicalMetricsOn] = useState(false);
   const [mail, setMail] = useState("");
   const [mailError, setMailError] = useState(false);
@@ -30,7 +31,8 @@ export default function EnableEthicalMetrics({
   useEffect(() => {
     if (ethicalMetricsConfig.data?.mail) {
       setMail(ethicalMetricsConfig.data.mail);
-      setEthicalMetricsOn(ethicalMetricsConfig.data?.enabled)
+      setEthicalMetricsOn(ethicalMetricsConfig.data?.enabled);
+      setWasEthicalMetricsOn(ethicalMetricsConfig.data?.enabled);
     }
   }, [ethicalMetricsConfig.data]);
 
@@ -77,17 +79,6 @@ export default function EnableEthicalMetrics({
     }
   }
 
-  function onSetEnableEthicalMetrics() {
-    if (ethicalMetricsOn) {
-      const tgChannelIdValue = tgChannelId && !tgChannelIdError ? tgChannelId : null;
-      const mailValue = mail && !mailError ? mail : null;
-      enableEthicalMetricsSync({ mailValue, tgChannelIdValue });
-    }
-    onNext();
-  }
-
-  console.log("Ethical Metrics On:", ethicalMetricsOn);
-
   return (
     <div className="ethical-container">
       <div className="header">
@@ -101,16 +92,22 @@ export default function EnableEthicalMetrics({
 
       <p className="instructions">
         <strong>Telegram notifications are available!</strong> Enter your{" "}
-        <strong>Telegram Channel ID</strong> to receive reliable alerts promptly.
+        <strong>Telegram Channel ID</strong> to receive reliable alerts
+        promptly.
       </p>
-      <em>Advice: We highly recommend using the Telegram channel option (or both) rather than relying only on email notifications. Email notifications may be categorized as spam, potentially causing you to miss important notifications!</em>
+      <em>
+        Advice: We highly recommend using the Telegram channel option (or both)
+        rather than relying only on email notifications. Email notifications may
+        be categorized as spam, potentially causing you to miss important
+        notifications!
+      </em>
 
       <Accordion defaultActiveKey={tgAccordionOpen ? "0" : ""}>
         <div>
           <Accordion.Toggle
             eventKey="0"
             onClick={() => setTgAccordionOpen(!tgAccordionOpen)}
-            className="accordion"
+            className="accordionModal"
           >
             <div className="header">
               <BsInfoCircleFill className="links-icon" />
@@ -123,11 +120,8 @@ export default function EnableEthicalMetrics({
               <ol>
                 <li>Create a private channel in your telegram.</li>
                 <li>
-                  Add dappnode bot{" "}
-                  <span>
-                    @ethicalMetricsAlerts_bot
-                  </span>{" "}
-                  to the channel as an administrator.
+                  Add dappnode bot <span>@ethicalMetricsAlerts_bot</span> to the
+                  channel as an administrator.
                 </li>
                 <li>
                   Open telegram in a web browser{" "}
@@ -135,28 +129,15 @@ export default function EnableEthicalMetrics({
                   open the channel.
                 </li>
                 <li>
-                  Copy the channel id from the url. The channel Id is the
-                  number of 13 digits that comes just after the{" "}
-                  <span>
-                    -
-                  </span>{" "}
-                  in the url. It always starts with{" "}
-                  <span>
-                    -100
-                  </span>
-                  . While coping it, make sure to include the{" "}
-                  <span>
-                    -
-                  </span>{" "}
-                  just before the number!
+                  Copy the channel id from the url. The channel Id is the number
+                  of 13 digits that comes just after the <span>-</span> in the
+                  url. It always starts with <span>-100</span>. While coping it,
+                  make sure to include the <span>-</span> just before the
+                  number!
                 </li>
                 <li>
                   Paste it in the Telegram Channel Id field and toggle the
-                  switch{" "}
-                  <span>
-                    ON
-                  </span>{" "}
-                  to start receiving notifications.
+                  switch <span>ON</span> to start receiving notifications.
                 </li>
               </ol>
             </div>
@@ -196,7 +177,7 @@ export default function EnableEthicalMetrics({
 
       {/* This top div prevents the card from stretching vertically */}
       <div>
-        {ethicalMetricsOn ? (
+        {wasEthicalMetricsOn ? (
           // Render the "Update" button if ethical metrics are enabled
           <div className="update-button">
             <Button
@@ -209,11 +190,13 @@ export default function EnableEthicalMetrics({
               }
               variant="dappnode"
               disabled={
-                tgChannelId === "" && mail === "" ||
-                tgChannelIdError && mailError ||
-                tgChannelIdError && mail === "" ||
-                tgChannelId === "" && mailError ||
-                mail === ethicalMetricsConfig.data?.mail && tgChannelId === ""
+                (tgChannelId === "" && mail === "") ||
+                (tgChannelIdError && mailError) ||
+                (tgChannelIdError && mail === "") ||
+                (tgChannelId === "" && mailError) ||
+                (mail === ethicalMetricsConfig.data?.mail &&
+                  tgChannelId === "") ||
+                (mail === ethicalMetricsConfig.data?.mail && tgChannelIdError)
               }
             >
               Update
@@ -221,16 +204,21 @@ export default function EnableEthicalMetrics({
           </div>
         ) : (
           <SwitchBig
-            disabled={mailError}
+            disabled={
+              (tgChannelId === "" && mail === "") ||
+              (tgChannelIdError && mailError) ||
+              (tgChannelIdError && mail === "") ||
+              (tgChannelId === "" && mailError)
+            }
             checked={ethicalMetricsOn}
-            onChange={() => setEthicalMetricsOn(true)}
+            onChange={() => setEthicalMetricsOn(!ethicalMetricsOn)}
             label="Enable system notifications"
             id="enable-ethical-metrics"
           />
         )}
       </div>
 
-      <BottomButtons onBack={onBack} onNext={onSetEnableEthicalMetrics} />
+      <BottomButtons onBack={onBack} onNext={() => onNext()} />
 
       {validationMessage && (
         <p className="validation-message">{validationMessage}</p>

--- a/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
+++ b/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
@@ -29,10 +29,13 @@ export default function EnableEthicalMetrics({
 
   // useEffect to populate email field when data is available
   useEffect(() => {
-    if (ethicalMetricsConfig.data?.mail) {
-      setMail(ethicalMetricsConfig.data.mail);
-      setEthicalMetricsOn(ethicalMetricsConfig.data?.enabled);
-      setWasEthicalMetricsOn(ethicalMetricsConfig.data?.enabled);
+    const ethicalMetricsData = ethicalMetricsConfig.data;
+    if (ethicalMetricsData) {
+      ethicalMetricsData.mail && setMail(ethicalMetricsData.mail);
+      ethicalMetricsData.tgChannelId &&
+        setTgChannelId(ethicalMetricsData.tgChannelId);
+      setEthicalMetricsOn(ethicalMetricsData.enabled);
+      setWasEthicalMetricsOn(ethicalMetricsData.enabled);
     }
   }, [ethicalMetricsConfig.data]);
 
@@ -103,11 +106,11 @@ export default function EnableEthicalMetrics({
       </em>
 
       <Accordion defaultActiveKey={tgAccordionOpen ? "0" : ""}>
-        <div>
+        <div className="accordion-modal-wrapper">
           <Accordion.Toggle
             eventKey="0"
             onClick={() => setTgAccordionOpen(!tgAccordionOpen)}
-            className="accordionModal"
+            className="accordion-modal"
           >
             <div className="header">
               <BsInfoCircleFill className="links-icon" />
@@ -152,7 +155,7 @@ export default function EnableEthicalMetrics({
         onValueChange={setTgChannelId}
         isInvalid={tgChannelIdError}
         required={true}
-        placeholder="Your Telegram Channel ID"
+        placeholder="-100XXXXXXXXXX"
       />
       {tgChannelIdError && (
         <span style={{ fontSize: "12px", color: "red" }}>

--- a/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
+++ b/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
@@ -69,17 +69,26 @@ export default function EnableEthicalMetrics({
     try {
       setValidationMessage("Enabling ethical metrics...");
       await api.enableEthicalMetrics({
-        mail: mailValue || mail,
-        tgChannelId: tgChannelIdValue || tgChannelId,
+        mail: mailValue ? mailValue : null,
+        tgChannelId: tgChannelIdValue ? tgChannelIdValue : null,
         sync: true
       });
       setEthicalMetricsOn(true);
       setValidationMessage("Ethical metrics enabled successfully.");
-      onNext();
     } catch (error) {
       setValidationMessage("Error enabling ethical metrics.");
       console.error("Error enabling ethical metrics:", error);
     }
+  }
+
+  function toggleEthicalSwitch() {
+    if (!ethicalMetricsOn) {
+      enableEthicalMetricsSync({
+        tgChannelIdValue: tgChannelId,
+        mailValue: mail
+      });
+    }
+    setEthicalMetricsOn(!ethicalMetricsOn);
   }
 
   return (
@@ -214,7 +223,7 @@ export default function EnableEthicalMetrics({
               (tgChannelId === "" && mailError)
             }
             checked={ethicalMetricsOn}
-            onChange={() => setEthicalMetricsOn(!ethicalMetricsOn)}
+            onChange={toggleEthicalSwitch}
             label="Enable system notifications"
             id="enable-ethical-metrics"
           />

--- a/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
+++ b/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
@@ -68,7 +68,7 @@ export default function EnableEthicalMetrics({
       });
       setEthicalMetricsOn(true);
       setValidationMessage("Ethical metrics enabled successfully.");
-      await ethicalMetricsConfig.revalidate()
+      await ethicalMetricsConfig.revalidate();
     } catch (error) {
       setValidationMessage("Error enabling ethical metrics.");
       console.error("Error enabling ethical metrics:", error);
@@ -98,8 +98,17 @@ export default function EnableEthicalMetrics({
         <div className="title">Enable System Notifications</div>
         <div className="description">
           <p className="description-text">
-            <span className="highlight">Enable ethical metrics</span> and receive alerts whenever your dappnode is down without compromising your privacy.
-            <span className="note"> Note: Ethical Metrics requires the Dappnode Monitoring Service (DMS) as a dependency.</span> <a href={docsUrl.ethicalMetricsOverview} className="learn-more">Learn more</a>
+            <span className="highlight">Enable ethical metrics</span> and
+            receive alerts whenever your dappnode is down without compromising
+            your privacy.
+            <span className="note">
+              {" "}
+              Note: Ethical Metrics requires the Dappnode Monitoring Service
+              (DMS) as a dependency.
+            </span>{" "}
+            <a href={docsUrl.ethicalMetricsOverview} className="learn-more">
+              Learn more
+            </a>
           </p>
         </div>
       </div>
@@ -110,12 +119,23 @@ export default function EnableEthicalMetrics({
         promptly.
       </p>
       <em className="advice">
-        <strong>Advice: </strong> We highly recommend using the Telegram channel option (or both)
-        rather than relying only on email notifications. Email notifications may
-        be categorized as spam, potentially causing you to miss important
-        notifications!
+        <strong>Advice: </strong> We highly recommend using the Telegram channel
+        option (or both) rather than relying only on email notifications. Email
+        notifications may be categorized as spam, potentially causing you to
+        miss important notifications!
       </em>
-
+      {!ethicalMetricsOn && (
+        <span
+          style={{
+            fontStyle: "italic",
+            fontSize: "14px",
+            color: "var(--dappnode-strong-main-color)"
+          }}
+        >
+          You must provide a Telegram channel ID or an email to enable ethical
+          metrics notifications
+        </span>
+      )}
       <span>Ethical metrics notifications by telegram channel</span>
       <Input
         prepend="Telegram"
@@ -133,7 +153,10 @@ export default function EnableEthicalMetrics({
             className="accordion-modal"
           >
             <div className="header">
-              <BsInfoCircleFill className="links-icon" style={{ fontSize: "14px" }} />
+              <BsInfoCircleFill
+                className="links-icon"
+                style={{ fontSize: "14px" }}
+              />
               How can I get a Telegram channel Id?{" "}
               {tgAccordionOpen ? <IoIosArrowUp /> : <IoIosArrowDown />}{" "}
             </div>
@@ -148,8 +171,10 @@ export default function EnableEthicalMetrics({
                 </li>
                 <li>
                   Open telegram in a web browser{" "}
-                  <a href="https://web.telegram.org/" target="_blank">(Telegram web)</a> and
-                  open the channel.
+                  <a href="https://web.telegram.org/" target="_blank">
+                    (Telegram web)
+                  </a>{" "}
+                  and open the channel.
                 </li>
                 <li>
                   Copy the channel id from the url. The channel Id is the number
@@ -202,17 +227,18 @@ export default function EnableEthicalMetrics({
               variant="dappnode"
               disabled={
                 // No input provided or both inputs have errors
-                (tgChannelId === "" && mail === "") || (tgChannelIdError && mailError) ||
+                (tgChannelId === "" && mail === "") ||
+                (tgChannelIdError && mailError) ||
                 // Only tgChannelId has error or only mail has error
-                (tgChannelIdError && mail === "") || (tgChannelId === "" && mailError) ||
+                (tgChannelIdError && mail === "") ||
+                (tgChannelId === "" && mailError) ||
                 // No changes in mail or tgChannelId
-                (mail === ethicalMetricsConfig.data?.mail && (
-                  tgChannelId === "" ||
-                  tgChannelId === ethicalMetricsConfig.data?.tgChannelId ||
-                  tgChannelIdError
-                )) ||
+                (mail === ethicalMetricsConfig.data?.mail &&
+                  (tgChannelId === "" ||
+                    tgChannelId === ethicalMetricsConfig.data?.tgChannelId ||
+                    tgChannelIdError)) ||
                 // Asynchronous operation in progress
-                (validationMessage !== "")
+                validationMessage !== ""
               }
             >
               Update
@@ -228,7 +254,7 @@ export default function EnableEthicalMetrics({
             }
             checked={ethicalMetricsOn}
             onChange={toggleEthicalSwitch}
-            label="Enable system notifications"
+            label=""
             id="enable-ethical-metrics"
           />
         )}

--- a/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
+++ b/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
@@ -18,7 +18,6 @@ export default function EnableEthicalMetrics({
   onNext: () => void;
 }) {
   const ethicalMetricsConfig = useApi.getEthicalMetricsConfig();
-  const [wasEthicalMetricsOn, setWasEthicalMetricsOn] = useState(false);
   const [ethicalMetricsOn, setEthicalMetricsOn] = useState(false);
   const [mail, setMail] = useState("");
   const [mailError, setMailError] = useState(false);
@@ -34,7 +33,6 @@ export default function EnableEthicalMetrics({
       setMail(ethicalMetricsData.mail || "");
       setTgChannelId(ethicalMetricsData.tgChannelId || "");
       setEthicalMetricsOn(ethicalMetricsData.enabled);
-      setWasEthicalMetricsOn(ethicalMetricsData.enabled);
     }
   }, [ethicalMetricsConfig.data]);
 
@@ -215,7 +213,7 @@ export default function EnableEthicalMetrics({
 
       {/* This top div prevents the card from stretching vertically */}
       <div>
-        {wasEthicalMetricsOn ? (
+        {ethicalMetricsOn ? (
           // Render the "Update" button if ethical metrics are enabled
           <div className="update-button">
             <Button

--- a/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
+++ b/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
@@ -75,7 +75,6 @@ export default function EnableEthicalMetrics({
     }
   }
 
-
   function toggleEthicalSwitch() {
     if (!ethicalMetricsOn) {
       enableEthicalMetricsSync();
@@ -88,9 +87,10 @@ export default function EnableEthicalMetrics({
       <div className="header">
         <div className="title">Enable System Notifications</div>
         <div className="description">
-          Enable ethical metrics and receive alerts whenever your dappnode is
-          down without losing your privacy.{" "}
-          <a href={docsUrl.ethicalMetricsOverview}>Learn more</a>
+          <p className="description-text">
+            <span className="highlight">Enable ethical metrics</span> and receive alerts whenever your dappnode is down without compromising your privacy.
+            <span className="note"> Note: Ethical Metrics requires the Dappnode Monitoring Service (DMS) as a dependency.</span> <a href={docsUrl.ethicalMetricsOverview} className="learn-more">Learn more</a>
+          </p>
         </div>
       </div>
 
@@ -99,8 +99,8 @@ export default function EnableEthicalMetrics({
         <strong>Telegram Channel ID</strong> to receive reliable alerts
         promptly.
       </p>
-      <em>
-        Advice: We highly recommend using the Telegram channel option (or both)
+      <em className="advice">
+        <strong>Advice: </strong> We highly recommend using the Telegram channel option (or both)
         rather than relying only on email notifications. Email notifications may
         be categorized as spam, potentially causing you to miss important
         notifications!

--- a/packages/admin-ui/src/components/welcome/features/enableEthicalMetrics.scss
+++ b/packages/admin-ui/src/components/welcome/features/enableEthicalMetrics.scss
@@ -17,15 +17,13 @@
     .header:hover {
       text-decoration: underline;
     }
+  
     span {
       padding: 5px;
       border-radius: 5px;
-      &.light {
-        background-color: lightgray;
-      }
-      &.dark {
-        background-color: dimgray;
-      }
+      background-color: lightgray;
+      font-size: 9px;
     }
   }
+  
   

--- a/packages/admin-ui/src/components/welcome/features/enableEthicalMetrics.scss
+++ b/packages/admin-ui/src/components/welcome/features/enableEthicalMetrics.scss
@@ -6,6 +6,7 @@
 .accordion {
     border-style: none;
     background-color: transparent;
+    font-size: 13px;
   
     .header {
       cursor: pointer;
@@ -19,10 +20,9 @@
     }
   
     span {
-      padding: 5px;
+      padding: 3px;
       border-radius: 5px;
       background-color: lightgray;
-      font-size: 9px;
     }
   }
   

--- a/packages/admin-ui/src/components/welcome/features/enableEthicalMetrics.scss
+++ b/packages/admin-ui/src/components/welcome/features/enableEthicalMetrics.scss
@@ -1,29 +1,27 @@
 .update-button {
-    display: flex;
-    justify-content: center;
+  display: flex;
+  justify-content: center;
 }
 
-.accordion {
-    border-style: none;
-    background-color: transparent;
-    font-size: 13px;
-  
-    .header {
-      cursor: pointer;
-      display: flex;
-      flex-direction: row;
-      align-items: center;
-      color: #3bb1f4;
-    }
-    .header:hover {
-      text-decoration: underline;
-    }
-  
-    span {
-      padding: 3px;
-      border-radius: 5px;
-      background-color: lightgray;
-    }
+.accordionModal {
+  border-style: none;
+  background-color: transparent;
+  font-size: 13px;
+
+  .header {
+    cursor: pointer;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    color: #3bb1f4;
   }
-  
-  
+  .header:hover {
+    text-decoration: underline;
+  }
+
+  span {
+    padding: 3px;
+    border-radius: 5px;
+    background-color: lightgray;
+  }
+}

--- a/packages/admin-ui/src/components/welcome/features/enableEthicalMetrics.scss
+++ b/packages/admin-ui/src/components/welcome/features/enableEthicalMetrics.scss
@@ -33,3 +33,32 @@
     background-color: lightgray;
   }
 }
+
+.description-text {
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+.note {
+  font-size: 14px;
+  color: #666;
+}
+
+.learn-more {
+  font-size: 14px;
+}
+
+.instructions {
+  font-size: 16px;
+}
+
+.instructions strong {
+  font-weight: bold;
+}
+
+.advice {
+  font-size: 14px;
+  font-style: italic;
+  color: #666;
+}
+

--- a/packages/admin-ui/src/components/welcome/features/enableEthicalMetrics.scss
+++ b/packages/admin-ui/src/components/welcome/features/enableEthicalMetrics.scss
@@ -1,0 +1,31 @@
+.update-button {
+    display: flex;
+    justify-content: center;
+}
+
+.accordion {
+    border-style: none;
+    background-color: transparent;
+  
+    .header {
+      cursor: pointer;
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      color: #3bb1f4;
+    }
+    .header:hover {
+      text-decoration: underline;
+    }
+    span {
+      padding: 5px;
+      border-radius: 5px;
+      &.light {
+        background-color: lightgray;
+      }
+      &.dark {
+        background-color: dimgray;
+      }
+    }
+  }
+  

--- a/packages/admin-ui/src/components/welcome/features/enableEthicalMetrics.scss
+++ b/packages/admin-ui/src/components/welcome/features/enableEthicalMetrics.scss
@@ -3,10 +3,9 @@
   justify-content: center;
 }
 
-.accordionModal {
+.accordion-modal {
   border-style: none;
   background-color: transparent;
-  font-size: 13px;
 
   .header {
     cursor: pointer;
@@ -19,6 +18,15 @@
     text-decoration: underline;
   }
 
+  span {
+    padding: 3px;
+    border-radius: 5px;
+    background-color: lightgray;
+  }
+}
+
+.accordion-modal-wrapper {
+  font-size: 13px;
   span {
     padding: 3px;
     border-radius: 5px;

--- a/packages/admin-ui/src/components/welcome/welcome.scss
+++ b/packages/admin-ui/src/components/welcome/welcome.scss
@@ -51,6 +51,7 @@
   .header {
     text-align: center;
     .title {
+      margin-top: 2rem;
       font-weight: bold;
       font-size: 2rem; // Titles must be big enough in 100% zoom
       transition: color 0.15s;
@@ -132,3 +133,11 @@
     margin-bottom: 3rem;
   }
 }
+
+// Ethical Metrics modal container
+
+.ethical-container {
+  display: grid;
+  gap: 1rem;
+}
+

--- a/packages/admin-ui/src/pages/system/components/Notifications/EthicalMetrics.tsx
+++ b/packages/admin-ui/src/pages/system/components/Notifications/EthicalMetrics.tsx
@@ -238,7 +238,11 @@ export default function EthicalMetrics() {
                   <ol>
                     <li>
                       Open{" "}
-                      <a href="https://web.telegram.org/a/" target="_blank">
+                      <a
+                        href="https://web.telegram.org/a/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
                         Telegram web
                       </a>
                       .
@@ -280,7 +284,7 @@ export default function EthicalMetrics() {
                           <span className={theme === "dark" ? "dark" : "light"}>
                             -
                           </span>{" "}
-                          while coping it.
+                          when coping it.
                         </li>
                       </ul>
                     </li>

--- a/packages/admin-ui/src/pages/system/components/Notifications/EthicalMetrics.tsx
+++ b/packages/admin-ui/src/pages/system/components/Notifications/EthicalMetrics.tsx
@@ -239,19 +239,28 @@ export default function EthicalMetrics() {
                       to the channel as an administrator.
                     </li>
                     <li>
-                      Open telegram in a web browser{" "}
-                      <a href="https://web.telegram.org/" target="_blank">
-                        (Telegram web)
-                      </a>{" "}
-                      and open the channel.
+                      Open Telegram Web using this link:{" "}
+                      <a href="https://web.telegram.org/a/" target="_blank">
+                        Telegram web
+                      </a>
+                      . If you haven't opened it using this link, ensure that in
+                      the URL, just after{" "}
+                      <span className={theme === "dark" ? "dark" : "light"}>
+                        https://web.telegram.org
+                      </span>{" "}
+                      is followed with{" "}
+                      <span className={theme === "dark" ? "dark" : "light"}>
+                        /a/
+                      </span>
+                      . Otherwise you wont be able to get the channel id.
                     </li>
                     <li>
-                      Copy the channel id from the url. The channel Id is the
-                      number of 13 digits that comes just after the{" "}
+                      Open the channel and copy its id from the URL. The channel
+                      Id is the number of 13 digits that comes just after the{" "}
                       <span className={theme === "dark" ? "dark" : "light"}>
                         -
                       </span>{" "}
-                      in the url. It always starts with{" "}
+                      in the URL. It always starts with{" "}
                       <span className={theme === "dark" ? "dark" : "light"}>
                         -100
                       </span>

--- a/packages/admin-ui/src/pages/system/components/Notifications/EthicalMetrics.tsx
+++ b/packages/admin-ui/src/pages/system/components/Notifications/EthicalMetrics.tsx
@@ -165,11 +165,11 @@ export default function EthicalMetrics() {
           <br />
           <br />
           <Accordion defaultActiveKey={tgAccordionOpen ? "0" : ""}>
-            <div>
+            <div className="accordion-notifications-wrapper">
               <Accordion.Toggle
                 eventKey="0"
                 onClick={() => setTgAccordionOpen(!tgAccordionOpen)}
-                className="accordion"
+                className="accordion-notifications"
               >
                 <div className="header">
                   <BsInfoCircleFill className="links-icon" />

--- a/packages/admin-ui/src/pages/system/components/Notifications/EthicalMetrics.tsx
+++ b/packages/admin-ui/src/pages/system/components/Notifications/EthicalMetrics.tsx
@@ -19,7 +19,7 @@ export default function EthicalMetrics() {
   const { theme } = React.useContext(AppContext);
 
   const ethicalMetricsConfig = useApi.getEthicalMetricsConfig();
-  const [ethicalEnabled, setEthicalEnabled] = useState(false);
+  const [ethicalMetricsOn, setEthicalMetricsOn] = useState(false);
 
   const [mail, setMail] = useState("");
   const [mailError, setMailError] = useState(false);
@@ -57,7 +57,7 @@ export default function EthicalMetrics() {
       ethicalMetricsData.mail && setMail(ethicalMetricsData.mail);
       ethicalMetricsData.tgChannelId &&
         setTgChannelId(ethicalMetricsData.tgChannelId);
-      setEthicalEnabled(ethicalMetricsData.enabled);
+      setEthicalMetricsOn(ethicalMetricsData.enabled);
     }
   }, [ethicalMetricsConfig.data]);
 
@@ -88,11 +88,11 @@ export default function EthicalMetrics() {
       );
       setReqStatusEnable({ result: true });
       ethicalMetricsConfig.revalidate();
-      setEthicalEnabled(true);
+      setEthicalMetricsOn(true);
     } catch (e) {
       setReqStatusEnable({ error: e });
       console.error("Error on enableEthicalMetrics", e);
-      setEthicalEnabled(false);
+      setEthicalMetricsOn(false);
     }
   }
 
@@ -105,7 +105,7 @@ export default function EthicalMetrics() {
       });
       setReqStatusDisable({ result: true });
       ethicalMetricsConfig.revalidate();
-      setEthicalEnabled(false);
+      setEthicalMetricsOn(false);
     } catch (e) {
       setReqStatusDisable({ error: e });
       console.error("Error on registerEthicalMetrics", e);
@@ -156,10 +156,10 @@ export default function EthicalMetrics() {
           <br />
           {/** TODO: show instance and register status */}
           <Switch
-            checked={ethicalEnabled}
-            label={ethicalEnabled ? "On" : "Off"}
+            checked={ethicalMetricsOn}
+            label={ethicalMetricsOn ? "On" : "Off"}
             onToggle={
-              ethicalEnabled ? disableEthicalMetrics : enableEthicalSwitch
+              ethicalMetricsOn ? disableEthicalMetrics : enableEthicalSwitch
             }
           ></Switch>
           <br />
@@ -232,7 +232,7 @@ export default function EthicalMetrics() {
             value={tgChannelId}
             onValueChange={setTgChannelId}
             append={
-              ethicalEnabled ? (
+              ethicalMetricsOn ? (
                 <Button
                   type="submit"
                   className="register-button"
@@ -266,7 +266,7 @@ export default function EthicalMetrics() {
             value={mail}
             onValueChange={setMail}
             append={
-              ethicalEnabled ? (
+              ethicalMetricsOn ? (
                 <Button
                   type="submit"
                   className="register-button"

--- a/packages/admin-ui/src/pages/system/components/Notifications/EthicalMetrics.tsx
+++ b/packages/admin-ui/src/pages/system/components/Notifications/EthicalMetrics.tsx
@@ -1,19 +1,32 @@
-import React, { useEffect, useState } from "react";
 import { api, useApi } from "api";
-import { ReqStatus } from "types";
-import Form from "react-bootstrap/esm/Form";
 import Button from "components/Button";
 import Card from "components/Card";
-import Switch from "components/Switch";
 import ErrorView from "components/ErrorView";
-import Ok from "components/Ok";
-import { withToast } from "components/toast/Toast";
 import Input from "components/Input";
+import Ok from "components/Ok";
+import Switch from "components/Switch";
+import { withToast } from "components/toast/Toast";
+import React, { useEffect, useState } from "react";
+import { Accordion } from "react-bootstrap";
+import Form from "react-bootstrap/esm/Form";
+import { BsInfoCircleFill } from "react-icons/bs";
+import { IoIosArrowUp, IoIosArrowDown } from "react-icons/io";
+import { ReqStatus } from "types";
+import "./ethicalMetrics.scss";
+import { AppContext } from "App";
 
 export default function EthicalMetrics() {
+  const { theme } = React.useContext(AppContext);
+
   const ethicalMetricsConfig = useApi.getEthicalMetricsConfig();
+  const [ethicalEnabled, setEthicalEnabled] = useState(false);
+
   const [mail, setMail] = useState("");
   const [mailError, setMailError] = useState(false);
+
+  const [tgAccordionOpen, setTgAccordionOpen] = useState(false);
+  const [tgChannelId, setTgChannelId] = useState("");
+  const [tgChannelIdError, setTgChannelIdError] = useState(false);
 
   const [reqStatusEnable, setReqStatusEnable] = useState<ReqStatus>({});
   const [reqStatusDisable, setReqStatusDisable] = useState<ReqStatus>({});
@@ -21,34 +34,65 @@ export default function EthicalMetrics() {
   // effect and regex for email validation
   useEffect(() => {
     const regex = /\S+@\S+\.\S+/;
-    if (regex.test(mail)) {
+    if (regex.test(mail) || mail === "") {
       setMailError(false);
     } else {
       setMailError(true);
     }
   }, [mail]);
 
+  // effect and regex for telegram channelId validation
   useEffect(() => {
-    if (ethicalMetricsConfig.data?.mail) {
-      setMail(ethicalMetricsConfig.data.mail);
+    const regex = /^-100\d{10}$/;
+    if (regex.test(tgChannelId) || tgChannelId === "") {
+      setTgChannelIdError(false);
+    } else {
+      setTgChannelIdError(true);
+    }
+  }, [tgChannelId]);
+
+  useEffect(() => {
+    const ethicalMetricsData = ethicalMetricsConfig.data;
+    if (ethicalMetricsData) {
+      ethicalMetricsData.mail && setMail(ethicalMetricsData.mail);
+      ethicalMetricsData.tgChannelId &&
+        setTgChannelId(ethicalMetricsData.tgChannelId);
+      setEthicalEnabled(ethicalMetricsData.enabled);
     }
   }, [ethicalMetricsConfig.data]);
 
-  async function enableEthicalMetricsSync() {
+  async function enableEthicalMetricsSync({
+    mailValue = ethicalMetricsConfig.data?.mail,
+    tgChannelIdValue = ethicalMetricsConfig.data?.tgChannelId
+  }) {
     try {
       setReqStatusEnable({ loading: true });
+
       await withToast(
-        () => api.enableEthicalMetrics({ mail, tgChannelId: null, sync: true }),
+        () =>
+          api.enableEthicalMetrics({
+            mail: mailValue ? mailValue : null,
+            tgChannelId: tgChannelIdValue ? tgChannelIdValue : null,
+            sync: true
+          }),
         {
-          message: `Enabling ethical metrics with email ${mail}...`,
+          message: `Enabling ethical metrics via ${
+            mailValue && tgChannelIdValue
+              ? "telegram channel and email"
+              : mailValue
+              ? "email"
+              : tgChannelId && "telegram channel"
+          }`,
           onSuccess: `Enabled ethical metrics`
         }
       );
       setReqStatusEnable({ result: true });
       ethicalMetricsConfig.revalidate();
+      setEthicalEnabled(true);
     } catch (e) {
       setReqStatusEnable({ error: e });
       console.error("Error on enableEthicalMetrics", e);
+      setEthicalEnabled(false);
     }
   }
 
@@ -61,18 +105,26 @@ export default function EthicalMetrics() {
       });
       setReqStatusDisable({ result: true });
       ethicalMetricsConfig.revalidate();
+      setEthicalEnabled(false);
     } catch (e) {
       setReqStatusDisable({ error: e });
       console.error("Error on registerEthicalMetrics", e);
     }
   }
 
+  function enableEthicalSwitch() {
+    enableEthicalMetricsSync({
+      mailValue: mail && !mailError ? mail : null,
+      tgChannelIdValue: tgChannelId && !tgChannelIdError ? tgChannelId : null
+    });
+  }
+
   return (
     <Card spacing>
       <div>
         Receive notifications about the status of your dappnode directly into
-        your email. Telemetry is tracked anonymously and no personal data is
-        collected.
+        your telegram or email. Telemetry is tracked anonymously and no personal
+        data is collected.
       </div>
       <div>
         The notifications you will receive are:
@@ -91,46 +143,153 @@ export default function EthicalMetrics() {
           </li>
         </ul>
       </div>
-
+      <div>
+        <span style={{ fontWeight: "bold" }}>Advice: </span>
+        We highly recommend using the Telegram channel option (or both) rather
+        than relying only on email notifications. Email notifications may be
+        categorized as spam, potentially causing you to miss important
+        notifications!
+      </div>
       {ethicalMetricsConfig.data ? (
         <Form.Group>
-          <Form.Label>Ethical metrics notifications email</Form.Label>
+          <Form.Label>Ethical metrics status</Form.Label>
+          <br />
+          {/** TODO: show instance and register status */}
+          <Switch
+            checked={ethicalEnabled}
+            label={ethicalEnabled ? "On" : "Off"}
+            onToggle={
+              ethicalEnabled ? disableEthicalMetrics : enableEthicalSwitch
+            }
+          ></Switch>
+          <br />
+          <br />
+          <Accordion defaultActiveKey={tgAccordionOpen ? "0" : ""}>
+            <div>
+              <Accordion.Toggle
+                eventKey="0"
+                onClick={() => setTgAccordionOpen(!tgAccordionOpen)}
+                className="accordion"
+              >
+                <div className="header">
+                  <BsInfoCircleFill className="links-icon" />
+                  How can I get a Telegram channel Id?{" "}
+                  {tgAccordionOpen ? <IoIosArrowUp /> : <IoIosArrowDown />}{" "}
+                </div>
+              </Accordion.Toggle>
+              <Accordion.Collapse eventKey="0">
+                <div>
+                  <ol>
+                    <li>Create a private channel in your telegram.</li>
+                    <li>
+                      Add dappnode bot{" "}
+                      <span className={theme === "dark" ? "dark" : "light"}>
+                        @ethicalMetricsAlerts_bot
+                      </span>{" "}
+                      to the channel as an administrator.
+                    </li>
+                    <li>
+                      Open telegram in a web browser{" "}
+                      <a href="https://web.telegram.org/">(Telegram web)</a> and
+                      open the channel.
+                    </li>
+                    <li>
+                      Copy the channel id from the url. The channel Id is the
+                      number of 13 digits that comes just after the{" "}
+                      <span className={theme === "dark" ? "dark" : "light"}>
+                        -
+                      </span>{" "}
+                      in the url. It always starts with{" "}
+                      <span className={theme === "dark" ? "dark" : "light"}>
+                        -100
+                      </span>
+                      . While coping it, make sure to include the{" "}
+                      <span className={theme === "dark" ? "dark" : "light"}>
+                        -
+                      </span>{" "}
+                      just before the number!
+                    </li>
+                    <li>
+                      Paste it in the Telegram Channel Id field and toggle the
+                      switch{" "}
+                      <span className={theme === "dark" ? "dark" : "light"}>
+                        ON
+                      </span>{" "}
+                      to start receiving notifications.
+                    </li>
+                  </ol>
+                </div>
+              </Accordion.Collapse>
+            </div>
+          </Accordion>
+          <br />
+          <Form.Label>
+            Ethical metrics notifications by telegram channel
+          </Form.Label>
+          <Input
+            placeholder="Telegram Channel Id"
+            isInvalid={tgChannelIdError}
+            value={tgChannelId}
+            onValueChange={setTgChannelId}
+            append={
+              ethicalEnabled ? (
+                <Button
+                  type="submit"
+                  className="register-button"
+                  onClick={() =>
+                    enableEthicalMetricsSync({ tgChannelIdValue: tgChannelId })
+                  }
+                  variant="dappnode"
+                  disabled={
+                    tgChannelId === "" ||
+                    tgChannelId === ethicalMetricsConfig.data.tgChannelId ||
+                    tgChannelIdError
+                  }
+                >
+                  Update
+                </Button>
+              ) : (
+                <></>
+              )
+            }
+          />
+          {tgChannelIdError && (
+            <span style={{ fontSize: "12px", color: "red" }}>
+              Telegram channel Id format is incorrect
+            </span>
+          )}
+          <br />
+          <Form.Label>Ethical metrics notifications by email</Form.Label>
           <Input
             placeholder="Email"
             isInvalid={mailError}
             value={mail}
             onValueChange={setMail}
             append={
-              <Button
-                type="submit"
-                className="register-button"
-                onClick={enableEthicalMetricsSync}
-                variant="dappnode"
-                disabled={ethicalMetricsConfig.data.mail === mail}
-              >
-                Submit
-              </Button>
+              ethicalEnabled ? (
+                <Button
+                  type="submit"
+                  className="register-button"
+                  onClick={() => enableEthicalMetricsSync({ mailValue: mail })}
+                  variant="dappnode"
+                  disabled={
+                    mail === "" ||
+                    mail === ethicalMetricsConfig.data.mail ||
+                    mailError
+                  }
+                >
+                  Update
+                </Button>
+              ) : (
+                <></>
+              )
             }
           />
-
-          <br />
-
-          <div>
-            <Form.Label>Ethical metrics status</Form.Label>
-          </div>
-
-          {/** TODO: show instance and register status */}
-
-          <Switch
-            disabled={mailError}
-            checked={ethicalMetricsConfig.data.enabled}
-            label={ethicalMetricsConfig.data.enabled ? "On" : "Off"}
-            onToggle={
-              ethicalMetricsConfig.data.enabled
-                ? disableEthicalMetrics
-                : enableEthicalMetricsSync
-            }
-          ></Switch>
+          {mailError && (
+            <span style={{ fontSize: "12px", color: "red" }}>
+              Email format is incorrect
+            </span>
+          )}
         </Form.Group>
       ) : ethicalMetricsConfig.error ? (
         <Ok msg={"Error getting status"} style={{ margin: "auto" }} />

--- a/packages/admin-ui/src/pages/system/components/Notifications/EthicalMetrics.tsx
+++ b/packages/admin-ui/src/pages/system/components/Notifications/EthicalMetrics.tsx
@@ -78,13 +78,12 @@ export default function EthicalMetrics() {
             sync: true
           }),
         {
-          message: `Enabling ethical metrics via ${
-            mailValue && tgChannelIdValue
-              ? "telegram channel and email"
-              : mailValue
+          message: `Enabling ethical metrics via ${mailValue && tgChannelIdValue
+            ? "telegram channel and email"
+            : mailValue
               ? "email"
               : tgChannelId && "telegram channel"
-          }`,
+            }`,
           onSuccess: `Enabled ethical metrics`
         }
       );
@@ -126,16 +125,20 @@ export default function EthicalMetrics() {
   return (
     <Card spacing>
       <div>
-        Receive notifications if your <strong>dappnode remains offline</strong>{" "}
-        for at least 6 hours, sent to either your Telegram or email. Telemetry
-        is collected anonymously to ensure no personal data is retained.
+        <p>
+          Receive notifications if your <strong>dappnode remains offline</strong>{" "}
+          for at least 6 hours, sent to either your Telegram or email. Telemetry
+          is collected anonymously to ensure no personal data is retained.
+        </p>
       </div>
       <div>
-        <span style={{ fontWeight: "bold" }}>Advice: </span>
-        We highly recommend using the Telegram channel option (or both) rather
-        than relying only on email notifications. Email notifications may be
-        categorized as spam, potentially causing you to miss important
-        notifications!
+        <p>
+          <span style={{ fontWeight: "bold" }}>Advice: </span>
+          We highly recommend using the Telegram channel option (or both) rather
+          than relying only on email notifications. Email notifications may be
+          categorized as spam, potentially causing you to miss important
+          notifications!
+        </p>
         <LinkDocs href={docsUrl.ethicalMetricsOverview}>
           Learn more about Ethical metrics in our Documentation
         </LinkDocs>
@@ -158,11 +161,11 @@ export default function EthicalMetrics() {
                 ethicalMetricsOn
                   ? disableConfirmation
                   : () =>
-                      enableEthicalMetricsSync({
-                        mailValue: mail && !mailError ? mail : null,
-                        tgChannelIdValue:
-                          tgChannelId && !tgChannelIdError ? tgChannelId : null
-                      })
+                    enableEthicalMetricsSync({
+                      mailValue: mail && !mailError ? mail : null,
+                      tgChannelIdValue:
+                        tgChannelId && !tgChannelIdError ? tgChannelId : null
+                    })
               }
               label={""}
               id="enable-ethical-metrics"

--- a/packages/admin-ui/src/pages/system/components/Notifications/EthicalMetrics.tsx
+++ b/packages/admin-ui/src/pages/system/components/Notifications/EthicalMetrics.tsx
@@ -76,12 +76,13 @@ export default function EthicalMetrics() {
             sync: true
           }),
         {
-          message: `Enabling ethical metrics via ${mailValue && tgChannelIdValue
+          message: `Enabling ethical metrics via ${
+            mailValue && tgChannelIdValue
               ? "telegram channel and email"
               : mailValue
-                ? "email"
-                : tgChannelId && "telegram channel"
-            }`,
+              ? "email"
+              : tgChannelId && "telegram channel"
+          }`,
           onSuccess: `Enabled ethical metrics`
         }
       );
@@ -151,11 +152,11 @@ export default function EthicalMetrics() {
                 ethicalMetricsOn
                   ? disableConfirmation
                   : () =>
-                    enableEthicalMetricsSync({
-                      mailValue: mail && !mailError ? mail : null,
-                      tgChannelIdValue:
-                        tgChannelId && !tgChannelIdError ? tgChannelId : null
-                    })
+                      enableEthicalMetricsSync({
+                        mailValue: mail && !mailError ? mail : null,
+                        tgChannelIdValue:
+                          tgChannelId && !tgChannelIdError ? tgChannelId : null
+                      })
               }
               label={""}
               id="enable-ethical-metrics"
@@ -239,8 +240,10 @@ export default function EthicalMetrics() {
                     </li>
                     <li>
                       Open telegram in a web browser{" "}
-                      <a href="https://web.telegram.org/" target="_blank">(Telegram web)</a> and
-                      open the channel.
+                      <a href="https://web.telegram.org/" target="_blank">
+                        (Telegram web)
+                      </a>{" "}
+                      and open the channel.
                     </li>
                     <li>
                       Copy the channel id from the url. The channel Id is the

--- a/packages/admin-ui/src/pages/system/components/Notifications/EthicalMetrics.tsx
+++ b/packages/admin-ui/src/pages/system/components/Notifications/EthicalMetrics.tsx
@@ -124,10 +124,9 @@ export default function EthicalMetrics() {
   return (
     <Card spacing>
       <div>
-        You will receive a notification if your{" "}
-        <strong>dappnode is down</strong> for atleast 6 hours into your telegram
-        or email. Telemetry is tracked anonymously and no personal data is
-        collected.
+        Receive notifications if your <strong>dappnode remains offline</strong>{" "}
+        for at least 6 hours, sent to either your Telegram or email. Telemetry
+        is collected anonymously to ensure no personal data is retained.
       </div>
       <div>
         <span style={{ fontWeight: "bold" }}>Advice: </span>

--- a/packages/admin-ui/src/pages/system/components/Notifications/EthicalMetrics.tsx
+++ b/packages/admin-ui/src/pages/system/components/Notifications/EthicalMetrics.tsx
@@ -112,13 +112,6 @@ export default function EthicalMetrics() {
     }
   }
 
-  function enableEthicalSwitch() {
-    enableEthicalMetricsSync({
-      mailValue: mail && !mailError ? mail : null,
-      tgChannelIdValue: tgChannelId && !tgChannelIdError ? tgChannelId : null
-    });
-  }
-
   return (
     <Card spacing>
       <div>
@@ -159,7 +152,14 @@ export default function EthicalMetrics() {
             checked={ethicalMetricsOn}
             label={ethicalMetricsOn ? "On" : "Off"}
             onToggle={
-              ethicalMetricsOn ? disableEthicalMetrics : enableEthicalSwitch
+              ethicalMetricsOn
+                ? disableEthicalMetrics
+                : () =>
+                    enableEthicalMetricsSync({
+                      mailValue: mail && !mailError ? mail : null,
+                      tgChannelIdValue:
+                        tgChannelId && !tgChannelIdError ? tgChannelId : null
+                    })
             }
           ></Switch>
           <br />

--- a/packages/admin-ui/src/pages/system/components/Notifications/EthicalMetrics.tsx
+++ b/packages/admin-ui/src/pages/system/components/Notifications/EthicalMetrics.tsx
@@ -76,13 +76,12 @@ export default function EthicalMetrics() {
             sync: true
           }),
         {
-          message: `Enabling ethical metrics via ${
-            mailValue && tgChannelIdValue
+          message: `Enabling ethical metrics via ${mailValue && tgChannelIdValue
               ? "telegram channel and email"
               : mailValue
-              ? "email"
-              : tgChannelId && "telegram channel"
-          }`,
+                ? "email"
+                : tgChannelId && "telegram channel"
+            }`,
           onSuccess: `Enabled ethical metrics`
         }
       );
@@ -152,11 +151,11 @@ export default function EthicalMetrics() {
                 ethicalMetricsOn
                   ? disableConfirmation
                   : () =>
-                      enableEthicalMetricsSync({
-                        mailValue: mail && !mailError ? mail : null,
-                        tgChannelIdValue:
-                          tgChannelId && !tgChannelIdError ? tgChannelId : null
-                      })
+                    enableEthicalMetricsSync({
+                      mailValue: mail && !mailError ? mail : null,
+                      tgChannelIdValue:
+                        tgChannelId && !tgChannelIdError ? tgChannelId : null
+                    })
               }
               label={""}
               id="enable-ethical-metrics"
@@ -240,7 +239,7 @@ export default function EthicalMetrics() {
                     </li>
                     <li>
                       Open telegram in a web browser{" "}
-                      <a href="https://web.telegram.org/">(Telegram web)</a> and
+                      <a href="https://web.telegram.org/" target="_blank">(Telegram web)</a> and
                       open the channel.
                     </li>
                     <li>

--- a/packages/admin-ui/src/pages/system/components/Notifications/EthicalMetrics.tsx
+++ b/packages/admin-ui/src/pages/system/components/Notifications/EthicalMetrics.tsx
@@ -34,25 +34,24 @@ export default function EthicalMetrics() {
   const [reqStatusEnable, setReqStatusEnable] = useState<ReqStatus>({});
   const [reqStatusDisable, setReqStatusDisable] = useState<ReqStatus>({});
 
-  // effect and regex for email validation
   useEffect(() => {
-    const regex = /\S+@\S+\.\S+/;
-    if (regex.test(mail) || mail === "") {
+    const emailRegex = /\S+@\S+\.\S+/;
+    const tgChannelIdRegex = /^-100\d{10}(?:_\d{1,3})?$/;
+
+    // Email validation
+    if (emailRegex.test(mail) || mail === "") {
       setMailError(false);
     } else {
       setMailError(true);
     }
-  }, [mail]);
 
-  // effect and regex for telegram channelId validation
-  useEffect(() => {
-    const regex = /^-100\d{10}$/;
-    if (regex.test(tgChannelId) || tgChannelId === "") {
+    // Telegram channel ID validation
+    if (tgChannelIdRegex.test(tgChannelId) || tgChannelId === "") {
       setTgChannelIdError(false);
     } else {
       setTgChannelIdError(true);
     }
-  }, [tgChannelId]);
+  }, [mail, tgChannelId]);
 
   useEffect(() => {
     const ethicalMetricsData = ethicalMetricsConfig.data;
@@ -127,7 +126,7 @@ export default function EthicalMetrics() {
       <div>
         <p>
           Receive notifications if your <strong>dappnode remains offline</strong>{" "}
-          for at least 6 hours, sent to either your Telegram or email. Telemetry
+          for at least 3 hours, sent to either your Telegram or email. Telemetry
           is collected anonymously to ensure no personal data is retained.
         </p>
       </div>

--- a/packages/admin-ui/src/pages/system/components/Notifications/EthicalMetrics.tsx
+++ b/packages/admin-ui/src/pages/system/components/Notifications/EthicalMetrics.tsx
@@ -15,6 +15,8 @@ import "./ethicalMetrics.scss";
 import { AppContext } from "App";
 import SwitchBig from "components/SwitchBig";
 import { confirm } from "components/ConfirmDialog";
+import LinkDocs from "components/LinkDocs";
+import { docsUrl } from "params";
 
 export default function EthicalMetrics() {
   const { theme } = React.useContext(AppContext);
@@ -134,7 +136,11 @@ export default function EthicalMetrics() {
         than relying only on email notifications. Email notifications may be
         categorized as spam, potentially causing you to miss important
         notifications!
+        <LinkDocs href={docsUrl.ethicalMetricsOverview}>
+          Learn more about Ethical metrics in our Documentation
+        </LinkDocs>
       </div>
+
       {ethicalMetricsConfig.data ? (
         <Form.Group>
           <Form.Label>Ethical metrics status</Form.Label>
@@ -185,7 +191,7 @@ export default function EthicalMetrics() {
             Ethical metrics notifications by telegram channel
           </Form.Label>
           <Input
-            placeholder="Telegram Channel Id"
+            placeholder="Telegram Channel ID"
             isInvalid={tgChannelIdError}
             value={tgChannelId}
             onValueChange={setTgChannelId}
@@ -223,60 +229,65 @@ export default function EthicalMetrics() {
                     className="links-icon"
                     style={{ fontSize: "14px" }}
                   />
-                  How can I get a Telegram channel Id?{" "}
+                  How can I get a Telegram channel ID?{" "}
                   {tgAccordionOpen ? <IoIosArrowUp /> : <IoIosArrowDown />}{" "}
                 </div>
               </Accordion.Toggle>
               <Accordion.Collapse eventKey="0">
                 <div>
                   <ol>
-                    <li>Create a private channel in your telegram.</li>
                     <li>
-                      Add dappnode bot{" "}
-                      <span className={theme === "dark" ? "dark" : "light"}>
-                        @ethicalMetricsAlerts_bot
-                      </span>{" "}
-                      to the channel as an administrator.
-                    </li>
-                    <li>
-                      Open Telegram Web using this link:{" "}
+                      Open{" "}
                       <a href="https://web.telegram.org/a/" target="_blank">
                         Telegram web
                       </a>
-                      . If you haven't opened it using this link, ensure that in
-                      the URL, just after{" "}
+                      .
+                      <ul>
+                        <li>
+                          Ensure the URL ends with{" "}
+                          <span className={theme === "dark" ? "dark" : "light"}>
+                            /a/
+                          </span>
+                          . If not, manually add{" "}
+                          <span className={theme === "dark" ? "dark" : "light"}>
+                            /a/
+                          </span>{" "}
+                          after{" "}
+                          <span className={theme === "dark" ? "dark" : "light"}>
+                            https://web.telegram.org
+                          </span>
+                          .{" "}
+                        </li>
+                      </ul>
+                    </li>
+                    <li>Create a private channel.</li>
+                    <li>
+                      Add{" "}
                       <span className={theme === "dark" ? "dark" : "light"}>
-                        https://web.telegram.org
+                        @ethicalMetricsAlerts_bot
                       </span>{" "}
-                      is followed with{" "}
-                      <span className={theme === "dark" ? "dark" : "light"}>
-                        /a/
-                      </span>
-                      . Otherwise you wont be able to get the channel id.
+                      as an administrator in the channel.
                     </li>
                     <li>
-                      Open the channel and copy its id from the URL. The channel
-                      Id is the number of 13 digits that comes just after the{" "}
-                      <span className={theme === "dark" ? "dark" : "light"}>
-                        -
-                      </span>{" "}
-                      in the URL. It always starts with{" "}
-                      <span className={theme === "dark" ? "dark" : "light"}>
-                        -100
-                      </span>
-                      . While coping it, make sure to include the{" "}
-                      <span className={theme === "dark" ? "dark" : "light"}>
-                        -
-                      </span>{" "}
-                      just before the number!
+                      Go to your channel and copy the 13-digit ID from the URL.
+                      <ul>
+                        <li>
+                          The channel ID always starts with{" "}
+                          <span className={theme === "dark" ? "dark" : "light"}>
+                            -100
+                          </span>
+                          . Ensure to include the{" "}
+                          <span className={theme === "dark" ? "dark" : "light"}>
+                            -
+                          </span>{" "}
+                          while coping it.
+                        </li>
+                      </ul>
                     </li>
+
                     <li>
-                      Paste it in the Telegram Channel Id field and toggle the
-                      switch{" "}
-                      <span className={theme === "dark" ? "dark" : "light"}>
-                        ON
-                      </span>{" "}
-                      to start receiving notifications.
+                      Paste the ID into the Telegram Channel ID field and enable
+                      Ethical Metrics to receive notifications.
                     </li>
                   </ol>
                 </div>
@@ -285,7 +296,7 @@ export default function EthicalMetrics() {
           </Accordion>
           {tgChannelIdError && (
             <span style={{ fontSize: "12px", color: "red" }}>
-              Telegram channel Id format is incorrect
+              Telegram channel ID format is incorrect
             </span>
           )}
           <br />

--- a/packages/admin-ui/src/pages/system/components/Notifications/EthicalMetrics.tsx
+++ b/packages/admin-ui/src/pages/system/components/Notifications/EthicalMetrics.tsx
@@ -55,9 +55,8 @@ export default function EthicalMetrics() {
   useEffect(() => {
     const ethicalMetricsData = ethicalMetricsConfig.data;
     if (ethicalMetricsData) {
-      ethicalMetricsData.mail && setMail(ethicalMetricsData.mail);
-      ethicalMetricsData.tgChannelId &&
-        setTgChannelId(ethicalMetricsData.tgChannelId);
+      setMail(ethicalMetricsData.mail || "");
+      setTgChannelId(ethicalMetricsData.tgChannelId || "");
       setEthicalMetricsOn(ethicalMetricsData.enabled);
     }
   }, [ethicalMetricsConfig.data]);
@@ -88,7 +87,7 @@ export default function EthicalMetrics() {
         }
       );
       setReqStatusEnable({ result: true });
-      ethicalMetricsConfig.revalidate();
+      await ethicalMetricsConfig.revalidate();
       setEthicalMetricsOn(true);
     } catch (e) {
       setReqStatusEnable({ error: e });
@@ -114,7 +113,7 @@ export default function EthicalMetrics() {
         onSuccess: `Disabled ethical metrics`
       });
       setReqStatusDisable({ result: true });
-      ethicalMetricsConfig.revalidate();
+      await ethicalMetricsConfig.revalidate();
       setEthicalMetricsOn(false);
     } catch (e) {
       setReqStatusDisable({ error: e });

--- a/packages/admin-ui/src/pages/system/components/Notifications/ethicalMetrics.scss
+++ b/packages/admin-ui/src/pages/system/components/Notifications/ethicalMetrics.scss
@@ -7,7 +7,7 @@
     display: flex;
     flex-direction: row;
     align-items: center;
-    color: #3bb1f4;
+    color: var(--dappnode-strong-main-color);
   }
   .header:hover {
     text-decoration: underline;

--- a/packages/admin-ui/src/pages/system/components/Notifications/ethicalMetrics.scss
+++ b/packages/admin-ui/src/pages/system/components/Notifications/ethicalMetrics.scss
@@ -2,16 +2,17 @@
   border-style: none;
   background-color: transparent;
 
-  &.header {
+  .header {
     cursor: pointer;
     display: flex;
     flex-direction: row;
     align-items: center;
     color: #3bb1f4;
   }
-  &.header:hover {
+  .header:hover {
     text-decoration: underline;
   }
+
   span {
     padding: 5px;
     border-radius: 5px;

--- a/packages/admin-ui/src/pages/system/components/Notifications/ethicalMetrics.scss
+++ b/packages/admin-ui/src/pages/system/components/Notifications/ethicalMetrics.scss
@@ -1,0 +1,25 @@
+.accordion {
+  border-style: none;
+  background-color: transparent;
+
+  &.header {
+    cursor: pointer;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    color: #3bb1f4;
+  }
+  &.header:hover {
+    text-decoration: underline;
+  }
+  span {
+    padding: 5px;
+    border-radius: 5px;
+    &.light {
+      background-color: lightgray;
+    }
+    &.dark {
+      background-color: dimgray;
+    }
+  }
+}

--- a/packages/admin-ui/src/pages/system/components/Notifications/ethicalMetrics.scss
+++ b/packages/admin-ui/src/pages/system/components/Notifications/ethicalMetrics.scss
@@ -1,4 +1,4 @@
-.accordion {
+.accordion-notifications {
   border-style: none;
   background-color: transparent;
 
@@ -12,7 +12,9 @@
   .header:hover {
     text-decoration: underline;
   }
+}
 
+.accordion-notifications-wrapper {
   span {
     padding: 5px;
     border-radius: 5px;

--- a/packages/daemons/src/ethicalMetrics/checkEthicalMetricsStatus.ts
+++ b/packages/daemons/src/ethicalMetrics/checkEthicalMetricsStatus.ts
@@ -16,7 +16,7 @@ export async function checkEthicalMetricsStatus(
   const dmsDnpName = "dms.dnp.dappnode.eth";
 
   try {
-    const ethicalMetricsConfig = db.ethicalMetrics.get();
+    const ethicalMetricsConfig = db.notifications.get();
     if (!ethicalMetricsConfig) return;
     const { mail, enabled, tgChannelId } = ethicalMetricsConfig;
     if (enabled) {

--- a/packages/dappmanager/src/calls/ethicalMetrics.ts
+++ b/packages/dappmanager/src/calls/ethicalMetrics.ts
@@ -19,7 +19,7 @@ import { dockerContainerStart, dockerContainerStop } from "@dappnode/dockerapi";
  */
 export async function disableEthicalMetrics(): Promise<void> {
   // disable ethical metrics in db for installer daemon
-  db.ethicalMetrics.set({
+  db.notifications.set({
     mail: null,
     tgChannelId: null,
     enabled: false
@@ -59,7 +59,7 @@ export async function enableEthicalMetrics({
   if (!mail && !tgChannelId)
     throw new Error("You must provide an email or a telegram channel id");
 
-  db.ethicalMetrics.set({
+  db.notifications.set({
     mail,
     tgChannelId,
     enabled: true
@@ -96,5 +96,5 @@ export async function enableEthicalMetrics({
  * - email: the email used to register the instance
  */
 export async function getEthicalMetricsConfig(): Promise<EthicalMetricsConfig | null> {
-  return db.ethicalMetrics.get();
+  return db.notifications.get();
 }

--- a/packages/dappmanager/src/initializeDb.ts
+++ b/packages/dappmanager/src/initializeDb.ts
@@ -64,6 +64,23 @@ export async function initializeDb(): Promise<void> {
     db.ipfsGateway.set(params.IPFS_REMOTE);
 
   /**
+   *
+   *
+   */
+
+  if (db.notifications.get() === null) {
+    const mail = db.ethicalMetricsMail.get();
+    const status = db.ethicalMetricsStatus.get();
+    db.notifications.set({
+      enabled: status,
+      mail,
+      tgChannelId: null
+    });
+
+    db.newFeatureStatus.set("enable-ethical-metrics", "pending");
+  }
+
+  /**
    * Migrate data from the VPN db
    * - dyndns identity (including the domain)
    * - staticIp (if set)

--- a/packages/db/src/ethicalMetrics.ts
+++ b/packages/db/src/ethicalMetrics.ts
@@ -1,28 +1,24 @@
 import { EthicalMetricsConfig } from "@dappnode/types";
 import { dbMain } from "./dbFactory.js";
 
-const ETHICAL_METRICS = "ethical-metrics";
+const NOTIFICATIONS = "notifications";
 
 // Deprecated
 const ETHICAL_METRICS_MAIL = "ethical-metrics-mail";
 const ETHICAL_METRICS_STATUS = "ethical-metrics-status";
 
-export const ethicalMetrics = dbMain.staticKey<EthicalMetricsConfig | null>(
-  ETHICAL_METRICS,
-  {
-    enabled: false,
-    mail: null,
-    tgChannelId: null,
-  }
+export const notifications = dbMain.staticKey<EthicalMetricsConfig | null>(
+  NOTIFICATIONS,
+  null
 );
 
-// Deprecated in favor of "ethical-metrics"
+// Deprecated in favor of "notifications"
 export const ethicalMetricsMail = dbMain.staticKey<string | null>(
   ETHICAL_METRICS_MAIL,
   null
 );
 
-// Deprecated in favor of "ethical-metrics"
+// Deprecated in favor of "notifications"
 export const ethicalMetricsStatus = dbMain.staticKey<boolean>(
   ETHICAL_METRICS_STATUS,
   false

--- a/packages/migrations/src/changeEthicalMetricsDbFormat.ts
+++ b/packages/migrations/src/changeEthicalMetricsDbFormat.ts
@@ -22,12 +22,5 @@ import * as db from "@dappnode/db";
  */
 export async function changeEthicalMetricsDbFormat(): Promise<void> {
   // Initial value is null, so if it has a value it means the migration was already done
-  if (db.ethicalMetrics.get()) return;
-  const mail = db.ethicalMetricsMail.get();
-  const status = db.ethicalMetricsStatus.get();
-  db.ethicalMetrics.set({
-    enabled: status,
-    mail,
-    tgChannelId: null, // Important: at the time of this migration the tgChannelId was not implemented
-  });
+  if (db.notifications.get()) return;
 }


### PR DESCRIPTION
Consolidated email and Telegram channel ID validations into a single useEffect hook for improved code organization and readability. Additionally, enhanced the regex pattern to allow for groups in the Telegram channel ID format, providing added flexibility and versatility.

Telegram IDs can be in the format `'-1001234567890'` or `'-1001761649725_393'`