### PR TITLE
Topbar's dropdowns mobile fix

### DIFF
--- a/packages/admin-ui/src/components/topbar/dropdownMenus/dropdown.scss
+++ b/packages/admin-ui/src/components/topbar/dropdownMenus/dropdown.scss
@@ -40,10 +40,9 @@
     &.show {
       display: block;
     }
-
-    /* 22 * 90% = 19.8 (the min-width specified above) */
-    @media (max-width: 25rem) {
-      width: 90vw;
+    
+    @media (max-width: 40rem) {
+      width: 15rem;
     }
 
     /* Menu items */


### PR DESCRIPTION
Fixing the Topbar dropdowns in mobile view, reducing excessive width for better usability.