### PR TITLE
ensure requirements in `packageInstall` and not only on `fetchDnpRequest`

### DIFF
--- a/packages/admin-ui/src/pages/installer/components/InstallDnpView.tsx
+++ b/packages/admin-ui/src/pages/installer/components/InstallDnpView.tsx
@@ -174,7 +174,6 @@ const InstallDnpView: React.FC<InstallDnpViewProps> = ({ dnp, progressLogs }) =>
 
   const disableInstallation =
     !isEmpty(progressLogs) || requiresCoreUpdate || requiresDockerUpdate || packagesToBeUninstalled.length > 0;
-  console.log("disableInstallation", disableInstallation);
 
   const setupSubPath = "setup";
   const permissionsSubPath = "permissions";
@@ -344,7 +343,7 @@ const InstallDnpView: React.FC<InstallDnpViewProps> = ({ dnp, progressLogs }) =>
             <InstallerStepInfo
               dnp={dnp}
               onInstall={() => goNext()}
-              disableInstallation={false}
+              disableInstallation={disableInstallation}
               optionsArray={optionsArray}
             />
           }

--- a/packages/admin-ui/src/pages/installer/components/InstallDnpView.tsx
+++ b/packages/admin-ui/src/pages/installer/components/InstallDnpView.tsx
@@ -172,8 +172,7 @@ const InstallDnpView: React.FC<InstallDnpViewProps> = ({ dnp, progressLogs }) =>
     }
   ].filter((option) => option.available);
 
-  const disableInstallation =
-    !isEmpty(progressLogs) || requiresCoreUpdate || requiresDockerUpdate || packagesToBeUninstalled.length > 0;
+  const disableInstallation = false; // !isEmpty(progressLogs) || requiresCoreUpdate || requiresDockerUpdate || packagesToBeUninstalled.length > 0;
 
   const setupSubPath = "setup";
   const permissionsSubPath = "permissions";

--- a/packages/admin-ui/src/pages/installer/components/InstallDnpView.tsx
+++ b/packages/admin-ui/src/pages/installer/components/InstallDnpView.tsx
@@ -172,7 +172,9 @@ const InstallDnpView: React.FC<InstallDnpViewProps> = ({ dnp, progressLogs }) =>
     }
   ].filter((option) => option.available);
 
-  const disableInstallation = false; // !isEmpty(progressLogs) || requiresCoreUpdate || requiresDockerUpdate || packagesToBeUninstalled.length > 0;
+  const disableInstallation =
+    !isEmpty(progressLogs) || requiresCoreUpdate || requiresDockerUpdate || packagesToBeUninstalled.length > 0;
+  console.log("disableInstallation", disableInstallation);
 
   const setupSubPath = "setup";
   const permissionsSubPath = "permissions";
@@ -342,7 +344,7 @@ const InstallDnpView: React.FC<InstallDnpViewProps> = ({ dnp, progressLogs }) =>
             <InstallerStepInfo
               dnp={dnp}
               onInstall={() => goNext()}
-              disableInstallation={disableInstallation}
+              disableInstallation={false}
               optionsArray={optionsArray}
             />
           }

--- a/packages/installer/src/calls/packageInstall.ts
+++ b/packages/installer/src/calls/packageInstall.ts
@@ -10,7 +10,8 @@ import {
   rollbackPackages,
   writeAndValidateFiles,
   postInstallClean,
-  afterInstall
+  afterInstall,
+  checkInstallRequirements
 } from "../installer/index.js";
 import { logs, getLogUi, logUiClear } from "@dappnode/logger";
 import { Routes } from "@dappnode/types";
@@ -53,6 +54,7 @@ export async function packageInstall(
       if (!release.signedSafe && !options.BYPASS_SIGNED_RESTRICTION) {
         throw Error(`Package ${release.dnpName} is from untrusted origin and is not signed`);
       }
+      if (!release.isCore) await checkInstallRequirements({ manifest: release.manifest });
     }
 
     // Gather all data necessary for the install

--- a/packages/installer/src/installer/checkInstallRequirements.ts
+++ b/packages/installer/src/installer/checkInstallRequirements.ts
@@ -7,6 +7,7 @@ import { valid, gt } from "semver";
  * Get the install requirements and throw an error if they are not met
  */
 export async function checkInstallRequirements({ manifest }: { manifest: Manifest }): Promise<void> {
+  if (manifest.type === "dncore") return;
   const installedPackages = await listPackages();
   const packagesRequiredToBeUninstalled = getRequiresUninstallPackages({ manifest, installedPackages });
   const requiresCoreUpdate = getRequiresCoreUpdate({ manifest, installedPackages });

--- a/packages/installer/src/installer/checkInstallRequirements.ts
+++ b/packages/installer/src/installer/checkInstallRequirements.ts
@@ -1,0 +1,60 @@
+import { listPackages, getDockerVersion } from "@dappnode/dockerapi";
+import { params } from "@dappnode/params";
+import { Manifest, InstalledPackageData } from "@dappnode/types";
+import { valid, gt } from "semver";
+
+/**
+ * Get the install requirements and throw an error if they are not met
+ */
+export async function checkInstallRequirements({ manifest }: { manifest: Manifest }): Promise<void> {
+  const installedPackages = await listPackages();
+  const packagesRequiredToBeUninstalled = getRequiresUninstallPackages({ manifest, installedPackages });
+  const requiresCoreUpdate = getRequiresCoreUpdate({ manifest, installedPackages });
+  const requiresDockerUpdate = await getRequiresDockerUpdate({ manifest });
+
+  const errors: string[] = [];
+  if (packagesRequiredToBeUninstalled.length > 0)
+    errors.push(`The following packages must be uninstalled: ${packagesRequiredToBeUninstalled.join(", ")}`);
+  if (requiresCoreUpdate) errors.push("The core package must be updated");
+  if (requiresDockerUpdate) errors.push("Docker must be updated");
+  if (errors.length > 0)
+    throw new Error(`The package cannot be installed because of the following requirements:
+${errors.join("\n")}`);
+}
+
+function getRequiresUninstallPackages({
+  manifest,
+  installedPackages
+}: {
+  manifest: Manifest;
+  installedPackages: InstalledPackageData[];
+}): string[] {
+  const { notInstalledPackages } = manifest.requirements || {};
+  if (!notInstalledPackages || notInstalledPackages.length === 0) return [];
+  return notInstalledPackages.filter((dnpName) => installedPackages.find((dnp) => dnp.dnpName === dnpName));
+}
+
+function getRequiresCoreUpdate({
+  manifest,
+  installedPackages
+}: {
+  manifest: Manifest;
+  installedPackages: InstalledPackageData[];
+}): boolean {
+  const coreDnp = installedPackages.find((dnp) => dnp.dnpName === params.coreDnpName);
+  if (!coreDnp) return false;
+  const coreVersion = coreDnp.version;
+  const minDnVersion = manifest.requirements ? manifest.requirements.minimumDappnodeVersion : "";
+  return Boolean(minDnVersion && valid(minDnVersion) && valid(coreVersion) && gt(minDnVersion, coreVersion));
+}
+async function getRequiresDockerUpdate({ manifest }: { manifest: Manifest }): Promise<boolean> {
+  const minDockerVersion = manifest.requirements?.minimumDockerVersion;
+  if (!minDockerVersion) return false;
+  const currentDockerVersion = await getDockerVersion();
+  return Boolean(
+    minDockerVersion &&
+      valid(minDockerVersion) &&
+      valid(currentDockerVersion) &&
+      gt(minDockerVersion, currentDockerVersion)
+  );
+}

--- a/packages/installer/src/installer/index.ts
+++ b/packages/installer/src/installer/index.ts
@@ -7,3 +7,4 @@ export * from "./rollbackPackages.js";
 export * from "./runPackages.js";
 export * from "./restartPatch.js";
 export * from "./writeAndValidateFiles.js";
+export * from "./checkInstallRequirements.js";

--- a/packages/schemas/test/unit/validateSchema.test.ts
+++ b/packages/schemas/test/unit/validateSchema.test.ts
@@ -5,7 +5,8 @@ import path from "path";
 import { cleanTestDir, testDir } from "../testUtils.js";
 import { Manifest, SetupWizard } from "@dappnode/types";
 
-describe("schemaValidation", () => {
+describe("schemaValidation", function () {
+  this.timeout(10000);
   describe("manifest", () => {
     before(() => {
       cleanTestDir();


### PR DESCRIPTION
Ensure requirements in `packageInstall` and not only on `fetchDnpRequest`.

This will affect mainly auto updates as long as the install from the dappstore is already tracked with the compatible data