### PR TITLE
Updated telegram id regex to allow for groups ids

### DIFF
--- a/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
+++ b/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
@@ -36,25 +36,24 @@ export default function EnableEthicalMetrics({
     }
   }, [ethicalMetricsConfig.data]);
 
-  // effect and regex for email validation
   useEffect(() => {
-    const regex = /\S+@\S+\.\S+/;
-    if (regex.test(mail) || mail === "") {
+    const emailRegex = /\S+@\S+\.\S+/;
+    const tgChannelIdRegex = /^-100\d{10}(?:_\d{1,3})?$/;
+
+    // Email validation
+    if (emailRegex.test(mail) || mail === "") {
       setMailError(false);
     } else {
       setMailError(true);
     }
-  }, [mail]);
 
-  // effect and regex for telegram channelId validation
-  useEffect(() => {
-    const regex = /^-100\d{10}$/;
-    if (regex.test(tgChannelId) || tgChannelId === "") {
+    // Telegram channel ID validation
+    if (tgChannelIdRegex.test(tgChannelId) || tgChannelId === "") {
       setTgChannelIdError(false);
     } else {
       setTgChannelIdError(true);
     }
-  }, [tgChannelId]);
+  }, [mail, tgChannelId]);
 
   async function enableEthicalMetricsSync() {
     try {
@@ -195,7 +194,6 @@ export default function EnableEthicalMetrics({
                       </li>
                     </ul>
                   </li>
-
                   <li>
                     Paste the ID into the Telegram Channel ID field and enable
                     Ethical Metrics to receive notifications.
@@ -282,3 +280,4 @@ export default function EnableEthicalMetrics({
     </div>
   );
 }
+

--- a/packages/admin-ui/src/pages/system/components/Notifications/EthicalMetrics.tsx
+++ b/packages/admin-ui/src/pages/system/components/Notifications/EthicalMetrics.tsx
@@ -34,25 +34,24 @@ export default function EthicalMetrics() {
   const [reqStatusEnable, setReqStatusEnable] = useState<ReqStatus>({});
   const [reqStatusDisable, setReqStatusDisable] = useState<ReqStatus>({});
 
-  // effect and regex for email validation
   useEffect(() => {
-    const regex = /\S+@\S+\.\S+/;
-    if (regex.test(mail) || mail === "") {
+    const emailRegex = /\S+@\S+\.\S+/;
+    const tgChannelIdRegex = /^-100\d{10}(?:_\d{1,3})?$/;
+
+    // Email validation
+    if (emailRegex.test(mail) || mail === "") {
       setMailError(false);
     } else {
       setMailError(true);
     }
-  }, [mail]);
 
-  // effect and regex for telegram channelId validation
-  useEffect(() => {
-    const regex = /^-100\d{10}$/;
-    if (regex.test(tgChannelId) || tgChannelId === "") {
+    // Telegram channel ID validation
+    if (tgChannelIdRegex.test(tgChannelId) || tgChannelId === "") {
       setTgChannelIdError(false);
     } else {
       setTgChannelIdError(true);
     }
-  }, [tgChannelId]);
+  }, [mail, tgChannelId]);
 
   useEffect(() => {
     const ethicalMetricsData = ethicalMetricsConfig.data;
@@ -78,13 +77,12 @@ export default function EthicalMetrics() {
             sync: true
           }),
         {
-          message: `Enabling ethical metrics via ${
-            mailValue && tgChannelIdValue
-              ? "telegram channel and email"
-              : mailValue
+          message: `Enabling ethical metrics via ${mailValue && tgChannelIdValue
+            ? "telegram channel and email"
+            : mailValue
               ? "email"
               : tgChannelId && "telegram channel"
-          }`,
+            }`,
           onSuccess: `Enabled ethical metrics`
         }
       );
@@ -126,16 +124,20 @@ export default function EthicalMetrics() {
   return (
     <Card spacing>
       <div>
-        Receive notifications if your <strong>dappnode remains offline</strong>{" "}
-        for at least 6 hours, sent to either your Telegram or email. Telemetry
-        is collected anonymously to ensure no personal data is retained.
+        <p>
+          Receive notifications if your <strong>dappnode remains offline</strong>{" "}
+          for at least 3 hours, sent to either your Telegram or email. Telemetry
+          is collected anonymously to ensure no personal data is retained.
+        </p>
       </div>
       <div>
-        <span style={{ fontWeight: "bold" }}>Advice: </span>
-        We highly recommend using the Telegram channel option (or both) rather
-        than relying only on email notifications. Email notifications may be
-        categorized as spam, potentially causing you to miss important
-        notifications!
+        <p>
+          <span style={{ fontWeight: "bold" }}>Advice: </span>
+          We highly recommend using the Telegram channel option (or both) rather
+          than relying only on email notifications. Email notifications may be
+          categorized as spam, potentially causing you to miss important
+          notifications!
+        </p>
         <LinkDocs href={docsUrl.ethicalMetricsOverview}>
           Learn more about Ethical metrics in our Documentation
         </LinkDocs>
@@ -158,11 +160,11 @@ export default function EthicalMetrics() {
                 ethicalMetricsOn
                   ? disableConfirmation
                   : () =>
-                      enableEthicalMetricsSync({
-                        mailValue: mail && !mailError ? mail : null,
-                        tgChannelIdValue:
-                          tgChannelId && !tgChannelIdError ? tgChannelId : null
-                      })
+                    enableEthicalMetricsSync({
+                      mailValue: mail && !mailError ? mail : null,
+                      tgChannelIdValue:
+                        tgChannelId && !tgChannelIdError ? tgChannelId : null
+                    })
               }
               label={""}
               id="enable-ethical-metrics"
@@ -355,3 +357,4 @@ export default function EthicalMetrics() {
     </Card>
   );
 }
+


### PR DESCRIPTION
Consolidated email and Telegram channel ID validations into a single useEffect hook for improved code organization and readability. Additionally, enhanced the regex pattern to allow for groups in the Telegram channel ID format, providing added flexibility and versatility.

Telegram IDs can be in the format `'-1001234567890'` or `'-1001761649725_393'`