### PR TITLE
Add LUKSO team key

### DIFF
--- a/packages/params/src/params.ts
+++ b/packages/params/src/params.ts
@@ -359,6 +359,12 @@ export const params = {
       dnpNameSuffix: ".public.dappnode.eth",
       signatureProtocol: "ECDSA_256" as const,
       key: "0xF84eeDc34257018Ba77353b9F5b3e11AeAeecC2a"
+    },
+    {
+      name: "LUKSO Team",
+      dnpNameSuffix: ".dnp.dappnode.eth",
+      signatureProtocol: "ECDSA_256" as const,
+      key: "0x6109dcd72b8a2485A5b3Ac4E76965159e9893aB7"
     }
   ]
 };


### PR DESCRIPTION
Add LUKSO team key

This key will be authorized to publish the following packages:
`lukso-geth.dnp.dappnode.eth`
`prysm-lukso.dnp.dappnode.eth`
`teku-lukso.dnp.dappnode.eth`