### PR TITLE
Packages tab mobile fixes

### DIFF
--- a/packages/admin-ui/src/dappnode_styles.scss
+++ b/packages/admin-ui/src/dappnode_styles.scss
@@ -126,7 +126,11 @@ p.no-p-style:last-child {
 */
 
 .list-grid {
-  --icon-size: 1.75em;
+  --icon-size: 1.75rem;
+  // Smaller icons for mobile
+  @media (max-width: 40rem) {
+    --icon-size: 1.25rem;
+  } 
   --grid-spacing: 1rem;
   display: grid;
   /* Specify a custom grid-template-columns:  */
@@ -194,6 +198,11 @@ p.no-p-style:last-child {
   overflow: hidden;
   width: 100%;
   font-size: 0.9rem;
+
+  // Hide on mobile view
+  @media (max-width: 40rem) {
+    display: none;
+  }
 }
 
 /* Generic centered container */

--- a/packages/admin-ui/src/pages/packages/components/PackagesList.tsx
+++ b/packages/admin-ui/src/pages/packages/components/PackagesList.tsx
@@ -30,11 +30,11 @@ export const PackagesList = ({ coreDnps }: { coreDnps: boolean }) => {
         <StateBadgeLegend dnps={filteredDnps}></StateBadgeLegend>
 
         <div className="list-grid dnps no-a-style">
-          <header className="center">Status</header>
-          <header className="center"> </header>
+          <header>Status</header>
+          <header> </header>
           <header>Name</header>
           <header>Open</header>
-          <header className="hide-on-small">Restart</header>
+          <header>Restart</header>
           {sortBy(filteredDnps, (dnp) => dnp.dnpName).map((dnp) => (
             <React.Fragment key={dnp.dnpName}>
               {/* <StateBadge state={getWorstState(dnp)} /> */}

--- a/packages/admin-ui/src/pages/packages/components/StateBadge/stateBadge.scss
+++ b/packages/admin-ui/src/pages/packages/components/StateBadge/stateBadge.scss
@@ -13,7 +13,9 @@
   overflow: hidden;
 
   // Force a min-size so on a packages/:id view the badge on its own is not too small
-  min-width: 4.9rem;
+  @media (min-width: 40rem) {
+    min-width: 4.9rem;
+  }
 
   > span {
     width: 100%;

--- a/packages/admin-ui/src/pages/packages/components/packages.scss
+++ b/packages/admin-ui/src/pages/packages/components/packages.scss
@@ -25,7 +25,7 @@
 
   @media screen and (max-width: 40rem) {
     grid-template-columns:
-      1.65rem
+      1.5rem
       min-content
       minmax(5rem, auto)
       minmax(calc(var(--icon-size) / 2), min-content);
@@ -35,8 +35,8 @@
     }
 
     .state-badge {
-      height: 1.65rem;
-      border-radius: 1.65rem;
+      height: 1rem;
+      border-radius: 1rem;
       .content {
         display: none;
       }


### PR DESCRIPTION
Includes mobile view fixes for the `/packages` list tab:
- Hid "title-labels" as they were not displaying correctly due to reduced screen width.
- Smaller "status pill"
- Smaller icons