### PR TITLE
Improve upstream repo schema

### DIFF
--- a/packages/daemons/src/autoUpdates/formatNotificationBody.ts
+++ b/packages/daemons/src/autoUpdates/formatNotificationBody.ts
@@ -15,7 +15,7 @@ export function formatPackageUpdateNotification({
   dnpName: string;
   currentVersion: string;
   newVersion: string;
-  upstreamVersion?: string;
+  upstreamVersion?: string | string[];
   autoUpdatesEnabled: boolean;
 }): string {
   const prettyName = prettyDnpName(dnpName);
@@ -25,7 +25,7 @@ export function formatPackageUpdateNotification({
     `New version ready to install for ${prettyName} (current version ${currentVersion})`,
     upstreamVersion
       ? ` - package version: ${newVersion}\n` +
-        ` - upstream version: ${upstreamVersion}`
+      ` - upstream version: ${upstreamVersion}`
       : ` - version: ${newVersion}`,
 
     `Connect to your DAppNode to install this new version [install / ${prettyName}](${installUrl}).`,
@@ -46,8 +46,7 @@ export function formatSystemUpdateNotification({
     "New system version ready to install",
     packages.map(
       (p) =>
-        ` - ${prettyDnpName(p.name)}: ${p.to} ${
-          p.from ? `(current: ${p.from})` : ""
+        ` - ${prettyDnpName(p.name)}: ${p.to} ${p.from ? `(current: ${p.from})` : ""
         }`
     ),
 

--- a/packages/schemas/src/schemas/manifest.schema.json
+++ b/packages/schemas/src/schemas/manifest.schema.json
@@ -7,6 +7,28 @@
   "title": "DAppNode Package (DNP) manifest",
   "required": ["name", "version", "description", "type", "license"],
   "description": "The DAppNode Package manifest defines all the necessary information for a DAppNode to understand this package:\n - IPFS of BZZ hashes to download its docker image \n - Docker related data to configure and run its container \n - Metadata to control how the package is shown in the admin UI.",
+  "dependencies": {
+    "upstream": {
+      "not": {
+        "required": ["upstreamRepo", "upstreamVersion", "upstreamArg"]
+      }
+    },
+    "upstreamRepo": {
+      "not": {
+        "required": ["upstream"]
+      }
+    },
+    "upstreamVersion": {
+      "not": {
+        "required": ["upstream"]
+      }
+    },
+    "upstreamArg": {
+      "not": {
+        "required": ["upstream"]
+      }
+    }
+  },
   "properties": {
     "name": {
       "type": "string",
@@ -70,6 +92,30 @@
           }
         }
       ]
+    },
+    "upstream": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["repo", "version", "arg"],
+        "properties": {
+          "repo": {
+            "type": "string",
+            "description": "Repository of the upstream software.",
+            "examples": ["ethereum/go-ethereum", "NethermindEth/nethermind"]
+          },
+          "version": {
+            "type": "string",
+            "description": "Version of the upstream software.",
+            "examples": ["2.6.0", "v1.2.1"]
+          },
+          "arg": {
+            "type": "string",
+            "description": "Environment variable name for specifying the version.",
+            "examples": ["GETH_VERSION", "NETHERMIND_VERSION"]
+          }
+        }
+      }
     },
     "shortDescription": {
       "type": "string",

--- a/packages/schemas/test/unit/validateSchema.test.ts
+++ b/packages/schemas/test/unit/validateSchema.test.ts
@@ -330,5 +330,89 @@ volumes:
 
       expect(() => validateSetupWizardSchema(invalidSetupWizard)).to.throw();
     });
+
+    it("should allow a manifest with upstream settings defined as an array of objects", () => {
+      const manifest: Manifest = {
+        name: "example.dnp.dappnode.eth",
+        version: "1.0.0",
+        description: "A sample DAppNode package",
+        type: "service",
+        license: "MIT",
+        upstream: [
+          {
+            repo: "ethereum/go-ethereum",
+            version: "1.9.24",
+            arg: "GETH_VERSION"
+          }
+        ]
+      };
+
+      expect(() => validateManifestSchema(manifest)).to.not.throw();
+    });
+
+    it("should allow a manifest with the upstream settings defined as separate strings", () => {
+      const manifest: Manifest = {
+        name: "example.dnp.dappnode.eth",
+        version: "1.0.0",
+        description: "A sample DAppNode package",
+        type: "service",
+        license: "MIT",
+        upstreamRepo: "ethereum/go-ethereum",
+        upstreamVersion: "1.9.24",
+        upstreamArg: "GETH_VERSION"
+      };
+
+      expect(() => validateManifestSchema(manifest)).to.not.throw();
+    });
+
+    it("should allow a manifest with the upstream settings defined as separate arrays", () => {
+      const manifest: Manifest = {
+        name: "example.dnp.dappnode.eth",
+        version: "1.0.0",
+        description: "A sample DAppNode package",
+        type: "service",
+        license: "MIT",
+        upstreamRepo: ["ethereum/go-ethereum", "NethermindEth/nethermind"],
+        upstreamVersion: ["1.9.24", "1.10.0"],
+        upstreamArg: ["GETH_VERSION", "NETHERMIND_VERSION"]
+      };
+
+      expect(() => validateManifestSchema(manifest)).to.not.throw();
+    });
+
+    it("should not allow a manifest with upstream settings defined in both possible ways", () => {
+      const manifest: Manifest = {  // Using 'any' to bypass TypeScript checks for invalid schema
+        name: "example.dnp.dappnode.eth",
+        version: "1.0.0",
+        description: "A sample DAppNode package",
+        type: "service",
+        license: "MIT",
+        upstream: [
+          {
+            repo: "ethereum/go-ethereum",
+            version: "1.9.24",
+            arg: "GETH_VERSION"
+          }
+        ],
+        upstreamRepo: "ethereum/go-ethereum",
+        upstreamVersion: "1.9.24",
+        upstreamArg: "GETH_VERSION"
+      };
+
+      expect(() => validateManifestSchema(manifest)).to.throw();
+    });
+
+    it("should allow a manifest without any upstream definitions", () => {
+      const manifest: Manifest = {
+        name: "example.dnp.dappnode.eth",
+        version: "1.0.0",
+        description: "A sample DAppNode package",
+        type: "service",
+        license: "MIT"
+      };
+
+      expect(() => validateManifestSchema(manifest)).to.not.throw();
+    });
+
   });
 });

--- a/packages/types/src/calls.ts
+++ b/packages/types/src/calls.ts
@@ -546,7 +546,7 @@ export type InstalledPackageData = Pick<
 
 export interface UpdateAvailable {
   newVersion: string;
-  upstreamVersion?: string;
+  upstreamVersion?: string | string[];
 }
 
 export interface InstalledPackageDetailData extends InstalledPackageData {
@@ -1034,9 +1034,9 @@ export type EthClientSyncedNotificationStatus = {
 
 export type Eth2ClientTarget =
   | {
-      execClient: ExecutionClientMainnet;
-      consClient: ConsensusClientMainnet;
-    }
+    execClient: ExecutionClientMainnet;
+    consClient: ConsensusClientMainnet;
+  }
   | "remote";
 
 /**

--- a/packages/types/src/manifest.ts
+++ b/packages/types/src/manifest.ts
@@ -9,9 +9,9 @@ export interface Manifest {
   // Package metadata
   name: string;
   version: string;
-  upstreamVersion?: string;
-  upstreamRepo?: string;
-  upstreamArg?: string;
+  upstreamVersion?: string | string[];
+  upstreamRepo?: string | string[];
+  upstreamArg?: string | string[];
   upstream?: {
     repo: string;
     version: string;

--- a/packages/types/src/manifest.ts
+++ b/packages/types/src/manifest.ts
@@ -12,6 +12,11 @@ export interface Manifest {
   upstreamVersion?: string;
   upstreamRepo?: string;
   upstreamArg?: string;
+  upstream?: {
+    repo: string;
+    version: string;
+    arg: string;
+  }[];
   shortDescription?: string;
   description?: string;
   author?: string;
@@ -49,13 +54,13 @@ export interface Manifest {
     minimumDockerVersion?: string;
   };
   globalEnvs?:
-    | {
-        all?: boolean;
-      }
-    | {
-        envs: string[];
-        services: string[];
-      }[];
+  | {
+    all?: boolean;
+  }
+  | {
+    envs: string[];
+    services: string[];
+  }[];
   architectures?: Architecture[];
 
   // Safety properties to solve problematic updates


### PR DESCRIPTION
Improve upstream repo schema to support the old way of handling upstream repos together with the newly defined in https://github.com/dappnode/DAppNodeSDK/issues/408

There are 3 possible cases:
1. No upstream settings defined
2. Upstream settings defined in the old way (upstreamRepo, upstreamArg and upstreamVersion fields)
3. Upstream settings defined in the new way (upstream object, with the fields repo, version and arg inside it)

It is not possible to define both at the same time