### PR TITLE
Mev Boost table style updated

### DIFF
--- a/packages/admin-ui/src/pages/stakers/components/columns.scss
+++ b/packages/admin-ui/src/pages/stakers/components/columns.scss
@@ -79,8 +79,7 @@
       color: var(--dappnode-color);
     }
   }
-  transition: color 0.15s, background-color 0.15s, border-color 0.15s,
-    box-shadow 0.15s;
+  transition: color 0.15s, background-color 0.15s, border-color 0.15s, box-shadow 0.15s;
 
   .avatar {
     --avatar-size: 6rem;
@@ -88,6 +87,12 @@
     margin: auto;
     height: var(--avatar-size);
     width: var(--avatar-size);
+  }
+
+  @media (max-width: 40rem) {
+    .hide-on-small {
+      display: none;
+    }
   }
 }
 
@@ -97,4 +102,3 @@
   color: var(--dappnode-color) !important;
   vertical-align: sub;
 }
-

--- a/packages/admin-ui/src/pages/stakers/components/columns/MevBoost.tsx
+++ b/packages/admin-ui/src/pages/stakers/components/columns/MevBoost.tsx
@@ -98,13 +98,13 @@ function RelaysList({
   const defaultRelays = getDefaultRelays(network);
   if (defaultRelays.length > 0)
     return (
-      <Table striped bordered hover size="sm">
+      <Table striped hover size="sm">
         <thead>
           <tr>
             <th>Relay</th>
             <th>
               OFAC
-              <a href="https://www.mevwatch.info/" target="_blank" rel="noopener noreferrer">
+              <a href="https://www.mevwatch.info/" target="_blank" rel="noopener noreferrer" className="hide-on-small">
                 <AiFillInfoCircle />
               </a>
             </th>


### PR DESCRIPTION
Updated the MevBoost table style and hid the OFAC link in mobile view in `/stakers`.

![image](https://github.com/user-attachments/assets/7bd6e01a-3327-4304-860a-90ca8dce250f)
