### PR TITLE
Prevent packages routes from auto-rendering

### DIFF
--- a/packages/admin-ui/src/pages/packages/pages/ById.tsx
+++ b/packages/admin-ui/src/pages/packages/pages/ById.tsx
@@ -139,7 +139,7 @@ export const PackageById: React.FC = () => {
             <Route
               key={route.subPath}
               path={route.subPath}
-              element={<route.render />}
+              element={route.render()}
             />
           ))}
         </Routes>


### PR DESCRIPTION
Preventing the package tab routes from auto-reloading after cursor being focused in another window. 
Passing the `react.render` as a `JSX element`, was creating a new instance of the element on each render, triggering unnecessary re-renders.