### PR TITLE
Fix `getPkgAsset` to return an array if multiple elements exist

### DIFF
--- a/packages/toolkit/src/repository/repository.ts
+++ b/packages/toolkit/src/repository/repository.ts
@@ -566,20 +566,24 @@ export class DappnodeRepository extends ApmRepository {
   private parseAsset<T>(data: string | string[], format: FileFormat): T {
     const parseSingle = (content: string): any => {
       switch (format) {
-        case FileFormat.YAML:
-          const parsedYaml = YAML.parse(content);
-          if (!parsedYaml || typeof parsedYaml === "string")
-            throw new Error("Invalid YAML object");
-          return parsedYaml;
-        case FileFormat.JSON:
-          return JSON.parse(content);
-        case FileFormat.TEXT:
+        case FileFormat.YAML: {
+            const parsedYaml = YAML.parse(content);
+            if (!parsedYaml || typeof parsedYaml === "string")
+              throw new Error("Invalid YAML object");
+            return parsedYaml;
+        }
+        case FileFormat.JSON: {
+            return JSON.parse(content);
+        }
+        case FileFormat.TEXT: {
           return content; // TEXT format assumes direct usage of the string.
-        default:
+        }
+        default: {
           throw new Error(`Unsupported format: ${format}`);
+        }
       }
     };
-
+  
     try {
       if (Array.isArray(data)) {
         // Map over array data if it's an array, using parseSingle for each item
@@ -593,6 +597,7 @@ export class DappnodeRepository extends ApmRepository {
       throw new Error(`Error processing content: ${e instanceof Error ? e.message : "Unknown error"}`);
     }
   }
+  
 
 
   /**

--- a/packages/toolkit/src/repository/repository.ts
+++ b/packages/toolkit/src/repository/repository.ts
@@ -275,9 +275,9 @@ export class DappnodeRepository extends ApmRepository {
       this.writeFileToMemory(entry.cid.toString(), maxLength)
     ));
   
-    // If multiple files are allowed and multiple files were found, we return an array of parsed assets.
+    // If multiple files are allowed, we return an array of parsed assets.
     // Otherwise, we return a single parsed asset.
-    return this.parseAsset<T>(multiple && matchingEntries.length > 1 ? contents : contents[0], format);
+    return this.parseAsset<T>(multiple ? contents : contents[0], format);
   }
   
 


### PR DESCRIPTION
closes https://github.com/dappnode/DAppNodePackage-DMS/issues/47 as part of the project https://github.com/orgs/dappnode/projects/72/views/1

**getPkgAsset()** now takes into account the "multiple" field of `fileConfig` parameter. If `multiple == true` and at least one file (here defined as IpfsEntry) passes the given name regex for the `fileConfig`,  **getPkgAsset()** will return `<T>` as a **json array**, instead of a **json object**.

For example, [dappnode exporter package](https://github.com/dappnode/DAppNodePackage-exporter) has two files that end with `grafana-dashboard.json`. When the IPFS content of the package is downloaded, dappmanager will now notice that both files must be appended as an array, since we permit multiple `grafana-dashboard.json` to exist in a dnp, and both files pass the `grafana-dashboard.json` regex

Returning the content in grafana-dashboards.json as an array solves the DMS bug, since DMS's manager expects this content to be an array