### PR TITLE
Allow semver ranges

### DIFF
--- a/packages/installer/src/dappGet/aggregate/aggregateDependencies.ts
+++ b/packages/installer/src/dappGet/aggregate/aggregateDependencies.ts
@@ -59,7 +59,7 @@ export default async function aggregateDependencies({
       // 2. Get dependencies of this specific version
       //    dependencies = { dnp-name-1: "semverRange", dnp-name-2: "/ipfs/Qmf53..."}
       const dependencies = await dappGetFetcher
-        .dependencies(dappnodeInstaller, name, version)
+        .dependenciesToInstall(dappnodeInstaller, name, version)
         .then(sanitizeDependencies)
         .catch((e: Error) => {
           e.message += `Error fetching ${name}@${version}`;

--- a/packages/installer/src/dappGet/basic.ts
+++ b/packages/installer/src/dappGet/basic.ts
@@ -19,10 +19,12 @@ export default async function dappGetBasic(
   req: PackageRequest
 ): Promise<DappGetResult> {
   const dappGetFetcher = new DappGetFetcher();
-  const dependencies = await dappGetFetcher.dependenciesToInstall(
+  const installedPackages = await listPackages();
+  const dependencies = await dappGetFetcher.dependencies(
     dappnodeInstaller,
     req.name,
-    req.ver
+    req.ver,
+    installedPackages
   );
 
   // Append dependencies in the list of DNPs to install

--- a/packages/installer/src/dappGet/basic.ts
+++ b/packages/installer/src/dappGet/basic.ts
@@ -19,7 +19,7 @@ export default async function dappGetBasic(
   req: PackageRequest
 ): Promise<DappGetResult> {
   const dappGetFetcher = new DappGetFetcher();
-  const dependencies = await dappGetFetcher.dependencies(
+  const dependencies = await dappGetFetcher.dependenciesToInstall(
     dappnodeInstaller,
     req.name,
     req.ver

--- a/packages/installer/src/dappGet/dappGet.ts
+++ b/packages/installer/src/dappGet/dappGet.ts
@@ -65,6 +65,7 @@ export async function dappGet(
    * It will not use the fetch or resolver module and only
    * fetch the first level dependencies of the request
    */
+  // TODO: Add catch here?
   if (options && options.BYPASS_RESOLVER)
     return await dappGetBasic(dappnodeInstaller, req);
 

--- a/packages/installer/src/dappGet/fetch/DappGetFetcher.ts
+++ b/packages/installer/src/dappGet/fetch/DappGetFetcher.ts
@@ -130,16 +130,39 @@ export class DappGetFetcher {
   }
 
   /**
- * Resolves and updates the given dependencies to their exact version by determining the maximum satisfying version.
- * 
- * This method takes a set of dependencies where the version is specified as a semver range and resolves it to the exact
- * version that should be installed. It does so by fetching all published versions of each dependency from the APM and 
- * determining the highest version that satisfies the given semver range.
- *
- * @param dependencies - An object representing the dependencies where the key is the dependency name and the value is the semver range or version.
- * @param dappnodeInstaller - An instance of `DappnodeInstaller` used to fetch published versions from the APM.
- * @throws If a semver range is invalid or if no satisfying version can be found for a dependency.
- */
+   * Resolves and updates the given dependencies to their exact version by determining the maximum satisfying version.
+   * 
+   * This method takes a set of dependencies where the version is specified as a semver range and resolves it to the exact
+   * version that should be installed. It does so by fetching all published versions of each dependency from the APM and 
+   * determining the highest version that satisfies the given semver range.
+   *
+   * @param dependencies - An object representing the dependencies where the key is the dependency name and the value is the semver range or version.
+   * @param dappnodeInstaller - An instance of `DappnodeInstaller` used to fetch published versions from the APM.
+   * @throws If a semver range is invalid or if no satisfying version can be found for a dependency.
+   * 
+   * @example
+   * // Given the following dependencies object with semver ranges:
+   * const dependencies = {
+   *   "example-dnp": "^1.0.0",
+   *   "another-dnp": "2.x",
+   *   "ipfs-dnp": "/ipfs/QmXf2...abc"
+   * };
+   * 
+   * // And assuming the following versions are available in the APM:
+   * // example-dnp: ["1.0.0", "1.1.0", "1.2.0"]
+   * // another-dnp: ["2.0.0", "2.1.0", "2.5.0"]
+   * // ipfs-dnp: ["/ipfs/QmXf2...abc"]
+   * 
+   * // After calling defineExactVersions:
+   * await defineExactVersions(dependencies, dappnodeInstaller);
+   * 
+   * // The dependencies object will be updated to:
+   * // {
+   * //   "example-dnp": "1.2.0",  // The highest version satisfying "^1.0.0"
+   * //   "another-dnp": "2.5.0",  // The highest version satisfying "2.x"
+   * //   "ipfs-dnp": "/ipfs/QmXf2...abc"  // Exact match
+   * // }
+   */
   private async defineExactVersions(
     dependencies: Dependencies,
     dappnodeInstaller: DappnodeInstaller

--- a/packages/installer/src/dappGet/fetch/DappGetFetcher.ts
+++ b/packages/installer/src/dappGet/fetch/DappGetFetcher.ts
@@ -110,23 +110,29 @@ export class DappGetFetcher {
         );
         // Remove the dependency if the installed version satisfies the required version
         delete dependencies[depName];
-      } else {
-
-        // Use "*" (latest) if the dependency is not installed and version is >... or >=... 
-        if (!installedPackage && /^>=?\d+\.\d+\.\d+$/.test(depVersion)) {
-          dependencies[depName] = '*';
-
-          // Use x.x.x if the dependency is not installed and version is ^x.x.x or ~x.x.x
-        } else if (!installedPackage && /^[\^~]\d+\.\d+\.\d+$/.test(depVersion)) {
-
-          // Remove the operator prefix and use the defined version
-          dependencies[depName] = depVersion.slice(1);
-
-        } else {
-
-          throw new Error(`Unsupported version range for dependency ${depName}: ${depVersion}. Only simle ranges with operators ^, ~, > and >= are supported`);
-        }
+        continue;
       }
+
+      dependencies[depName] = this.parseSemverRangeToApmVersion(depVersion);
+
     }
+  }
+
+  private parseSemverRangeToApmVersion(semverRange: string): string {
+    // Exact version, just keep it
+    if (/\d+\.\d+\.\d+$/.test(semverRange))
+      return semverRange;
+
+    // Use "*" (latest) if version is >... or >=...
+    if (/^>=?\d+\.\d+\.\d+$/.test(semverRange)) {
+      return '*';
+    }
+
+    // Use x.x.x if version is ^x.x.x or ~x.x.x
+    if (/^[\^~]\d+\.\d+\.\d+$/.test(semverRange)) {
+      return semverRange.slice(1);
+    }
+
+    throw new Error(`Unsupported version range (${semverRange}). Only simple ranges with operators ^, ~, > and >= are supported`);
   }
 }

--- a/packages/installer/src/dappGet/fetch/DappGetFetcher.ts
+++ b/packages/installer/src/dappGet/fetch/DappGetFetcher.ts
@@ -1,6 +1,7 @@
 import { Dependencies, InstalledPackageData } from "@dappnode/types";
 import { validRange, satisfies, valid } from "semver";
 import { DappnodeInstaller } from "../../dappnodeInstaller.js";
+import { listPackages } from "@dappnode/dockerapi";
 
 export class DappGetFetcher {
   /**
@@ -13,11 +14,11 @@ export class DappGetFetcher {
     dappnodeInstaller: DappnodeInstaller,
     name: string,
     version: string,
-    installedPackages: InstalledPackageData[]
   ): Promise<Dependencies> {
     const manifest = await dappnodeInstaller.getManifestFromDir(name, version);
     const dependencies = manifest.dependencies || {};
     const optionalDependencies = manifest.optionalDependencies || {};
+    const installedPackages = await listPackages();
 
     this.mergeOptionalDependencies(dependencies, optionalDependencies, installedPackages);
 

--- a/packages/installer/src/dappGet/fetch/DappGetFetcher.ts
+++ b/packages/installer/src/dappGet/fetch/DappGetFetcher.ts
@@ -1,8 +1,6 @@
 import { Dependencies, InstalledPackageData } from "@dappnode/types";
-import { validRange, satisfies, valid, maxSatisfying } from "semver";
+import { validRange, satisfies, valid } from "semver";
 import { DappnodeInstaller } from "../../dappnodeInstaller.js";
-import { listPackages } from "@dappnode/dockerapi";
-import { isIpfsHash } from "../../utils.js";
 
 export class DappGetFetcher {
   /**
@@ -11,21 +9,19 @@ export class DappGetFetcher {
    * @returns dependencies:
    *   { dnp-name-1: "semverRange", dnp-name-2: "/ipfs/Qmf53..."}
    */
-  async dependenciesToInstall(
+  async dependencies(
     dappnodeInstaller: DappnodeInstaller,
     name: string,
-    version: string
+    version: string,
+    installedPackages: InstalledPackageData[]
   ): Promise<Dependencies> {
     const manifest = await dappnodeInstaller.getManifestFromDir(name, version);
     const dependencies = manifest.dependencies || {};
     const optionalDependencies = manifest.optionalDependencies || {};
-    const installedPackages = await listPackages();
 
     this.mergeOptionalDependencies(dependencies, optionalDependencies, installedPackages);
-    this.filterSatisfiedDependencies(dependencies, installedPackages);
-    await this.defineExactVersions(dependencies, dappnodeInstaller);
 
-    console.log(`Resolved dependencies to install for ${name}@${version}: ${JSON.stringify(dependencies)}`);
+    console.log(`Resolved dependencies for ${name}@${version}: ${JSON.stringify(dependencies)}`);
 
     return dependencies;
   }
@@ -97,96 +93,6 @@ export class DappGetFetcher {
       if (isInstalled) {
         dependencies[optionalDepName] = optionalDepVersion;
       }
-    }
-  }
-
-  /**
-   * Processes the dependencies by first filtering out those that are already satisfied by installed packages
-   * and then converting any remaining semver ranges to appropriate APM versions.
-   *
-   * @param dependencies The main dependencies object to be processed.
-   * @param installedPackages The list of currently installed packages.
-   */
-  private filterSatisfiedDependencies(
-    dependencies: Dependencies,
-    installedPackages: InstalledPackageData[]
-  ): void {
-    for (const [depName, depVersion] of Object.entries(dependencies)) {
-      const installedPackage = installedPackages.find(
-        (pkg) => pkg.dnpName === depName
-      );
-
-      if (!validRange(depVersion))
-        throw new Error(`Invalid semver notation for dependency ${depName}: ${depVersion}`);
-
-      // Remove dependency if it is already satisfied by an installed package
-      if (installedPackage && satisfies(installedPackage.version, depVersion)) {
-        console.log(
-          `Dependency ${depName} is already installed with version ${installedPackage.version}`
-        );
-        delete dependencies[depName];
-      }
-    }
-  }
-
-  /**
-   * Resolves and updates the given dependencies to their exact version by determining the maximum satisfying version.
-   * 
-   * This method takes a set of dependencies where the version is specified as a semver range and resolves it to the exact
-   * version that should be installed. It does so by fetching all published versions of each dependency from the APM and 
-   * determining the highest version that satisfies the given semver range.
-   *
-   * @param dependencies - An object representing the dependencies where the key is the dependency name and the value is the semver range or version.
-   * @param dappnodeInstaller - An instance of `DappnodeInstaller` used to fetch published versions from the APM.
-   * @throws If a semver range is invalid or if no satisfying version can be found for a dependency.
-   * 
-   * @example
-   * // Given the following dependencies object with semver ranges:
-   * const dependencies = {
-   *   "example-dnp": "^1.0.0",
-   *   "another-dnp": "2.x",
-   *   "ipfs-dnp": "/ipfs/QmXf2...abc"
-   * };
-   * 
-   * // And assuming the following versions are available in the APM:
-   * // example-dnp: ["1.0.0", "1.1.0", "1.2.0"]
-   * // another-dnp: ["2.0.0", "2.1.0", "2.5.0"]
-   * // ipfs-dnp: ["/ipfs/QmXf2...abc"]
-   * 
-   * // After calling defineExactVersions:
-   * await defineExactVersions(dependencies, dappnodeInstaller);
-   * 
-   * // The dependencies object will be updated to:
-   * // {
-   * //   "example-dnp": "1.2.0",  // The highest version satisfying "^1.0.0"
-   * //   "another-dnp": "2.5.0",  // The highest version satisfying "2.x"
-   * //   "ipfs-dnp": "/ipfs/QmXf2...abc"  // Exact match
-   * // }
-   */
-  private async defineExactVersions(
-    dependencies: Dependencies,
-    dappnodeInstaller: DappnodeInstaller
-  ): Promise<void> {
-
-    for (const [depName, depVersion] of Object.entries(dependencies)) {
-
-      if (isIpfsHash(depVersion)) continue;
-
-      if (!validRange(depVersion))
-        throw new Error(`Invalid semver notation for dependency ${depName}: ${depVersion}`);
-
-      const pkgPublishments = await dappnodeInstaller.fetchApmVersionsState(depName);
-
-      const pkgVersions = Object.values(pkgPublishments)
-        .map(({ version }) => version);
-
-      const maxSatisfyingVersion = maxSatisfying(pkgVersions, depVersion);
-
-      if (!maxSatisfyingVersion)
-        throw new Error(`Could not find any satisfying versions for ${depName}`);
-
-      dependencies[depName] = maxSatisfyingVersion;
-
     }
   }
 }

--- a/packages/installer/src/dappGet/fetch/DappGetFetcher.ts
+++ b/packages/installer/src/dappGet/fetch/DappGetFetcher.ts
@@ -1,7 +1,7 @@
-import { Dependencies } from "@dappnode/types";
-import { validRange, satisfies, valid } from "semver";
+import { Dependencies, InstalledPackageData } from "@dappnode/types";
+import { validRange, satisfies, valid, Range } from "semver";
 import { DappnodeInstaller } from "../../dappnodeInstaller.js";
-import { listPackageNoThrow } from "@dappnode/dockerapi";
+import { listPackages } from "@dappnode/dockerapi";
 
 export class DappGetFetcher {
   /**
@@ -17,21 +17,11 @@ export class DappGetFetcher {
   ): Promise<Dependencies> {
     const manifest = await dappnodeInstaller.getManifestFromDir(name, version);
     const dependencies = manifest.dependencies || {};
+    const optionalDependencies = manifest.optionalDependencies || {};
+    const installedPackages = await listPackages();
 
-    const optionalDependencies = manifest.optionalDependencies;
-    if (optionalDependencies) {
-      // Iterate over optional dependencies and inject them if installed
-      for (const [
-        optionalDependencyName,
-        optionalDependencyVersion,
-      ] of Object.entries(optionalDependencies)) {
-        const optionalDependency = await listPackageNoThrow({
-          dnpName: optionalDependencyName,
-        });
-        if (!optionalDependency) continue;
-        dependencies[optionalDependencyName] = optionalDependencyVersion;
-      }
-    }
+    this.mergeOptionalDependencies(dependencies, optionalDependencies, installedPackages);
+    this.filterSatisfiedDependencies(dependencies, installedPackages);
 
     return dependencies;
   }
@@ -80,5 +70,63 @@ export class DappGetFetcher {
     }
     // Case 3. unvalid semver version ("/ipfs/Qmre4..."): Asume it's the only version
     return [versionRange];
+  }
+
+  private mergeOptionalDependencies(
+    dependencies: Dependencies,
+    optionalDependencies: Dependencies,
+    installedPackages: InstalledPackageData[]
+  ): void {
+    for (const [optionalDepName, optionalDepVersion] of Object.entries(optionalDependencies)) {
+      const isInstalled = installedPackages.some(
+        (installedPackage) => installedPackage.dnpName === optionalDepName
+      );
+
+      if (isInstalled) {
+        dependencies[optionalDepName] = optionalDepVersion;
+      }
+    }
+  }
+
+  private filterSatisfiedDependencies(
+    dependencies: Dependencies,
+    installedPackages: InstalledPackageData[]
+  ): void {
+    for (const [depName, depVersion] of Object.entries(dependencies)) {
+      const installedPackage = installedPackages.find(
+        (pkg) => pkg.dnpName === depName
+      );
+
+      if (!validRange(depVersion))
+        throw new Error(`Invalid semver notation for dependency ${depName}: ${depVersion}`);
+
+      if (depVersion.includes('||') || depVersion.includes(' ')) {
+        throw new Error(`Unsupported version range for dependency ${depName}: ${depVersion}. Only simple ranges are supported`);
+      }
+
+      if (installedPackage && satisfies(installedPackage.version, depVersion)) {
+        console.log(
+          `Dependency ${depName} is already installed with version ${installedPackage.version}`
+        );
+        // Remove the dependency if the installed version satisfies the required version
+        delete dependencies[depName];
+      } else {
+
+        // Use "*" (latest) if the dependency is not installed and version is >... or >=... 
+        if (!installedPackage && /^>=?\d+\.\d+\.\d+$/.test(depVersion)) {
+          dependencies[depName] = '*';
+
+          // Use x.x.x if the dependency is not installed and version is ^x.x.x or ~x.x.x
+        } else if (!installedPackage && /^[\^~]\d+\.\d+\.\d+$/.test(depVersion)) {
+
+          // Remove the operator prefix and use the defined version
+          dependencies[depName] = depVersion.slice(1);
+
+        } else {
+
+          throw new Error(`Unsupported version range for dependency ${depName}: ${depVersion}. Only simle ranges with operators ^, ~, > and >= are supported`);
+        }
+      }
+    }
   }
 }

--- a/packages/installer/src/dappGet/utils/filterSatisfiedDependencies.ts
+++ b/packages/installer/src/dappGet/utils/filterSatisfiedDependencies.ts
@@ -1,0 +1,37 @@
+import { Dependencies, InstalledPackageData } from "@dappnode/types";
+import { satisfies, validRange } from "semver";
+
+/**
+ * Processes the dependencies by first filtering out those that are already satisfied by installed packages
+ * and then converting any remaining semver ranges to appropriate APM versions.
+ *
+ * @param dependencies The main dependencies object to be processed.
+ * @param installedPackages The list of currently installed packages.
+ */
+export function filterSatisfiedDependencies(
+    dependencies: Dependencies,
+    installedPackages: InstalledPackageData[]
+): Dependencies {
+
+    const filteredDependencies: Dependencies = {};
+
+    for (const [depName, depVersion] of Object.entries(dependencies)) {
+        const installedPackage = installedPackages.find(
+            (pkg) => pkg.dnpName === depName
+        );
+
+        if (!validRange(depVersion))
+            throw new Error(`Invalid semver notation for dependency ${depName}: ${depVersion}`);
+
+        // Remove dependency if it is already satisfied by an installed package
+        if (installedPackage && satisfies(installedPackage.version, depVersion)) {
+            console.log(
+                `Dependency ${depName} is already installed with version ${installedPackage.version}`
+            );
+
+            filteredDependencies[depName] = installedPackage.version;
+        }
+    }
+
+    return filteredDependencies;
+}

--- a/packages/installer/src/dappGet/utils/parseSemverRangeToVersion.ts
+++ b/packages/installer/src/dappGet/utils/parseSemverRangeToVersion.ts
@@ -1,0 +1,62 @@
+import { Dependencies } from "@dappnode/types";
+import { isIpfsHash } from "../../utils.js";
+import { DappnodeInstaller } from "../../dappnodeInstaller.js";
+import { maxSatisfying, validRange } from "semver";
+
+/**
+ * Resolves and updates the given dependencies to their exact version by determining the maximum satisfying version.
+ * 
+ * This method takes a set of dependencies where the version is specified as a semver range and resolves it to the exact
+ * version that should be installed. It does so by fetching all published versions of each dependency from the APM and 
+ * determining the highest version that satisfies the given semver range.
+ *
+ * @param dependencies - An object representing the dependencies where the key is the dependency name and the value is the semver range or version.
+ * @param dappnodeInstaller - An instance of `DappnodeInstaller` used to fetch published versions from the APM.
+ * @throws If a semver range is invalid or if no satisfying version can be found for a dependency.
+ * 
+ * @example
+ * Given the following dependencies object with semver ranges:
+ * const dependencies = {
+ *   "example-dnp": "^1.0.0",
+ *   "another-dnp": "2.x",
+ *   "ipfs-dnp": "/ipfs/QmXf2...abc"
+ * };
+ * 
+ * And assuming the following versions are available in the APM:
+ * example-dnp: ["1.0.0", "1.1.0", "1.2.0"]
+ * another-dnp: ["2.0.0", "2.1.0", "2.5.0"]
+ * ipfs-dnp: ["/ipfs/QmXf2...abc"]
+ * 
+ * After calling defineExactVersions, the dependencies object will be updated to:
+ * {
+ *   "example-dnp": "1.2.0",  // The highest version satisfying "^1.0.0"
+ *   "another-dnp": "2.5.0",  // The highest version satisfying "2.x"
+ *   "ipfs-dnp": "/ipfs/QmXf2...abc"  // Exact match
+ * }
+ */
+export async function parseSemverRangeToVersion(
+    dependencies: Dependencies,
+    dappnodeInstaller: DappnodeInstaller
+): Promise<void> {
+
+    for (const [depName, depVersion] of Object.entries(dependencies)) {
+
+        if (isIpfsHash(depVersion)) continue;
+
+        if (!validRange(depVersion))
+            throw new Error(`Invalid semver notation for dependency ${depName}: ${depVersion}`);
+
+        const pkgPublishments = await dappnodeInstaller.fetchApmVersionsState(depName);
+
+        const pkgVersions = Object.values(pkgPublishments)
+            .map(({ version }) => version);
+
+        const maxSatisfyingVersion = maxSatisfying(pkgVersions, depVersion);
+
+        if (!maxSatisfyingVersion)
+            throw new Error(`Could not find any satisfying versions for ${depName}`);
+
+        dependencies[depName] = maxSatisfyingVersion;
+
+    }
+}

--- a/packages/installer/src/dappGet/utils/parseSemverRangeToVersion.ts
+++ b/packages/installer/src/dappGet/utils/parseSemverRangeToVersion.ts
@@ -37,7 +37,9 @@ import { maxSatisfying, validRange } from "semver";
 export async function parseSemverRangeToVersion(
     dependencies: Dependencies,
     dappnodeInstaller: DappnodeInstaller
-): Promise<void> {
+): Promise<Dependencies> {
+
+    const parsedDeps: Dependencies = {};
 
     for (const [depName, depVersion] of Object.entries(dependencies)) {
 
@@ -56,7 +58,9 @@ export async function parseSemverRangeToVersion(
         if (!maxSatisfyingVersion)
             throw new Error(`Could not find any satisfying versions for ${depName}`);
 
-        dependencies[depName] = maxSatisfyingVersion;
+        parsedDeps[depName] = maxSatisfyingVersion;
 
     }
+
+    return parsedDeps;
 }


### PR DESCRIPTION

This PR refactors the `DappGetFetcher` class to improve the handling of dependencies and their version ranges. The main improvements include:

1. **Separation of Concerns:**
   - The `processDependencies` method was introduced to handle two main responsibilities:
     - Filtering out dependencies that are already satisfied by installed packages.
     - Parsing and converting semver ranges to appropriate APM-compatible versions.

2. **Improved Optional Dependencies Handling:**
   - A new `mergeOptionalDependencies` method was introduced to inject optional dependencies into the main dependencies object only if the corresponding packages are installed.

3. **Enhanced Semver Range Handling:**
   - The `parseSemverRangeToApmVersion` method was created to convert semver ranges like `^x.x.x`, `~x.x.x`, `>x.x.x`, and `>=x.x.x` to appropriate APM-compatible versions or the latest version (`*`) if applicable.
   - Added checks to ensure that only simple version ranges are supported, throwing errors for complex or combined ranges.

4. **Code Readability and Maintainability:**
   - The code was refactored to be more modular and easier to understand, with clear method responsibilities and added inline documentation.
   - Methods were renamed and reorganized for clarity, following best practices.