### PR TITLE
Only support 1 upstream repo with separate fields

### DIFF
--- a/packages/schemas/src/schemas/manifest.schema.json
+++ b/packages/schemas/src/schemas/manifest.schema.json
@@ -43,55 +43,19 @@
       "errorMessage": "should be a semantic version in the format x.y.z"
     },
     "upstreamRepo": {
-      "oneOf": [
-        {
-          "type": "string",
-          "description": "For DAppNode Packages that only wrap existing software (i.e. Bitcoin node, Ethereum node), the upstream software repository can be specified here.",
-          "examples": ["ethereum/go-ethereum", "NethermindEth/nethermind"]
-        },
-        {
-          "type": "array",
-          "description": "For DAppNode Packages that only wrap existing software (i.e. Bitcoin node, Ethereum node), several upstream software repositories can be specified here.",
-          "items": {
-            "type": "string",
-            "examples": ["ethereum/go-ethereum", "NethermindEth/nethermind"]
-          }
-        }
-      ]
+      "type": "string",
+      "description": "For DAppNode Packages that only wrap existing software (i.e. Bitcoin node, Ethereum node), the upstream software repository can be specified here.",
+      "examples": ["ethereum/go-ethereum", "NethermindEth/nethermind"]
     },
     "upstreamVersion": {
-      "oneOf": [
-        {
-          "type": "string",
-          "description": "For DAppNode Packages that only wrap existing software (i.e. Bitcoin node, Ethereum node), the underlying software version can be specified here. It will be shown in the admin UI alongside the field `version`.",
-          "examples": ["2.6.0", "v1.2.1"]
-        },
-        {
-          "type": "array",
-          "description": "For DAppNode Packages that only wrap existing software (i.e. Bitcoin node, Ethereum node) from several repositories, the underlying software version can be specified here. It will be shown in the admin UI alongside the field `version`.",
-          "items": {
-            "type": "string",
-            "examples": ["2.6.0", "v1.2.1"]
-          }
-        }
-      ]
+      "type": "string",
+      "description": "For DAppNode Packages that only wrap existing software (i.e. Bitcoin node, Ethereum node), the underlying software version can be specified here. It will be shown in the admin UI alongside the field `version`.",
+      "examples": ["2.6.0", "v1.2.1"]
     },
     "upstreamArg": {
-      "oneOf": [
-        {
-          "type": "string",
-          "description": "For DAppNode Packages that only wrap existing software (i.e. Bitcoin node, Ethereum node), the env var name to handle the upstream software version can be specified here.",
-          "examples": ["UPSTREAM_VERSION", "UPSTREAM_ARG"]
-        },
-        {
-          "type": "array",
-          "description": "For DAppNode Packages that only wrap existing software (i.e. Bitcoin node, Ethereum node) from several repositories, the env var names to handle the upstream software versions can be specified here.",
-          "items": {
-            "type": "string",
-            "examples": ["UPSTREAM_VERSION", "UPSTREAM_ARG"]
-          }
-        }
-      ]
+      "type": "string",
+      "description": "For DAppNode Packages that only wrap existing software (i.e. Bitcoin node, Ethereum node), the env var name to handle the upstream software version can be specified here.",
+      "examples": ["UPSTREAM_VERSION", "UPSTREAM_ARG"]
     },
     "upstream": {
       "type": "array",

--- a/packages/schemas/test/unit/validateSchema.test.ts
+++ b/packages/schemas/test/unit/validateSchema.test.ts
@@ -365,7 +365,8 @@ volumes:
       expect(() => validateManifestSchema(manifest)).to.not.throw();
     });
 
-    it("should allow a manifest with the upstream settings defined as separate arrays", () => {
+    it("should not allow a manifest with the upstream settings defined as separate arrays", () => {
+      // This way of defining the upstream settings has been deprecated
       const manifest: Manifest = {
         name: "example.dnp.dappnode.eth",
         version: "1.0.0",
@@ -377,7 +378,7 @@ volumes:
         upstreamArg: ["GETH_VERSION", "NETHERMIND_VERSION"]
       };
 
-      expect(() => validateManifestSchema(manifest)).to.not.throw();
+      expect(() => validateManifestSchema(manifest)).to.throw();
     });
 
     it("should not allow a manifest with upstream settings defined in both possible ways", () => {

--- a/packages/types/src/manifest.ts
+++ b/packages/types/src/manifest.ts
@@ -9,9 +9,9 @@ export interface Manifest {
   // Package metadata
   name: string;
   version: string;
-  upstreamVersion?: string | string[];
-  upstreamRepo?: string | string[];
-  upstreamArg?: string | string[];
+  upstreamVersion?: string;
+  upstreamRepo?: string;
+  upstreamArg?: string;
   upstream?: {
     repo: string;
     version: string;


### PR DESCRIPTION
After researching, I have not found any package that defines multiple upstream repos like an array of string, so we have decided that the only way of having multiple upstream projects will be using the new format defined in https://github.com/dappnode/DAppNodeSDK/issues/408#issuecomment-2063702185