### PR TITLE
Add UpstreamItem type

### DIFF
--- a/packages/types/src/manifest.ts
+++ b/packages/types/src/manifest.ts
@@ -12,11 +12,7 @@ export interface Manifest {
   upstreamVersion?: string;
   upstreamRepo?: string;
   upstreamArg?: string;
-  upstream?: {
-    repo: string;
-    version: string;
-    arg: string;
-  }[];
+  upstream?: UpstreamItem[];
   shortDescription?: string;
   description?: string;
   author?: string;
@@ -106,6 +102,12 @@ export interface Manifest {
 
   // setupWizard for compacted manifests in core packages
   setupWizard?: SetupWizard;
+}
+
+export interface UpstreamItem {
+  repo: string;
+  version: string;
+  arg: string;
 }
 
 // Metrics


### PR DESCRIPTION
Added `UpstreamItem` type to `types` package. It will be used in SDK for the bump upstream action