### PR TITLE
Implement has fullnode alias property in backend

### DIFF
--- a/packages/stakers/src/signer.ts
+++ b/packages/stakers/src/signer.ts
@@ -11,7 +11,7 @@ import {
 import { StakerComponent } from "./stakerComponent.js";
 import { DappnodeInstaller } from "@dappnode/installer";
 import { params } from "@dappnode/params";
-import { listPackageNoThrow } from "@dappnode/dockerapi";
+import { listPackageNoThrow, listPackages } from "@dappnode/dockerapi";
 
 export class Signer extends StakerComponent {
   protected static readonly ServiceAliasesMap: Record<string, string[]> = {};
@@ -44,10 +44,16 @@ export class Signer extends StakerComponent {
   }
 
   async getAllSigners(network: Network): Promise<StakerItem[]> {
-    return await super.getAll({
-      dnpNames: [Signer.CompatibleSigners[network].dnpName],
-      currentClient: Signer.CompatibleSigners[network].dnpName
-    });
+    return await Promise.all(
+      [Signer.CompatibleSigners[network].dnpName].map(async (dnpName) =>
+        super.getStakerPkg({
+          dnpName,
+          dnpList: await listPackages(),
+          userSettings: this.getUserSettings(network),
+          currentClient: Signer.CompatibleSigners[network].dnpName
+        })
+      )
+    );
   }
 
   async persistSignerIfInstalledAndRunning(network: Network): Promise<void> {

--- a/packages/types/src/stakers.ts
+++ b/packages/types/src/stakers.ts
@@ -141,6 +141,7 @@ export type StakerItemOk = {
   isRunning: boolean;
   data?: PackageItemData;
   isSelected: boolean;
+  hasFullnodeAlias: boolean;
 } & StakerItemBasic;
 
 export interface StakerConfigGet {


### PR DESCRIPTION
Implement has fullnode alias property in backend. This property defines weather a selected staker component (execution, consensus, signer or mevboost) contains the desired network properties to work properly, this is:
- containing the unique alias in the `dncore_network`
- containing the unique alias in the stakers network: `<network>_network`