### PR TITLE
Navigate when located in uninstalling pkg

### DIFF
--- a/packages/admin-ui/src/pages/packages/components/Info/RemovePackage.tsx
+++ b/packages/admin-ui/src/pages/packages/components/Info/RemovePackage.tsx
@@ -97,7 +97,14 @@ export function RemovePackage({ dnp }: { dnp: InstalledPackageDetailData }) {
         message: `Removing ${name} ${deleteVolumes ? " and volumes" : ""}...`,
         onSuccess: `Removed ${name}`
       });
-      navigate("/" + packagesRelativePath);
+
+      // Navigate to "/packages/my" only if user located in current unistalling package tab
+      const currentPath = location.pathname
+        .split("/")
+        .slice(0, -1)
+        .join("/");
+      currentPath === "/" + packagesRelativePath + "/" + dnpName &&
+        navigate("/" + packagesRelativePath);
     } catch (e) {
       console.error(e);
     }


### PR DESCRIPTION
Currently, when a package is removed, the user is always redirected to /packages/my regardless of their current location. This PR changes it so that the redirection only occurs if the user is on the tab of the package being uninstalled.