### PR TITLE
"Copied tooltip" in `packages/info`

### DIFF
--- a/packages/admin-ui/src/dappnode_styles.scss
+++ b/packages/admin-ui/src/dappnode_styles.scss
@@ -232,7 +232,36 @@ p.no-p-style:last-child {
 .copy-input-copy {
   padding: 4px 9px 0px 11px;
   font-size: 1.3rem;
+  position: relative;
+  display: inline-block;
 }
+
+.copy-tooltip {
+  position: absolute;
+  background-color: #555;
+  color: #fff;
+  text-align: center;
+  font-size: 15px;
+  padding: 5px;
+  border-radius: 6px;
+  z-index: 1;
+  bottom: calc(100% + 5px);
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+// The triangle just below the 'copied' dialog
+.copy-tooltip::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  margin-left: -5px;
+  border-width: 5px;
+  border-style: solid;
+  border-color: #555 transparent transparent transparent;
+}
+
 .copy-input-open {
   padding: 0px 9px 0px 10px;
   font-size: 1.3rem;

--- a/packages/admin-ui/src/pages/packages/components/Info/PackageSentData.tsx
+++ b/packages/admin-ui/src/pages/packages/components/Info/PackageSentData.tsx
@@ -86,6 +86,14 @@ function SentDataRow({
   isSecret?: boolean;
 }) {
   const [show, setShow] = useState(false);
+  const [showCopyTooltip, setShowCopyTooltip] = useState(false);
+
+  const handleShowCopyTooltip = () => {
+    setShowCopyTooltip(true);
+    setTimeout(() => {
+      setShowCopyTooltip(false);
+    }, 1500);
+  };
 
   useEffect(() => {
     // Activate the copy functionality
@@ -121,7 +129,9 @@ function SentDataRow({
           <Button
             className="input-append-button copy-input-copy"
             data-clipboard-text={value}
+            onClick={handleShowCopyTooltip}
           >
+            {showCopyTooltip && <div className="copy-tooltip">copied!</div>}
             <GoCopy />
           </Button>
         </InputGroup.Append>


### PR DESCRIPTION
Displaying a "Copied" tooltip when clicking the copy button from inputs in `packages/my/package-name/info`
![image](https://github.com/dappnode/DNP_DAPPMANAGER/assets/52827122/e62731c8-41b1-4856-956b-af83bf85c89a)
