### PR TITLE
Define pkg version as query param instead of path

### DIFF
--- a/packages/admin-ui/src/pages/installer/components/InstallDnpContainer.tsx
+++ b/packages/admin-ui/src/pages/installer/components/InstallDnpContainer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useApi } from "api";
 import { useSelector } from "react-redux";
-import { useParams } from "react-router-dom";
+import { useParams, useSearchParams } from "react-router-dom";
 import { title } from "../data";
 // This module
 import InstallDnpView from "./InstallDnpView";
@@ -13,7 +13,9 @@ import ErrorView from "components/ErrorView";
 import { getProgressLogsByDnp } from "services/isInstallingLogs/selectors";
 
 const InstallDnpContainer: React.FC = () => {
-  const { id, version } = useParams<{ id: string; version: string }>();
+  const { id } = useParams<{ id: string }>();
+  const [searchParams] = useSearchParams();
+  const version = searchParams.get("version") || undefined;
   const progressLogsByDnp = useSelector(getProgressLogsByDnp);
 
   // TODO: return a beautiful error page

--- a/packages/admin-ui/src/pages/installer/components/InstallerRoot.tsx
+++ b/packages/admin-ui/src/pages/installer/components/InstallerRoot.tsx
@@ -105,7 +105,7 @@ const InstallerRoot: React.FC = () => {
             element={
               <Routes>
                 <Route index element={<route.component />} />
-                <Route path=":id/:version?/*" element={<InstallDnpContainer />} />
+                <Route path=":id/*" element={<InstallDnpContainer />} />
               </Routes>
             }
           />

--- a/packages/admin-ui/src/pages/installer/components/dappnodeDappstore/InstallerDnp.tsx
+++ b/packages/admin-ui/src/pages/installer/components/dappnodeDappstore/InstallerDnp.tsx
@@ -67,8 +67,7 @@ export const InstallerDnp: React.FC = () => {
       // open a dialog that says it will open an external link, are you sure?
       confirmPromise({
         title: "Ready to Explore Stakehouse?",
-        text:
-          "Clicking 'Open' will direct you to external Stakehouse App in a new tab. It's not part of Dappnode, but it's a trusted platform. Happy journey!",
+        text: "Clicking 'Open' will direct you to external Stakehouse App in a new tab. It's not part of Dappnode, but it's a trusted platform. Happy journey!",
         buttons: [
           {
             label: "Cancel",

--- a/packages/admin-ui/src/pages/installer/components/dappnodeDappstore/InstallerDnp.tsx
+++ b/packages/admin-ui/src/pages/installer/components/dappnodeDappstore/InstallerDnp.tsx
@@ -67,7 +67,8 @@ export const InstallerDnp: React.FC = () => {
       // open a dialog that says it will open an external link, are you sure?
       confirmPromise({
         title: "Ready to Explore Stakehouse?",
-        text: "Clicking 'Open' will direct you to external Stakehouse App in a new tab. It's not part of Dappnode, but it's a trusted platform. Happy journey!",
+        text:
+          "Clicking 'Open' will direct you to external Stakehouse App in a new tab. It's not part of Dappnode, but it's a trusted platform. Happy journey!",
         buttons: [
           {
             label: "Cancel",
@@ -89,7 +90,7 @@ export const InstallerDnp: React.FC = () => {
       const encodedDnpName = encodeURIComponent(dnpName);
       const encodedVersion = version ? encodeURIComponent(version) : null;
 
-      const pkgPath = encodedVersion ? `${encodedDnpName}/${encodedVersion}` : encodedDnpName;
+      const pkgPath = encodedVersion ? `${encodedDnpName}?version=${encodedVersion}` : encodedDnpName;
 
       navigate(pkgPath);
     }


### PR DESCRIPTION
This fixes a bug introduced in https://github.com/dappnode/DNP_DAPPMANAGER/pull/2013

Version of a package is now defined as a query param (`?version=x.x.x`) instead of a path (`/x.x.x/`) so that each of the steps of the installation, like the setup wizard or the disclaimer are properly rendered in the browser

Version to install is now defined like:

![image](https://github.com/user-attachments/assets/707d691b-f0ff-43c7-98a4-6a4f733d4aed)


![image](https://github.com/user-attachments/assets/0fbd41f9-ab08-435e-9b59-6abc3be837c2)
