### PR TITLE
Ensure all promisses are settled when persisting staker configuration per network

### DIFF
--- a/packages/migrations/src/createStakerNetworkAndConnectStakerPkgs.ts
+++ b/packages/migrations/src/createStakerNetworkAndConnectStakerPkgs.ts
@@ -15,12 +15,15 @@ export async function createStakerNetworkAndConnectStakerPkgs(
 ): Promise<void> {
   for (const network of Object.values(Network)) {
     await createDockerStakerNetwork(params.DOCKER_STAKER_NETWORKS[network]);
-    await Promise.all([
+    const results = await Promise.allSettled([
       await execution.persistSelectedExecutionIfInstalled(network),
       await consensus.persistSelectedConsensusIfInstalled(network),
       await signer.persistSignerIfInstalledAndRunning(network),
       await mevBoost.persistMevBoostIfInstalledAndRunning(network)
     ]);
+
+    const errors = results.filter((result) => result.status === "rejected").map((result) => result.reason);
+    logs.error(`Errors while connecting staker packages to the network ${network}`, errors);
   }
 }
 


### PR DESCRIPTION
Ensure all promisses are settled when persisting staker configuration per network. Its a more robust solution to persist staking configuration when at least one of them can fail
