### PR TITLE
Use mev boost as optional in stakers frontend

### DIFF
--- a/packages/admin-ui/src/pages/stakers/components/StakerNetwork.tsx
+++ b/packages/admin-ui/src/pages/stakers/components/StakerNetwork.tsx
@@ -221,23 +221,24 @@ export default function StakerNetwork({
                   isSelected={Boolean(newWeb3signer)}
                 />
               </Col>
-              {["prater", "mainnet", "holesky"].includes(network) && (
-                <Col>
-                  <SubTitle>Mev Boost</SubTitle>
-                  <MevBoost
-                    network={network}
-                    mevBoost={currentStakerConfigReq.data.mevBoost}
-                    newMevBoost={newMevBoost}
-                    setNewMevBoost={setNewMevBoost}
-                    newRelays={newRelays}
-                    setNewRelays={setNewRelays}
-                    isSelected={
-                      currentStakerConfigReq.data.mevBoost.dnpName ===
-                      newMevBoost?.dnpName
-                    }
-                  />
-                </Col>
-              )}
+              {["prater", "mainnet", "holesky"].includes(network) &&
+                currentStakerConfigReq.data.mevBoost && (
+                  <Col>
+                    <SubTitle>Mev Boost</SubTitle>
+                    <MevBoost
+                      network={network}
+                      mevBoost={currentStakerConfigReq.data.mevBoost}
+                      newMevBoost={newMevBoost}
+                      setNewMevBoost={setNewMevBoost}
+                      newRelays={newRelays}
+                      setNewRelays={setNewRelays}
+                      isSelected={
+                        currentStakerConfigReq.data.mevBoost.dnpName ===
+                        newMevBoost?.dnpName
+                      }
+                    />
+                  </Col>
+                )}
             </Row>
             <hr />
             <div>

--- a/packages/admin-ui/src/pages/stakers/components/useStakerConfig.ts
+++ b/packages/admin-ui/src/pages/stakers/components/useStakerConfig.ts
@@ -51,10 +51,9 @@ export const useStakerConfig = <T extends Network>(
       if (consensusClient && consensusClient.status === "ok")
         setNewConsClient(consensusClient);
 
-      const currentMevBoost = isOkSelectedInstalledAndRunning(mevBoost)
-        ? mevBoost
-        : null;
-      if (currentMevBoost && mevBoost.status === "ok") {
+      const currentMevBoost =
+        mevBoost && isOkSelectedInstalledAndRunning(mevBoost) ? mevBoost : null;
+      if (currentMevBoost && mevBoost?.status === "ok") {
         setNewMevBoost(mevBoost);
         mevBoost.relays && setNewRelays(mevBoost.relays);
       }

--- a/packages/types/src/stakers.ts
+++ b/packages/types/src/stakers.ts
@@ -146,7 +146,7 @@ export interface StakerConfigGet {
   executionClients: StakerItem[];
   consensusClients: StakerItem[];
   web3Signer: StakerItem;
-  mevBoost: StakerItem;
+  mevBoost?: StakerItem;
 }
 
 export interface StakerConfigSet {


### PR DESCRIPTION
Use mev boost as optional in stakers frontend due to the possibility of not available in networks: Lukso and Gnosis chain