### PR TITLE
Spacing for warning

### DIFF
--- a/packages/admin-ui/src/pages/installer/components/Steps/Warnings.tsx
+++ b/packages/admin-ui/src/pages/installer/components/Steps/Warnings.tsx
@@ -74,6 +74,8 @@ export default function Warnings({
         </div>
       ) : null}
 
+      <br />
+
       <div className="button-group">
         <Button onClick={goBack}>Back</Button>
         <Button variant="dappnode" onClick={goNext}>


### PR DESCRIPTION
Spacing for warning was too small.

This is how it looks after adding `<br/>`

![image](https://github.com/user-attachments/assets/9a5f7826-29f5-486f-9373-389bd225aae5)
