### PR TITLE
Update index.ts

### DIFF
--- a/packages/installer/src/dappGet/aggregate/index.ts
+++ b/packages/installer/src/dappGet/aggregate/index.ts
@@ -102,7 +102,7 @@ export default async function aggregate({
           await aggregateDependencies({
             dappnodeInstaller,
             name: dnpName,
-            versionRange: `>=${version}`,
+            versionRange: `*`,
             dnps,
             dappGetFetcher // #### Injected dependency
           });


### PR DESCRIPTION
WIP
 
Goal of this PR is to make dappmanager try to fetch only latest published version of a package that is in the `optionalDependencies` instead of trying to fetch all releases that pass the optional dependencies check.

For example, if optional deps is mevboost > 0.1.6, and mevboost has 0.1.6, 0.2.0 and 0.3.0:
- Currently dappmanages tries to fetch content of 0.1.6, 0.2.0 and 0.3.0.
- Goal: try to fetch only 0.3.0