### PR TITLE
Collapsable `PackageUpdatesCards`

### DIFF
--- a/packages/admin-ui/src/pages/dashboard/components/PackageUpdates.tsx
+++ b/packages/admin-ui/src/pages/dashboard/components/PackageUpdates.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import Alert from "react-bootstrap/esm/Alert";
 import { useApi } from "api";
 import { getInstallerPath } from "pages/installer";
@@ -9,24 +9,27 @@ import ErrorView from "components/ErrorView";
 import Ok from "components/Ok";
 import CardList from "components/CardList";
 import { prettyDnpName } from "utils/format";
+import { Accordion } from "react-bootstrap";
+import { IoIosArrowDown, IoIosArrowUp } from "react-icons/io";
+interface UpdatesInterface extends UpdateAvailable {
+  dnpName: string;
+}
 
 export function PackageUpdates() {
   const dnps = useApi.packagesGet();
-  const navigate = useNavigate();
 
   if (dnps.error) return <ErrorView error={dnps.error} hideIcon red />;
   if (dnps.isValidating) return <Ok loading msg="Loading packages" />;
   if (!dnps.data) return <ErrorView error={"No data"} hideIcon red />;
 
-  const updatesAvailable: {
-    dnpName: string;
-    updateAvailable: UpdateAvailable;
-  }[] = [];
+  const updatesAvailable: UpdatesInterface[] = [];
   for (const dnp of dnps.data) {
     if (dnp.updateAvailable) {
+      const upstreamVersions = dnp.updateAvailable.upstreamVersion?.toString().split(",");
       updatesAvailable.push({
         dnpName: dnp.dnpName,
-        updateAvailable: dnp.updateAvailable
+        newVersion: dnp.updateAvailable.newVersion,
+        upstreamVersion: upstreamVersions
       });
     }
   }
@@ -39,21 +42,54 @@ export function PackageUpdates() {
             All packages are up to date
           </Alert>
         ) : (
-          <CardList className="package-updates">
-            {updatesAvailable.map(({ dnpName, updateAvailable }) => (
-              <div className="package-update-item">
-                <span>
-                  <strong>{prettyDnpName(dnpName)}</strong> to version {updateAvailable.newVersion}{" "}
-                  {updateAvailable.upstreamVersion && `(${updateAvailable.upstreamVersion} upstream)`}
-                </span>
-
-                <Button onClick={() => navigate(`${getInstallerPath(dnpName)}/${dnpName}`)} variant="dappnode">
-                  Update
-                </Button>
-              </div>
+          <>
+            {updatesAvailable.map((update) => (
+              <>
+                <CardList className="package-updates">
+                  <UpdateCard key={update.dnpName} update={update} />
+                </CardList>
+              </>
             ))}
-          </CardList>
+          </>
         )}
+      </div>
+    </div>
+  );
+}
+
+function UpdateCard({ update }: { update: UpdatesInterface }) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const navigate = useNavigate();
+
+  return (
+    <div className="package-update-item">
+      <Accordion defaultActiveKey={isOpen ? "0" : "1"}>
+        <Accordion.Toggle
+          as={"div"}
+          eventKey="0"
+          onClick={() => setIsOpen(!isOpen)}
+          style={{ cursor: "pointer", minWidth: "max-content" }}
+        >
+          {isOpen ? <IoIosArrowUp /> : <IoIosArrowDown />} <strong>{prettyDnpName(update.dnpName)}</strong> to version{" "}
+          {update.newVersion}
+          <Accordion.Collapse eventKey="0">
+            <div>
+              {Array.isArray(update.upstreamVersion) && update.upstreamVersion.length > 0 && (
+                <ul className="package-update-details">
+                  {update.upstreamVersion.map((upstreamVersion) => (
+                    <li>{upstreamVersion}</li>
+                  ))}{" "}
+                </ul>
+              )}
+            </div>
+          </Accordion.Collapse>
+        </Accordion.Toggle>{" "}
+      </Accordion>
+      <div className="package-update-actions">
+        <Button onClick={() => navigate(`${getInstallerPath(update.dnpName)}/${update.dnpName}`)} variant="dappnode">
+          Update
+        </Button>
       </div>
     </div>
   );

--- a/packages/admin-ui/src/pages/dashboard/components/PackageUpdates.tsx
+++ b/packages/admin-ui/src/pages/dashboard/components/PackageUpdates.tsx
@@ -64,15 +64,12 @@ function UpdateCard({ update }: { update: UpdatesInterface }) {
 
   return (
     <div className="package-update-item">
-      <Accordion defaultActiveKey={isOpen ? "0" : "1"}>
-        <Accordion.Toggle
-          as={"div"}
-          eventKey="0"
-          onClick={() => setIsOpen(!isOpen)}
-          style={{ cursor: "pointer", minWidth: "max-content" }}
-        >
-          {isOpen ? <IoIosArrowUp /> : <IoIosArrowDown />} <strong>{prettyDnpName(update.dnpName)}</strong> to version{" "}
-          {update.newVersion}
+      <Accordion defaultActiveKey={isOpen ? "0" : "1"} className="package-update-accordion">
+        <Accordion.Toggle as={"div"} eventKey="0" onClick={() => setIsOpen(!isOpen)}>
+          <div>
+            <strong>{prettyDnpName(update.dnpName)}</strong> v{update.newVersion}
+            {isOpen ? <IoIosArrowUp /> : <IoIosArrowDown />}
+          </div>
           <Accordion.Collapse eventKey="0">
             <div>
               {Array.isArray(update.upstreamVersion) && update.upstreamVersion.length > 0 && (

--- a/packages/admin-ui/src/pages/dashboard/components/dashboard.scss
+++ b/packages/admin-ui/src/pages/dashboard/components/dashboard.scss
@@ -92,7 +92,17 @@
 .package-update-item {
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: stretch;
+  height: 100%;
+
+  .package-update-accordion {
+    min-width: max-content;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: flex-start;
+    cursor: pointer;
+  }
 
   .package-update-details {
     margin: 0;
@@ -103,22 +113,27 @@
   }
 
   .package-update-actions {
-    width: 100%;
+    align-self: stretch;
     display: flex;
-    justify-content: flex-end;
+    align-items: flex-start;
   }
 
   @media screen and (max-width: 80rem) {
     flex-direction: column;
     align-items: start;
     justify-content: start;
-    gap: 5px;
+    gap: 10px;
 
     .package-update-details {
       padding-left: 1rem;
       > li {
         font-size: 0.7rem;
       }
+    }
+    .package-update-actions {
+      flex-direction: row;
+      justify-content: flex-end;
+      align-items: flex-start;
     }
   }
 }

--- a/packages/admin-ui/src/pages/dashboard/components/dashboard.scss
+++ b/packages/admin-ui/src/pages/dashboard/components/dashboard.scss
@@ -107,9 +107,6 @@
   .package-update-details {
     margin: 0;
     width: 100%;
-    > li {
-      color: var(--color-dark-secondarytext);
-    }
   }
 
   .package-update-actions {

--- a/packages/admin-ui/src/pages/dashboard/components/dashboard.scss
+++ b/packages/admin-ui/src/pages/dashboard/components/dashboard.scss
@@ -28,8 +28,10 @@
   }
 
   .package-updates {
-    // Give the single card a max width that matches the other cards
-    grid-column: 1 / 4;
+    @media screen and (min-width: 65rem) {
+      // Give the single card a max width that matches the other cards
+      grid-column: 1 / 4;
+    }
   }
 }
 
@@ -92,9 +94,37 @@
   justify-content: space-between;
   align-items: center;
 
-  // Make buttons smaller so the list is not that big
-  button {
-    padding: 3px 12px;
-    font-size: 94%;
+  .package-update-details {
+    margin: 0;
+    width: 100%;
+    > li {
+      color: var(--color-dark-secondarytext);
+    }
   }
+
+  .package-update-actions {
+    width: 100%;
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  @media screen and (max-width: 80rem) {
+    flex-direction: column;
+    align-items: start;
+    justify-content: start;
+    gap: 5px;
+
+    .package-update-details {
+      padding-left: 1rem;
+      > li {
+        font-size: 0.7rem;
+      }
+    }
+  }
+}
+
+// Make buttons smaller so the list is not that big
+button {
+  padding: 3px 12px;
+  font-size: 94%;
 }


### PR DESCRIPTION
Improved the `PackageUpdates` cards in `/dashboard` by placing all upstream versions inside a collapsable section for better readability. Also included fixes for mobile responsiveness.