### PR TITLE
Return if not nimbus

### DIFF
--- a/packages/dappmanager/src/calls/packageInstall.ts
+++ b/packages/dappmanager/src/calls/packageInstall.ts
@@ -29,7 +29,7 @@ export async function packageInstall({
     options
   });
 
-  ensureNimbusConnection(reqName);
+  await ensureNimbusConnection(reqName);
 }
 
 /**
@@ -41,7 +41,7 @@ export async function packageInstall({
  *
  * TODO: Remove this once all Nimbus packages are multiservice
  */
-function ensureNimbusConnection(dnpName: string): void {
+async function ensureNimbusConnection(dnpName: string): Promise<void> {
   if (!dnpName.includes("nimbus")) {
     logs.debug("Not a Nimbus package, skipping network reconnection");
     return;
@@ -66,5 +66,5 @@ function ensureNimbusConnection(dnpName: string): void {
   }
 
   // Not awaited
-  consensus.persistSelectedConsensusIfInstalled(network);
+  await consensus.persistSelectedConsensusIfInstalled(network);
 }

--- a/packages/dappmanager/src/calls/packageInstall.ts
+++ b/packages/dappmanager/src/calls/packageInstall.ts
@@ -44,6 +44,7 @@ export async function packageInstall({
 function ensureNimbusConnection(dnpName: string): void {
   if (!dnpName.includes("nimbus")) {
     logs.debug("Not a Nimbus package, skipping network reconnection");
+    return;
   }
 
   logs.info("Ensuring Nimbus services are connected to the staker network");


### PR DESCRIPTION
Exit the function `ensureNimbusConnection` if the DNP name does not correspond to a Nimbus package