### PR TITLE
Hidden network descriptions on mobile view

### DIFF
--- a/packages/admin-ui/src/pages/stakers/components/StakerNetwork.tsx
+++ b/packages/admin-ui/src/pages/stakers/components/StakerNetwork.tsx
@@ -17,7 +17,7 @@ import { disclaimer } from "../data";
 import Loading from "components/Loading";
 import { responseInterface } from "swr";
 import { Alert } from "react-bootstrap";
-import "./columns.scss";
+import "./stakers.scss";
 import { AppContext } from "App";
 import { Network } from "@dappnode/types";
 import { useStakerConfig } from "./useStakerConfig";
@@ -160,9 +160,7 @@ export default function StakerNetwork({ network, description }: { network: Netwo
                 </>
               )}
             </p>
-            <br />
-
-            <p>{description}</p>
+            <p className="network-description">{description}</p>
 
             <Row className="staker-network">
               <Col>

--- a/packages/admin-ui/src/pages/stakers/components/stakers.scss
+++ b/packages/admin-ui/src/pages/stakers/components/stakers.scss
@@ -102,3 +102,10 @@
   color: var(--dappnode-color) !important;
   vertical-align: sub;
 }
+
+// Hide network description in mobile view
+.network-description {
+  @media (max-width: 40rem) {
+    display: none;
+  }
+}


### PR DESCRIPTION
Since network descriptions are long and can take up most of the screen in mobile view, they are now hidden on mobile. However, they should be reviewed and rewritten if necessary.