### PR TITLE
Hide title labels in `/package/info` mobile view

### DIFF
--- a/packages/admin-ui/src/pages/packages/components/Info/ContainerList.tsx
+++ b/packages/admin-ui/src/pages/packages/components/Info/ContainerList.tsx
@@ -43,10 +43,10 @@ export const ContainerList = ({ dnp }: { dnp: InstalledPackageData }) => {
   return (
     <div className="info-container-list">
       <div className="list-grid containers">
-        <header className="center">Status</header>
-        <header></header>
-        <header className="center">Pause</header>
-        <header className="center">Restart</header>
+        <header className="title-label">Status</header>
+        <header className="title-label"></header>
+        <header className="title-label">Pause</header>
+        <header className="title-label">Restart</header>
 
         {/* DNP entry */}
         <React.Fragment>

--- a/packages/admin-ui/src/pages/packages/components/Info/VolumesList.tsx
+++ b/packages/admin-ui/src/pages/packages/components/Info/VolumesList.tsx
@@ -77,9 +77,9 @@ export const VolumesList = ({ dnp }: { dnp: InstalledPackageDetailData }) => {
 
   return (
     <div className="list-grid container-volumes">
-      <header>Volume</header>
-      <header className="center">Size</header>
-      <header className="center">Remove</header>
+      <header className="title-label">Volume</header>
+      <header className="title-label">Size</header>
+      <header className="title-label">Remove</header>
 
       {/* All containers entry */}
       <React.Fragment>

--- a/packages/admin-ui/src/pages/packages/components/Info/containerList.scss
+++ b/packages/admin-ui/src/pages/packages/components/Info/containerList.scss
@@ -47,4 +47,11 @@
       text-align: right;
     }
   }
+
+  // Hide title labels in mobile view
+  .title-label {
+    @media (max-width: 40rem) {
+      display: none;
+    }
+  }
 }

--- a/packages/admin-ui/src/pages/packages/components/Info/volumesList.scss
+++ b/packages/admin-ui/src/pages/packages/components/Info/volumesList.scss
@@ -19,4 +19,11 @@
   .trash-icon {
     font-size: 0.8rem;
   }
+
+  // Hide title labels in mobile view
+  .title-label {
+    @media (max-width: 40rem) {
+      display: none;
+    }
+  }
 }


### PR DESCRIPTION
Hid "title-labels" in `/package/info` in mobile view as they were not displaying correctly due to reduced screen width.