### PR TITLE
Order data sent in pkg info

### DIFF
--- a/packages/admin-ui/src/pages/packages/components/Info/PackageSentData.tsx
+++ b/packages/admin-ui/src/pages/packages/components/Info/PackageSentData.tsx
@@ -37,12 +37,22 @@ export function RenderPackageSentData({
     });
   }
 
+  // Sorts the entries alphabetically
+  function orderEntries(entries: [string, string][]): [string, string][] {
+    return entries.sort((a, b) =>
+      a[0].localeCompare(b[0], undefined, {
+        numeric: true,
+        sensitivity: "base"
+      })
+    );
+  }
+
   return (
     <div className="package-sent-data">
       <header className="list-grid-header">Key</header>
       <header className="list-grid-header">Package sent values</header>
 
-      {entries.map(([key, value]) => (
+      {orderEntries(entries).map(([key, value]) => (
         <React.Fragment key={key}>
           <div>{key}</div>
           <div>

--- a/packages/admin-ui/src/pages/packages/components/Info/PackageSentData.tsx
+++ b/packages/admin-ui/src/pages/packages/components/Info/PackageSentData.tsx
@@ -37,12 +37,13 @@ export function RenderPackageSentData({
     });
   }
 
-  // Sorts the entries alphabetically
+  // Sorts the entries alphanumerically
   function orderEntries(entries: [string, string][]): [string, string][] {
     return entries.sort((a, b) =>
+      // Undefined here to use the default browser locale
       a[0].localeCompare(b[0], undefined, {
         numeric: true,
-        sensitivity: "base"
+        sensitivity: "base" // Case insensitive (a, A and other variations are considered the same)
       })
     );
   }


### PR DESCRIPTION
For packages like Obol we need several values sent to the dappmanager and the ideal situation involves having them sorted alphanumerically. This is the objective of the present PR.

Before:
![image](https://github.com/dappnode/DNP_DAPPMANAGER/assets/144998261/f3003b91-9ac1-4bfe-93e3-17c8c98c0224)

After:
![image](https://github.com/dappnode/DNP_DAPPMANAGER/assets/144998261/ce7dd55f-0bce-4400-88a4-b85183ecc9ad)
