### PR TITLE
Start container before docker cp

### DIFF
--- a/packages/dockerApi/src/api/copyFileTo.ts
+++ b/packages/dockerApi/src/api/copyFileTo.ts
@@ -97,7 +97,7 @@ export async function copyFileToDockerContainer({
 
   if (!isInitiallyRunning)
     dockerContainerStop(containerName).catch(
-      (err) => logs.error(`Error stopping container ${containerName} after copying a to it: ${err}`)
+      (err) => logs.error(`Error stopping container ${containerName} after copying a file to it: ${err}`)
     );
 }
 


### PR DESCRIPTION
Before copying files to a docker container using `docker cp` the container needs to be running. This causes trouble in packages like Obol, where some services are stopped by default