### PR TITLE
Get status of ssh instead of sshd

### DIFF
--- a/packages/dappmanager/src/calls/sshManager.ts
+++ b/packages/dappmanager/src/calls/sshManager.ts
@@ -75,7 +75,7 @@ class SshManager {
     try {
       // shellHost("systemctl is-active sshd") returns
       // 'active'
-      await this.shellHost("systemctl is-active sshd");
+      await this.shellHost("systemctl is-active ssh");
       return "enabled";
     } catch (e) {
       // Error: Command failed: docker run --rm --privileged --pid=host -t alpine:3.8 nsenter -t 1 -m -u -n -i systemctl is-active sshd


### PR DESCRIPTION
SSH status fetch is failing in modern Ubuntu distributions as `sshd` is not found anymore as a service. It is `ssh` instead. There needs to be some more testing but in my research it seems to be quite backwards compatible.