### PR TITLE
Add Lido to the allowed categories

### DIFF
--- a/packages/schemas/src/schemas/manifest.schema.json
+++ b/packages/schemas/src/schemas/manifest.schema.json
@@ -458,7 +458,9 @@
           "Monitoring",
           "Payment channels",
           "Storage",
-          "Lido"
+          "Lido",
+          "DVT",
+          "LSD"
         ],
         "enumDescriptions": {
           "Blockchain": "Blockchain nodes, i.e. Bitcoin, Monero",
@@ -469,7 +471,9 @@
           "Monitoring": "Packages that track metrics",
           "Payment channels": "Packages whose main purpose is to manage or control payment channels, i.e. Raiden",
           "Storage": "Decentralized storage solutions, i.e. Swarm",
-          "Lido": "Packages for Lido operators"
+          "Lido": "Packages for Lido operators",
+          "DVT": "Packages for operators of Distributed Validators",
+          "LSD": "Packages for Liquidity Staking operators"
         }
       }
     },

--- a/packages/schemas/src/schemas/manifest.schema.json
+++ b/packages/schemas/src/schemas/manifest.schema.json
@@ -457,7 +457,8 @@
           "Economic incentive",
           "Monitoring",
           "Payment channels",
-          "Storage"
+          "Storage",
+          "Lido"
         ],
         "enumDescriptions": {
           "Blockchain": "Blockchain nodes, i.e. Bitcoin, Monero",
@@ -467,7 +468,8 @@
           "Economic incentive": "Packages that offer an economic incentive or reward to the admin that runs it, i.e. Lightning Network",
           "Monitoring": "Packages that track metrics",
           "Payment channels": "Packages whose main purpose is to manage or control payment channels, i.e. Raiden",
-          "Storage": "Decentralized storage solutions, i.e. Swarm"
+          "Storage": "Decentralized storage solutions, i.e. Swarm",
+          "Lido": "Packages for Lido operators"
         }
       }
     },


### PR DESCRIPTION
Lido has been added to the allowed categories so that the Dappstore shows it as one of the filters to find packages