### PR TITLE
Make sure compose write is called after applying user settings

### DIFF
--- a/packages/stakers/src/stakerComponent.ts
+++ b/packages/stakers/src/stakerComponent.ts
@@ -157,11 +157,12 @@ export class StakerComponent {
 
       composeEditor.applyUserSettings(userSettings, { dnpName });
       const newSettings = composeEditor.getUserSettings();
+      // it must be called write after applying user settings otherwise the new settings will be lost and therefore the compose up will not have effect
+      composeEditor.write();
 
       // TODO: remove nimbus condition once nimbus published with multi-service
       // isMatch returns true when migrating from single-service to multi-service in the nimbus package
       if (!isMatch(previousSettings, newSettings) || dnpName.includes("nimbus")) {
-        composeEditor.write();
         forceRecreate = true;
         logs.info(`Settings for ${dnpName} have changed. Forcing recreation of containers.`);
       }


### PR DESCRIPTION
Make sure compose write is called after applying user settings, otherwise these new settings will be lost and the `compose up` action will not take effect since there are no changes detected in the compose file