### PR TITLE
Remove validator and beacon-chain fullnode alises

### DIFF
--- a/packages/stakers/src/consensus.ts
+++ b/packages/stakers/src/consensus.ts
@@ -102,7 +102,7 @@ export class Consensus extends StakerComponent {
     await super.setNew({
       newStakerDnpName: newConsensusDnpName,
       dockerNetworkName: params.DOCKER_STAKER_NETWORKS[network],
-      fullnodeAlias: `consensus.${network}.dncore.dappnode`,
+      fullnodeAliases: [`beacon-chain.${network}.dncore.dappnode`, `validator.${network}.dncore.dappnode`],
       compatibleClients: Consensus.CompatibleConsensus[network],
       userSettings,
       prevClient: prevConsClientDnpName

--- a/packages/stakers/src/execution.ts
+++ b/packages/stakers/src/execution.ts
@@ -97,7 +97,7 @@ export class Execution extends StakerComponent {
     await super.setNew({
       newStakerDnpName: newExecutionDnpName,
       dockerNetworkName: params.DOCKER_STAKER_NETWORKS[network],
-      fullnodeAlias: `execution.${network}.dncore.dappnode`,
+      fullnodeAliases: [`execution.${network}.dncore.dappnode`],
       compatibleClients: Execution.CompatibleExecutions[network],
       userSettings: await this.getUserSettings(network, newExecutionDnpName),
       prevClient: prevExecClientDnpName

--- a/packages/stakers/src/mevBoost.ts
+++ b/packages/stakers/src/mevBoost.ts
@@ -84,7 +84,7 @@ export class MevBoost extends StakerComponent {
     await super.setNew({
       newStakerDnpName: newMevBoostDnpName,
       dockerNetworkName: params.DOCKER_STAKER_NETWORKS[network],
-      fullnodeAlias: `mev-boost.${network}.dncore.dappnode`,
+      fullnodeAliases: [`mev-boost.${network}.dncore.dappnode`],
       compatibleClients: compatibleMevBoost ? [compatibleMevBoost] : null,
       userSettings: newMevBoostDnpName ? this.getUserSettings(network, newRelays) : {},
       prevClient: compatibleMevBoost ? compatibleMevBoost.dnpName : null

--- a/packages/stakers/src/signer.ts
+++ b/packages/stakers/src/signer.ts
@@ -67,7 +67,7 @@ export class Signer extends StakerComponent {
     await super.setNew({
       newStakerDnpName: newWeb3signerDnpName,
       dockerNetworkName: params.DOCKER_STAKER_NETWORKS[network],
-      fullnodeAlias: `signer.${network}.dncore.dappnode`,
+      fullnodeAliases: [`signer.${network}.dncore.dappnode`],
       compatibleClients: [Signer.CompatibleSigners[network]],
       userSettings: this.getUserSettings(network),
       prevClient: Signer.CompatibleSigners[network].dnpName


### PR DESCRIPTION
Remove validator and beacon fullnode alises from the `dncore_network` when unsetting the staker configuration.