### PR TITLE
Ethical Metrics fixes before publish

### DIFF
--- a/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
+++ b/packages/admin-ui/src/components/welcome/features/EnableEthicalMetrics.tsx
@@ -25,6 +25,7 @@ export default function EnableEthicalMetrics({
   const [tgChannelIdError, setTgChannelIdError] = useState(false);
   const [validationMessage, setValidationMessage] = useState("");
   const [tgAccordionOpen, setTgAccordionOpen] = useState(false);
+  const [ethicalLoading, setEthicalLoading] = useState(false);
 
   // useEffect to populate email field when data is available
   useEffect(() => {
@@ -56,6 +57,7 @@ export default function EnableEthicalMetrics({
   }, [mail, tgChannelId]);
 
   async function enableEthicalMetricsSync() {
+    setEthicalLoading(true);
     try {
       setValidationMessage("Enabling ethical metrics...");
       await api.enableEthicalMetrics({
@@ -70,6 +72,7 @@ export default function EnableEthicalMetrics({
       setValidationMessage("Error enabling ethical metrics.");
       console.error("Error enabling ethical metrics:", error);
     }
+    setEthicalLoading(false);
   }
 
   // clear the success message after 5 seconds
@@ -262,7 +265,8 @@ export default function EnableEthicalMetrics({
               (tgChannelId === "" && mail === "") ||
               (tgChannelIdError && mailError) ||
               (tgChannelIdError && mail === "") ||
-              (tgChannelId === "" && mailError)
+              (tgChannelId === "" && mailError) ||
+              ethicalLoading
             }
             checked={ethicalMetricsOn}
             onChange={toggleEthicalSwitch}
@@ -280,4 +284,3 @@ export default function EnableEthicalMetrics({
     </div>
   );
 }
-

--- a/packages/admin-ui/src/pages/system/components/Notifications/EthicalMetrics.tsx
+++ b/packages/admin-ui/src/pages/system/components/Notifications/EthicalMetrics.tsx
@@ -23,6 +23,7 @@ export default function EthicalMetrics() {
 
   const ethicalMetricsConfig = useApi.getEthicalMetricsConfig();
   const [ethicalMetricsOn, setEthicalMetricsOn] = useState(false);
+  const [ethicalLoading, setEthicalLoading] = useState(false);
 
   const [mail, setMail] = useState("");
   const [mailError, setMailError] = useState(false);
@@ -66,6 +67,7 @@ export default function EthicalMetrics() {
     mailValue = ethicalMetricsConfig.data?.mail,
     tgChannelIdValue = ethicalMetricsConfig.data?.tgChannelId
   }) {
+    setEthicalLoading(true);
     try {
       setReqStatusEnable({ loading: true });
 
@@ -77,12 +79,13 @@ export default function EthicalMetrics() {
             sync: true
           }),
         {
-          message: `Enabling ethical metrics via ${mailValue && tgChannelIdValue
-            ? "telegram channel and email"
-            : mailValue
+          message: `Enabling ethical metrics via ${
+            mailValue && tgChannelIdValue
+              ? "telegram channel and email"
+              : mailValue
               ? "email"
               : tgChannelId && "telegram channel"
-            }`,
+          }`,
           onSuccess: `Enabled ethical metrics`
         }
       );
@@ -94,6 +97,7 @@ export default function EthicalMetrics() {
       console.error("Error on enableEthicalMetrics", e);
       setEthicalMetricsOn(false);
     }
+    setEthicalLoading(false);
   }
 
   function disableConfirmation() {
@@ -106,6 +110,7 @@ export default function EthicalMetrics() {
   }
 
   async function disableEthicalMetrics() {
+    setEthicalLoading(true);
     try {
       setReqStatusDisable({ loading: true });
       await withToast(() => api.disableEthicalMetrics(), {
@@ -119,15 +124,17 @@ export default function EthicalMetrics() {
       setReqStatusDisable({ error: e });
       console.error("Error on registerEthicalMetrics", e);
     }
+    setEthicalLoading(false);
   }
 
   return (
     <Card spacing>
       <div>
         <p>
-          Receive notifications if your <strong>dappnode remains offline</strong>{" "}
-          for at least 3 hours, sent to either your Telegram or email. Telemetry
-          is collected anonymously to ensure no personal data is retained.
+          Receive notifications if your{" "}
+          <strong>dappnode remains offline</strong> for at least 3 hours, sent
+          to either your Telegram or email. Telemetry is collected anonymously
+          to ensure no personal data is retained.
         </p>
       </div>
       <div>
@@ -151,20 +158,21 @@ export default function EthicalMetrics() {
           <div style={{ display: "inline-block" }}>
             <SwitchBig
               disabled={
-                (tgChannelId === "" && mail === "") ||
+                (tgChannelId === "" && mail === "" && !ethicalMetricsOn) ||
                 mailError ||
-                tgChannelIdError
+                tgChannelIdError ||
+                ethicalLoading
               }
               checked={ethicalMetricsOn}
               onChange={
                 ethicalMetricsOn
                   ? disableConfirmation
                   : () =>
-                    enableEthicalMetricsSync({
-                      mailValue: mail && !mailError ? mail : null,
-                      tgChannelIdValue:
-                        tgChannelId && !tgChannelIdError ? tgChannelId : null
-                    })
+                      enableEthicalMetricsSync({
+                        mailValue: mail && !mailError ? mail : null,
+                        tgChannelIdValue:
+                          tgChannelId && !tgChannelIdError ? tgChannelId : null
+                      })
               }
               label={""}
               id="enable-ethical-metrics"
@@ -357,4 +365,3 @@ export default function EthicalMetrics() {
     </Card>
   );
 }
-

--- a/packages/dappmanager/src/calls/ethicalMetrics.ts
+++ b/packages/dappmanager/src/calls/ethicalMetrics.ts
@@ -8,8 +8,7 @@ import { logs } from "@dappnode/logger";
 import {
   ethicalMetricsDnpName,
   register,
-  unregister,
-  isApiUp
+  unregister
 } from "@dappnode/ethicalmetrics";
 import { dockerContainerStart, dockerContainerStop } from "@dappnode/dockerapi";
 
@@ -78,14 +77,6 @@ export async function enableEthicalMetrics({
     for (const container of ethicalMetricsPkg.containers)
       if (!container.running)
         await dockerContainerStart(container.containerName);
-
-    //Checking if Ethical Metrics API is up before registering
-    let isEthicalUp = await isApiUp();
-    while (!isEthicalUp) {
-      setInterval(async () => {
-        isEthicalUp = await isApiUp();
-      }, 500);
-    }
 
     // Make sure the instance is registered
     await register({

--- a/packages/dappmanager/src/calls/ethicalMetrics.ts
+++ b/packages/dappmanager/src/calls/ethicalMetrics.ts
@@ -8,7 +8,8 @@ import { logs } from "@dappnode/logger";
 import {
   ethicalMetricsDnpName,
   register,
-  unregister
+  unregister,
+  isApiUp
 } from "@dappnode/ethicalmetrics";
 import { dockerContainerStart, dockerContainerStop } from "@dappnode/dockerapi";
 
@@ -77,6 +78,14 @@ export async function enableEthicalMetrics({
     for (const container of ethicalMetricsPkg.containers)
       if (!container.running)
         await dockerContainerStart(container.containerName);
+
+    //Checking if Ethical Metrics API is up before registering
+    let isEthicalUp = await isApiUp();
+    while (!isEthicalUp) {
+      setInterval(async () => {
+        isEthicalUp = await isApiUp();
+      }, 500);
+    }
 
     // Make sure the instance is registered
     await register({

--- a/packages/ethicalMetrics/src/index.ts
+++ b/packages/ethicalMetrics/src/index.ts
@@ -3,3 +3,4 @@ export { unregister } from "./unregister.js";
 export { register } from "./register.js";
 export { getIsRegistered } from "./getIsRegistered.js";
 export { getInstance } from "./getInstance.js";
+export { isApiUp } from "./isApiUp.js";

--- a/packages/ethicalMetrics/src/isApiUp.ts
+++ b/packages/ethicalMetrics/src/isApiUp.ts
@@ -1,0 +1,13 @@
+import * as url from "url";
+import fetch from "node-fetch";
+export async function isApiUp(): Promise<boolean> {
+  const ethicalMetricsEndpoint = "http://api-ui.ethical-metrics.dappnode:3000";
+  try {
+    const response = await fetch(url.resolve(ethicalMetricsEndpoint, "/"), {
+      method: "HEAD",
+    });
+    return response.ok;
+  } catch (error) {
+    return false;
+  }
+}

--- a/packages/ethicalMetrics/src/isApiUp.ts
+++ b/packages/ethicalMetrics/src/isApiUp.ts
@@ -1,13 +1,23 @@
 import * as url from "url";
 import fetch from "node-fetch";
-export async function isApiUp(): Promise<boolean> {
-  const ethicalMetricsEndpoint = "http://api-ui.ethical-metrics.dappnode:3000";
-  try {
-    const response = await fetch(url.resolve(ethicalMetricsEndpoint, "/"), {
-      method: "HEAD",
-    });
-    return response.ok;
-  } catch (error) {
-    return false;
-  }
+
+/**
+ * Returns true or false, depending on if api's response returns ok
+ */
+
+export async function isApiUp(timeout: number = 1000): Promise<boolean> {
+  return new Promise<boolean>(() => {
+    setTimeout(async () => {
+      const ethicalMetricsEndpoint =
+        "http://api-ui.ethical-metrics.dappnode:3000";
+      try {
+        const response = await fetch(url.resolve(ethicalMetricsEndpoint, "/"), {
+          method: "HEAD",
+        });
+        return response.ok;
+      } catch (error) {
+        return false;
+      }
+    }, timeout);
+  });
 }

--- a/packages/ethicalMetrics/src/register.ts
+++ b/packages/ethicalMetrics/src/register.ts
@@ -1,6 +1,7 @@
 import url from "url";
 import { ethicalMetricsEndpoint } from "./params.js";
 import fetch from "node-fetch";
+import { isApiUp } from "./isApiUp.js";
 
 /**
  * Register the instance in the Ethical Metrics server with the given email
@@ -12,25 +13,29 @@ export async function register({
   mail: string | null;
   tgChannelId: string | null;
 }): Promise<void> {
-  if (!mail && !tgChannelId) throw Error("mail or tgChannelId is required");
+  if (await isApiUp(2000)) {
+    if (!mail && !tgChannelId) throw Error("mail or tgChannelId is required");
 
-  const body: { mail?: string; tgChannelId?: string } = {};
-  if (mail) body["mail"] = mail;
-  if (tgChannelId) body["tgChannelId"] = tgChannelId;
+    const body: { mail?: string; tgChannelId?: string } = {};
+    if (mail) body["mail"] = mail;
+    if (tgChannelId) body["tgChannelId"] = tgChannelId;
 
-  const response = await fetch(
-    url.resolve(ethicalMetricsEndpoint, "/targets"),
-    {
-      method: "POST",
-      body: JSON.stringify(body),
-      headers: {
-        "Content-Type": "application/json",
-      },
-    }
-  );
+    const response = await fetch(
+      url.resolve(ethicalMetricsEndpoint, "/targets"),
+      {
+        method: "POST",
+        body: JSON.stringify(body),
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }
+    );
 
-  if (response.status === 200) return;
+    if (response.status === 200) return;
 
-  const message = await response.text();
-  throw Error(`Error registering instance: ${message}`);
+    const message = await response.text();
+    throw Error(`Error registering instance: ${message}`);
+  } else {
+    throw Error("Ethical metrics API is not up");
+  }
 }


### PR DESCRIPTION
- Disabling Switches while loading.
- Allowing to turn `OFF` the switch even if its fields are empty.
- Checking API status and don't allow the register until its status is up.