### PR TITLE
Implement auth for https in backend

### DIFF
--- a/packages/admin-ui/src/pages/packages/components/Network/HttpsMappings.tsx
+++ b/packages/admin-ui/src/pages/packages/components/Network/HttpsMappings.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { api, useApi } from "api";
 import { useSelector } from "react-redux";
 import { NavLink, useNavigate } from "react-router-dom";
@@ -58,7 +58,8 @@ export function HttpsMappings({
       fromSubdomain: from,
       dnpName,
       serviceName,
-      port: parseInt(port)
+      port: parseInt(port),
+      auth: user && password ? { username: user, password } : undefined
     };
 
     try {
@@ -143,9 +144,12 @@ export function HttpsMappings({
     // New mapping validation
     const fromError = validateFromSubdomain(from, mappings.data);
     const portError = validatePort(port);
-    const userError = validateUser(user);
-    const passwordError = validatePassword(password);
-    const isValid = !fromError && !portError;
+    const userError = user ? validateUser(user) : null;
+    const passwordError = user ? validatePassword(password) : null;
+    // - domain and port are valid and user and password are not set
+    // - domain and port are valid and user and password are set and user and password are valid
+    const isValid =
+      !fromError && !portError && (!user || (!userError && !passwordError));
 
     return (
       <div className="network-mappings">

--- a/packages/admin-ui/src/pages/packages/components/Network/HttpsMappings.tsx
+++ b/packages/admin-ui/src/pages/packages/components/Network/HttpsMappings.tsx
@@ -39,6 +39,8 @@ export function HttpsMappings({
   const [editing, setEditing] = useState(false);
   const [from, setFrom] = useState("");
   const [port, setPort] = useState("80");
+  const [user, setUser] = useState("");
+  const [password, setPassword] = useState("");
 
   const mappings = useApi.httpsPortalMappingsGet();
   const dnpsRequest = useApi.packagesGet();
@@ -141,6 +143,8 @@ export function HttpsMappings({
     // New mapping validation
     const fromError = validateFromSubdomain(from, mappings.data);
     const portError = validatePort(port);
+    const userError = validateUser(user);
+    const passwordError = validatePassword(password);
     const isValid = !fromError && !portError;
 
     return (
@@ -160,6 +164,7 @@ export function HttpsMappings({
           <header className="name">CONTAINER</header>
           <header className="name" />
           <header className="name">SUBDOMAIN</header>
+          <header className="name">AUTH</header>
           <header className="header">REMOVE</header>
 
           <hr />
@@ -187,6 +192,10 @@ export function HttpsMappings({
                 </a>
               </span>
 
+              <span className="name">
+                {mapping.auth ? `${mapping.auth.username}` : "-"}
+              </span>
+
               <MdClose onClick={() => removeMapping(mapping)} />
             </React.Fragment>
           ))}
@@ -209,6 +218,23 @@ export function HttpsMappings({
                 value: port,
                 onValueChange: setPort,
                 error: portError
+              },
+              {
+                label: "User",
+                labelId: "user",
+                required: false,
+                value: user,
+                onValueChange: setUser,
+                error: userError
+              },
+              {
+                label: "Password",
+                labelId: "password",
+                required: false,
+                secret: true,
+                value: password,
+                onValueChange: setPassword,
+                error: passwordError
               }
             ]}
           >
@@ -279,5 +305,21 @@ function validatePort(port: string): string | null {
   const portNum = parseInt(port);
   if (!portNum) return "Invalid port number";
   if (portNum > 65535) return "Port number too high";
+  return null;
+}
+
+function validatePassword(password: string): string | null {
+  if (!password) return "Invalid empty password";
+  const regex = new RegExp("^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.{8,})");
+  if (!regex.test(password))
+    return "Password must contain at least 8 characters, one uppercase, one lowercase, one number";
+  return null;
+}
+
+function validateUser(user: string): string | null {
+  if (!user) return "Invalid empty user";
+  // regex for user. it must not contain special characters
+  const regex = new RegExp("^[a-zA-Z0-9]*$");
+  if (!regex.test(user)) return "User must contain only letters and numbers";
   return null;
 }

--- a/packages/admin-ui/src/pages/packages/components/Network/https-mapping.scss
+++ b/packages/admin-ui/src/pages/packages/components/Network/https-mapping.scss
@@ -15,6 +15,7 @@
     grid-template-columns:
       minmax(min-content, max-content)
       minmax(min-content, max-content)
+      minmax(min-content, max-content)
       minmax(min-content, auto)
       minmax(calc(var(--icon-size) / 2), min-content);
 

--- a/packages/httpsPortal/src/apiClient.ts
+++ b/packages/httpsPortal/src/apiClient.ts
@@ -139,7 +139,7 @@ export class HttpsPortalApiClient {
    * @see https://nginx.org/en/docs/http/ngx_http_auth_basic_module.html
    * @param {string} params.username - The username.
    * @param {string} params.password - The password.
-   * @returns {Promise<string>} The htpasswd entry in the format `username:{SSHA}base64hash`.
+   * @returns {Promise<string>}`exampleUser:{SSHA}5ZCbZYs5Pn5T6Z9wXV5YWZRp+mgc0e3cLQFklHQbU3W5bg==`.
    */
   private async getHtpasswdEntry({
     username,

--- a/packages/httpsPortal/src/apiClient.ts
+++ b/packages/httpsPortal/src/apiClient.ts
@@ -1,5 +1,6 @@
 import fetch from "node-fetch";
 import Ajv from "ajv";
+import crypto from "crypto";
 import querystring from "querystring";
 import { urlJoin } from "@dappnode/utils";
 
@@ -17,6 +18,13 @@ export interface HttpPortalEntry {
    * `"validator-prysm"`, `"internal-docker-dns-based-host"`
    */
   toHost: string;
+  /**
+   * Optional auth credentials for mapping with basic auth
+   */
+  auth?: {
+    username: string;
+    password: string;
+  };
 }
 
 export const httpsPortalResponseSchema = {
@@ -54,10 +62,11 @@ export class HttpsPortalApiClient {
    * GET /add?from=<chosen-subodomain>&to=<internal-resource>
    * Empty reply
    */
-  async add({ fromSubdomain, toHost }: HttpPortalEntry): Promise<void> {
+  async add({ fromSubdomain, toHost, auth }: HttpPortalEntry): Promise<void> {
     const search = querystring.encode({
       from: fromSubdomain,
       to: toHost,
+      auth: auth && (await this.getHtpasswdEntry(auth)),
     });
     await this.get(urlJoin(this.baseUrl, `/add?${search}`));
   }
@@ -84,9 +93,9 @@ export class HttpsPortalApiClient {
    * [{"from":"validator-prysm-pyrmont.1ba499fcc3aff025.dyndns.dappnode.io","to":"validator-prysm-pyrmont"}]
    */
   async list(): Promise<HttpPortalEntry[]> {
-    const entries = await this.get<{ from: string; to: string }[]>(
-      urlJoin(this.baseUrl, `/?format=json`)
-    );
+    const entries = await this.get<
+      { from: string; to: string; auth?: string }[]
+    >(urlJoin(this.baseUrl, `/?format=json`));
 
     if (!ajv.validate(httpsPortalResponseSchema, entries)) {
       throw Error(`Invalid response: ${JSON.stringify(ajv.errors, null, 2)}`);
@@ -95,6 +104,12 @@ export class HttpsPortalApiClient {
     return entries.map((entry) => ({
       fromSubdomain: entry.from,
       toHost: entry.to,
+      auth: entry.auth
+        ? {
+            username: entry.auth.split(":")[0],
+            password: entry.auth.split(":")[1],
+          }
+        : undefined,
     }));
   }
 
@@ -111,5 +126,43 @@ export class HttpsPortalApiClient {
     } catch (e) {
       throw Error(`Error parsing JSON ${e.message}\n${body}`);
     }
+  }
+
+  /**
+   * Generates an htpasswd entry for a given username and password using the {SSHA} scheme.
+   * This entry can be used for HTTP Basic Authentication in NGINX.
+   *
+   * The {SSHA} scheme uses the SHA-1 hashing algorithm combined with a salt for added security.
+   * The salt helps to protect against dictionary and rainbow table attacks by ensuring that even
+   * identical passwords will have different hashes if different salts are used.
+   *
+   * @see https://nginx.org/en/docs/http/ngx_http_auth_basic_module.html
+   * @param {string} params.username - The username.
+   * @param {string} params.password - The password.
+   * @returns {Promise<string>} The htpasswd entry in the format `username:{SSHA}base64hash`.
+   */
+  private async getHtpasswdEntry({
+    username,
+    password,
+  }: {
+    username: string;
+    password: string;
+  }): Promise<string> {
+    const saltLength = 16; // Length of the salt in bytes
+
+    // Generate a random salt
+    const salt = crypto.randomBytes(saltLength);
+
+    // Hash the password using SHA-1 with the salt
+    const sha1Hasher = crypto.createHash("sha1");
+    sha1Hasher.update(password);
+    sha1Hasher.update(salt);
+    const hash = sha1Hasher.digest();
+
+    // Combine the hash and salt, then encode in Base64
+    const combined = Buffer.concat([hash, salt]).toString("base64");
+
+    // Format the htpasswd entry with the {SSHA} scheme
+    return `${username}:{SSHA}${combined}`;
   }
 }

--- a/packages/httpsPortal/src/httpsPortal.ts
+++ b/packages/httpsPortal/src/httpsPortal.ts
@@ -71,6 +71,7 @@ export class HttpsPortal {
     await this.httpsPortalApiClient.add({
       fromSubdomain: mapping.fromSubdomain,
       toHost: `${externalNetworkAlias}:${mapping.port}`,
+      auth: mapping.auth,
     });
 
     // Edit compose to persist the setting
@@ -144,7 +145,7 @@ export class HttpsPortal {
     }
 
     const mappings: HttpsPortalMapping[] = [];
-    for (const { fromSubdomain, toHost } of entries) {
+    for (const { fromSubdomain, toHost, auth } of entries) {
       const [alias, port] = toHost.split(":");
       const container = aliases.get(alias);
       if (container) {
@@ -153,6 +154,7 @@ export class HttpsPortal {
           dnpName: container.dnpName,
           serviceName: container.serviceName,
           port: parseInt(port) || 80,
+          auth,
         });
       }
     }

--- a/packages/types/src/calls.ts
+++ b/packages/types/src/calls.ts
@@ -26,6 +26,10 @@ export interface HttpsPortalMapping {
   dnpName: string;
   serviceName: string;
   port: number;
+  auth?: {
+    username: string;
+    password: string;
+  };
 }
 
 export interface ExposableServiceInfo extends HttpsPortalMapping {


### PR DESCRIPTION
Implement auth for https in backend:

- Allows to add optional query argument to add mapping API call **auth**
- The auth comes as a string in format `${username}:{SSHA}${combined}`
- No password stored in dappmanager side