### PR TITLE
add deletedns unit test

### DIFF
--- a/packages/dockerCompose/src/editor.ts
+++ b/packages/dockerCompose/src/editor.ts
@@ -77,16 +77,14 @@ export class ComposeServiceEditor {
   }
 
   /**
-   * Remove the property, dont append undefined to the yaml
+   * Remove the property directly from the service.
    */
   removeDns(): void {
-    this.edit((service) => {
-      if (!service.dns) return service;
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { dns, ...rest } = service;
-      return rest;
-    });
-  }
+    const service = this.get();
+    if ('dns' in service) {
+      delete service.dns;
+    }
+  }  
 
   removeNetworkAliases(networkName: string, aliasesToRemove: string[], serviceNetwork: ComposeServiceNetwork): void {
     this.edit((service) => {

--- a/packages/dockerCompose/src/editor.ts
+++ b/packages/dockerCompose/src/editor.ts
@@ -81,10 +81,10 @@ export class ComposeServiceEditor {
    */
   removeDns(): void {
     const service = this.get();
-    if ('dns' in service) {
+    if ("dns" in service) {
       delete service.dns;
     }
-  }  
+  }
 
   removeNetworkAliases(networkName: string, aliasesToRemove: string[], serviceNetwork: ComposeServiceNetwork): void {
     this.edit((service) => {

--- a/packages/dockerCompose/test/unit/composeDeleteDns.test.ts
+++ b/packages/dockerCompose/test/unit/composeDeleteDns.test.ts
@@ -3,29 +3,29 @@ import { expect } from "chai";
 import { ComposeEditor } from "../../src/index.js";
 import { Compose } from "@dappnode/types";
 
-describe('ComposeServiceEditor', function() {
-  describe('removeDns()', function() {
-    it.only('should remove the dns field from the service', function() {
+describe("ComposeServiceEditor", function () {
+  describe("removeDns()", function () {
+    it("should remove the dns field from the service", function () {
       // Create a mock compose object
       const mockCompose: Compose = {
-        version: '3',
+        version: "3",
         services: {
           myservice: {
-            image: 'myimage',
-            dns: '8.8.8.8',
-            environment: [],
-          },
-        },
+            image: "myimage",
+            dns: "8.8.8.8",
+            environment: []
+          }
+        }
       };
 
       // Create a ComposeEditor instance with the mock compose
       const composeEditor = new ComposeEditor(mockCompose);
 
       // Get the service editor for 'myservice'
-      const serviceEditor = composeEditor.services()['myservice'];
+      const serviceEditor = composeEditor.services()["myservice"];
 
       // Ensure dns field is present before removal
-      expect(serviceEditor.get().dns).to.deep.equal('8.8.8.8');
+      expect(serviceEditor.get().dns).to.deep.equal("8.8.8.8");
 
       // Call removeDns()
       serviceEditor.removeDns();
@@ -38,10 +38,10 @@ describe('ComposeServiceEditor', function() {
 
       // Output the compose and check that dns is not present
       const outputCompose = composeEditor.output();
-      expect(outputCompose.services['myservice'].dns).to.be.undefined;
+      expect(outputCompose.services["myservice"].dns).to.be.undefined;
 
       // Ensure other fields remain unchanged
-      expect(outputCompose.services['myservice'].image).to.equal('myimage');
+      expect(outputCompose.services["myservice"].image).to.equal("myimage");
     });
   });
 });

--- a/packages/dockerCompose/test/unit/composeDeleteDns.test.ts
+++ b/packages/dockerCompose/test/unit/composeDeleteDns.test.ts
@@ -1,0 +1,47 @@
+import "mocha";
+import { expect } from "chai";
+import { ComposeEditor } from "../../src/index.js";
+import { Compose } from "@dappnode/types";
+
+describe('ComposeServiceEditor', function() {
+  describe('removeDns()', function() {
+    it.only('should remove the dns field from the service', function() {
+      // Create a mock compose object
+      const mockCompose: Compose = {
+        version: '3',
+        services: {
+          myservice: {
+            image: 'myimage',
+            dns: '8.8.8.8',
+            environment: [],
+          },
+        },
+      };
+
+      // Create a ComposeEditor instance with the mock compose
+      const composeEditor = new ComposeEditor(mockCompose);
+
+      // Get the service editor for 'myservice'
+      const serviceEditor = composeEditor.services()['myservice'];
+
+      // Ensure dns field is present before removal
+      expect(serviceEditor.get().dns).to.deep.equal('8.8.8.8');
+
+      // Call removeDns()
+      serviceEditor.removeDns();
+
+      // Get the updated service
+      const updatedService = serviceEditor.get();
+
+      // Verify that the dns field is removed
+      expect(updatedService.dns).to.be.undefined;
+
+      // Output the compose and check that dns is not present
+      const outputCompose = composeEditor.output();
+      expect(outputCompose.services['myservice'].dns).to.be.undefined;
+
+      // Ensure other fields remain unchanged
+      expect(outputCompose.services['myservice'].image).to.equal('myimage');
+    });
+  });
+});


### PR DESCRIPTION
The current `edit()` method merges the original service object with the partial updates returned by `serviceEditor(service)`. Merging { ...service, ...updatedFields } doesn't remove properties from service unless they are explicitly overwritten. Properties that aren't included in updatedFields remain in the merged object.

```
private edit(serviceEditor: (service: ComposeService) => Partial<ComposeService>): void {
    const service = this.parent.compose.services[this.serviceName];
    this.parent.compose.services[this.serviceName] = {
      ...service,
      ...serviceEditor(service)
    };
}
```

This is why this implementation of removeDns() doesnt work
```
removeDns(): void {
    this.edit((service) => {
      if (!service.dns) return service;
      // eslint-disable-next-line @typescript-eslint/no-unused-vars
      const { dns, ...rest } = service;
      return rest;
    });
  }
```

and this one (that deletes the dns directly without passing through `edit()`) does:
```
  removeDns(): void {
    const service = this.get();
    if ('dns' in service) {
      delete service.dns;
    }
}  
```

