### PR TITLE
Allow validation of merged compose files

### DIFF
--- a/packages/schemas/src/validateComposeSchema.ts
+++ b/packages/schemas/src/validateComposeSchema.ts
@@ -6,16 +6,20 @@ import { exec } from "child_process";
  * Validates compose file with docker-compose config
  * @param compose
  */
-export async function validateComposeSchema(
-  composeFilePath: string
-): Promise<void> {
-  if (!fs.existsSync(composeFilePath))
-    throw Error(`Compose file ${composeFilePath} not found`);
+export async function validateComposeSchema(composePaths: string[]): Promise<void> {
+
+  if (composePaths.length < 1)
+    throw Error(`No compose files provided`);
+
+  composePaths.forEach((composePath) => {
+    if (!fs.existsSync(composePath))
+      throw Error(`Compose file ${composePath} not found`);
+  });
 
   return new Promise((resolve, reject) => {
     exec(
-      `docker-compose -f ${composeFilePath} config`,
-      (error, stdout, stderr) => {
+      `docker-compose -f ${composePaths.join(" -f")} config`,
+      (error, _stdout, stderr) => {
         if (error) {
           console.error(`Error: ${error.message}`);
           reject(new CliError(`Invalid compose:\n${stderr}`));


### PR DESCRIPTION
For the project of multi-variant packages, we need to handle compose files merging*, because we have a common compose file that will be merged with each of the variants compose files. This PR aims to support compose validation for these multi-variant package repositories.


* Compose files merging is natively supported by docker compose. For example, if you want to validate the result of merging 2 compose files, you could do:
```
docker compose -f docker-compose-1.yml -f docker-compose-2.yml config
```