### PR TITLE
Only recreate on modified user settings

### DIFF
--- a/packages/stakers/src/stakerComponent.ts
+++ b/packages/stakers/src/stakerComponent.ts
@@ -61,7 +61,7 @@ export class StakerComponent {
     userSettings: UserSettings;
   }): Promise<void> {
     logs.info(`Persisting ${dnpName}`);
-    await this.setStakerPkgConfig({ dnpName, isInstalled: true, userSettings, forceRecreate: false });
+    await this.setStakerPkgConfig({ dnpName, isInstalled: true, userSettings });
   }
 
   protected async setNew({
@@ -133,14 +133,13 @@ export class StakerComponent {
   private async setStakerPkgConfig({
     dnpName,
     isInstalled,
-    userSettings,
-    forceRecreate = true
+    userSettings
   }: {
     dnpName: string;
     isInstalled: boolean;
     userSettings: UserSettings;
-    forceRecreate?: boolean;
   }): Promise<void> {
+    let forceRecreate = false;
     // ensure pkg installed
     if (!isInstalled)
       await packageInstall(this.dappnodeInstaller, {
@@ -154,6 +153,7 @@ export class StakerComponent {
       if (!isMatch(userSettingsPrev, userSettings)) {
         composeEditor.applyUserSettings(userSettings, { dnpName });
         composeEditor.write();
+        forceRecreate = true; // Only recreate if userSettings changed
       }
     }
 

--- a/packages/stakers/src/stakerComponent.ts
+++ b/packages/stakers/src/stakerComponent.ts
@@ -139,18 +139,33 @@ export class StakerComponent {
     isInstalled: boolean;
     userSettings: UserSettings;
   }): Promise<void> {
-    let forceRecreate = false;
-    // ensure pkg installed
-    if (!isInstalled)
+    if (isInstalled) {
+      await this.setInstalledStakerPkgConfig({ dnpName, userSettings });
+    } else {
       await packageInstall(this.dappnodeInstaller, {
         name: dnpName,
         userSettings: userSettings ? { [dnpName]: userSettings } : {}
       });
-    else if (userSettings) {
+    }
+  }
+
+  private async setInstalledStakerPkgConfig({
+    dnpName,
+    userSettings
+  }: {
+    dnpName: string;
+    userSettings: UserSettings;
+  }): Promise<void> {
+    let forceRecreate = false;
+
+    if (userSettings) {
       const composeEditor = new ComposeFileEditor(dnpName, false);
-      const userSettingsPrev: UserSettingsAllDnps = {};
-      userSettingsPrev[dnpName] = composeEditor.getUserSettings();
-      if (!isMatch(userSettingsPrev, userSettings)) {
+
+      const previousSettings: UserSettingsAllDnps = {
+        [dnpName]: composeEditor.getUserSettings()
+      };
+
+      if (!isMatch(previousSettings, userSettings)) {
         composeEditor.applyUserSettings(userSettings, { dnpName });
         composeEditor.write();
         forceRecreate = true; // Only recreate if userSettings changed


### PR DESCRIPTION
In the method `setStakerPkgConfig` we check if there are user settings to apply. Only recreate the package containers in case that there are any user settings that have been modified