### PR TITLE
Add  `notifications/settings` subpath

### DIFF
--- a/packages/admin-ui/src/components/Slider.tsx
+++ b/packages/admin-ui/src/components/Slider.tsx
@@ -1,0 +1,57 @@
+import React, { useState } from "react";
+import "./slider.scss";
+
+interface SliderProps {
+  min?: number;
+  max?: number;
+  step?: number;
+  value?: number;
+  unit?: string;
+  onChange?: (value: number) => void;
+  onChangeComplete?: (value: number) => void;
+}
+
+const Slider: React.FC<SliderProps> = ({
+  min = 0,
+  max = 100,
+  step = 1,
+  value = 50,
+  unit = "%",
+  onChange,
+  onChangeComplete, // In order to trigger an action when the user releases the slider
+}) => {
+  const [sliderValue, setSliderValue] = useState(value);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = Number(e.target.value);
+    setSliderValue(newValue);
+    if (onChange) onChange(newValue);
+  };
+
+  const handleMouseUp = () => {
+    if (onChangeComplete) onChangeComplete(sliderValue);
+  };
+
+  const handleTouchEnd = () => {
+    if (onChangeComplete) onChangeComplete(sliderValue);
+  };
+
+  return (
+    <div className="slider-container">
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={sliderValue}
+        onChange={handleChange}
+        onMouseUp={handleMouseUp} // For mouse support
+        onTouchEnd={handleTouchEnd} // For mobile support
+        className="slider-component"
+      />
+      <span className="slider-value">{sliderValue} {unit && unit}</span>
+    </div>
+  );
+};
+
+export default Slider;

--- a/packages/admin-ui/src/components/slider.scss
+++ b/packages/admin-ui/src/components/slider.scss
@@ -1,0 +1,40 @@
+.slider-container {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+  }
+  
+  .slider-component {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 100%;
+    height: 4px;
+    background: #c0c0c0;
+    border-radius: 2px;
+      
+    &::-webkit-slider-thumb {
+      -webkit-appearance: none;
+      appearance: none;
+      width: 16px;
+      height: 16px;
+      background: var(--dappnode-color);
+      border-radius: 50%;
+      cursor: pointer;
+    }
+  
+    &::-moz-range-thumb {
+      width: 16px;
+      height: 16px;
+      background: var(--dappnode-color);
+      border-radius: 50%;
+      cursor: pointer;
+    }
+  }
+  
+  .slider-value {
+    color: #c0c0c0;
+    font-weight: bold;
+    min-width: fit-content;
+  }
+  

--- a/packages/admin-ui/src/pages/notifications/NotificationsRoot.tsx
+++ b/packages/admin-ui/src/pages/notifications/NotificationsRoot.tsx
@@ -8,6 +8,7 @@ import { InstallNotificationsPkg } from "./tabs/InstallNotifications/InstallNoti
 import Title from "components/Title";
 import { renderResponse } from "components/SwrRender";
 import { Inbox } from "./tabs/Inbox/Inbox";
+import { NotificationsSettings } from "./tabs/Settings/Settings";
 
 export const NotificationsRoot: React.FC = () => {
   const availableRoutes: {
@@ -20,6 +21,11 @@ export const NotificationsRoot: React.FC = () => {
       name: "Inbox",
       subPath: subPaths.inbox,
       component: Inbox
+    },
+    {
+      name: "Settings",
+      subPath: subPaths.settings,
+      component: NotificationsSettings
     }
   ];
 

--- a/packages/admin-ui/src/pages/notifications/data.ts
+++ b/packages/admin-ui/src/pages/notifications/data.ts
@@ -6,5 +6,6 @@ export const title = "Notifications";
 
 // SubPaths
 export const subPaths = {
-  inbox: "inbox"
+  inbox: "inbox",
+  settings: "settings"
 };

--- a/packages/admin-ui/src/pages/notifications/tabs/Settings/CustomEndpointItem.tsx
+++ b/packages/admin-ui/src/pages/notifications/tabs/Settings/CustomEndpointItem.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
 import { CustomEndpoint } from "@dappnode/types";
-import Switch from "components/Switch";
-import Slider from "components/Slider";
+import { EndpointItem } from "./EndpointItem";
 
 interface CustomEndpointItemProps {
   endpoint: CustomEndpoint;
@@ -25,45 +24,44 @@ export function CustomEndpointItem({ endpoint, index, numEndpoints, setCustomEnd
     setSliderValue(value);
   };
 
-    const handleSliderUpdateComplete = (value: number) => {
-      setCustomEndpoints((prevEndpoints) =>
-        prevEndpoints.map((ep, i) =>
-          i === index && ep.metric
-            ? {
-                ...ep,
-                metric: {
-                  ...ep.metric,
-                  treshold: value,
-                },
+  const handleSliderUpdateComplete = (value: number) => {
+    setCustomEndpoints((prevEndpoints) =>
+      prevEndpoints.map((ep, i) =>
+        i === index && ep.metric
+          ? {
+              ...ep,
+              metric: {
+                ...ep.metric,
+                treshold: value
               }
-            : ep
-        )
-      );
-    };
-    
+            }
+          : ep
+      )
+    );
+  };
 
   return (
     <>
-      <div key={index} className="endpoint-row">
-        <div>
-          <strong>{endpoint.name}</strong>
-          <div>{endpoint.description}</div>
-        </div>
-        <Switch checked={endpointEnabled} onToggle={handleEndpointToggle} />
-      </div>
-      {endpointEnabled && endpoint.metric && (
-        <div className="slider-wrapper">
-          <Slider
-            value={sliderValue}
-            onChange={handleSliderUpdate}
-            onChangeComplete={handleSliderUpdateComplete}
-            min={endpoint.metric.min}
-            max={endpoint.metric.max}
-            unit={endpoint.metric.unit}
-          />
-        </div>
-      )}
-      {index + 1 < numEndpoints && <hr />}
+      <EndpointItem
+        index={index}
+        title={endpoint.name}
+        description={endpoint.description}
+        endpointEnabled={endpointEnabled}
+        handleEndpointToggle={handleEndpointToggle}
+        metric={
+          endpoint.metric
+            ? {
+                min: endpoint.metric.min,
+                max: endpoint.metric.max,
+                unit: endpoint.metric.unit,
+                sliderValue: sliderValue
+              }
+            : undefined
+        }
+        handleSliderUpdate={handleSliderUpdate}
+        handleSliderUpdateComplete={handleSliderUpdateComplete}
+        numEndpoints={numEndpoints}
+      />
     </>
   );
 }

--- a/packages/admin-ui/src/pages/notifications/tabs/Settings/CustomEndpointItem.tsx
+++ b/packages/admin-ui/src/pages/notifications/tabs/Settings/CustomEndpointItem.tsx
@@ -1,0 +1,69 @@
+import React, { useState } from "react";
+import { CustomEndpoint } from "@dappnode/types";
+import Switch from "components/Switch";
+import Slider from "components/Slider";
+
+interface CustomEndpointItemProps {
+  endpoint: CustomEndpoint;
+  index: number;
+  numEndpoints: number;
+  setCustomEndpoints: React.Dispatch<React.SetStateAction<CustomEndpoint[]>>;
+}
+
+export function CustomEndpointItem({ endpoint, index, numEndpoints, setCustomEndpoints }: CustomEndpointItemProps) {
+  const endpointEnabled = endpoint.enabled;
+
+  const [sliderValue, setSliderValue] = useState<number>(endpoint.metric?.treshold || 0);
+
+  const handleEndpointToggle = () => {
+    setCustomEndpoints((prevEndpoints) =>
+      prevEndpoints.map((ep, i) => (i === index ? { ...ep, enabled: !ep.enabled } : ep))
+    );
+  };
+
+  const handleSliderUpdate = (value: number) => {
+    setSliderValue(value);
+  };
+
+    const handleSliderUpdateComplete = (value: number) => {
+      setCustomEndpoints((prevEndpoints) =>
+        prevEndpoints.map((ep, i) =>
+          i === index && ep.metric
+            ? {
+                ...ep,
+                metric: {
+                  ...ep.metric,
+                  treshold: value,
+                },
+              }
+            : ep
+        )
+      );
+    };
+    
+
+  return (
+    <>
+      <div key={index} className="endpoint-row">
+        <div>
+          <strong>{endpoint.name}</strong>
+          <div>{endpoint.description}</div>
+        </div>
+        <Switch checked={endpointEnabled} onToggle={handleEndpointToggle} />
+      </div>
+      {endpointEnabled && endpoint.metric && (
+        <div className="slider-wrapper">
+          <Slider
+            value={sliderValue}
+            onChange={handleSliderUpdate}
+            onChangeComplete={handleSliderUpdateComplete}
+            min={endpoint.metric.min}
+            max={endpoint.metric.max}
+            unit={endpoint.metric.unit}
+          />
+        </div>
+      )}
+      {index + 1 < numEndpoints && <hr />}
+    </>
+  );
+}

--- a/packages/admin-ui/src/pages/notifications/tabs/Settings/EndpointItem.tsx
+++ b/packages/admin-ui/src/pages/notifications/tabs/Settings/EndpointItem.tsx
@@ -1,0 +1,84 @@
+import React, { useState } from "react";
+import { Endpoint } from "@dappnode/types";
+import Switch from "components/Switch";
+import Slider from "components/Slider";
+
+interface EndpointItemProps {
+  endpoint: Endpoint;
+  index: number;
+  numEndpoints: number;
+  setPkgEndpoints: React.Dispatch<React.SetStateAction<Endpoint[]>>;
+}
+
+export function EndpointItem({ endpoint, index, numEndpoints, setPkgEndpoints }: EndpointItemProps) {
+  const endpointEnabled = endpoint.enabled;
+
+  const operators = ["<", ">", "==", "!=", ">=", "<="];
+
+  // Extract the operator and number from the condition string from the 1ST CONDITION. Rn, is only supporting 1 slider (from 1st condition) per endpoint
+  const conditionString = endpoint.conditions[0];
+  const operator = operators.find((op) => conditionString.includes(op));
+  const conditionValue = operator
+    ? conditionString
+        .split(operator)
+        .pop()
+        ?.trim() || ""
+    : "0";
+
+  const [sliderValue, setSliderValue] = useState<number>(parseFloat(conditionValue));
+
+  const handleEndpointToggle = () => {
+    setPkgEndpoints((prevEndpoints) =>
+      prevEndpoints.map((ep, i) => (i === index ? { ...ep, enabled: !ep.enabled } : ep))
+    );
+  };
+
+  const handleSliderUpdate = (value: number) => {
+    setSliderValue(value);
+  };
+
+  const handleSliderUpdateComplete = (value: number) => {
+    const updatedCondition = operator
+      ? `${endpoint.conditions[0].split(operator)[0].trim()} ${operator} ${value}`
+      : endpoint.conditions[0];
+
+    setPkgEndpoints((prevEndpoints) =>
+      prevEndpoints.map((ep, i) =>
+        i === index
+          ? {
+              ...ep,
+              conditions: [
+                updatedCondition, // Update ONLY the first condition
+                ...ep.conditions.slice(1)
+              ]
+            }
+          : ep
+      )
+    );
+  };
+
+  return (
+    <>
+      <div key={index} className="endpoint-row">
+        <div>
+          <strong>{endpoint.definition.title}</strong>
+          <div>{endpoint.definition.description}</div>
+        </div>
+        <Switch checked={endpointEnabled} onToggle={handleEndpointToggle} />
+      </div>
+      {endpointEnabled && endpoint.metric && (
+        <div className="slider-wrapper">
+          <Slider
+            value={sliderValue}
+            onChange={handleSliderUpdate}
+            onChangeComplete={handleSliderUpdateComplete}
+            min={endpoint.metric.min}
+            max={endpoint.metric.max}
+            unit={endpoint.metric.unit}
+          />
+        </div>
+      )}
+      {index + 1 < numEndpoints && <hr />}
+    </>
+  );
+}

--- a/packages/admin-ui/src/pages/notifications/tabs/Settings/EndpointItem.tsx
+++ b/packages/admin-ui/src/pages/notifications/tabs/Settings/EndpointItem.tsx
@@ -6,16 +6,25 @@ interface EndpointItemProps {
   title: string;
   description: string;
   endpointEnabled: boolean;
-  metric: any;
+  metric?: { min: number; max: number; unit: string; sliderValue: number };
   index: number;
   numEndpoints: number;
-  sliderValue: number;
   handleEndpointToggle: () => void;
   handleSliderUpdate: (value: number) => void;
   handleSliderUpdateComplete: (value: number) => void;
 }
 
-export function EndpointItem({index, title, description, endpointEnabled, metric, numEndpoints, sliderValue, handleEndpointToggle, handleSliderUpdate, handleSliderUpdateComplete}: EndpointItemProps) {  
+export function EndpointItem({
+  index,
+  title,
+  description,
+  endpointEnabled,
+  metric,
+  numEndpoints,
+  handleEndpointToggle,
+  handleSliderUpdate,
+  handleSliderUpdateComplete
+}: EndpointItemProps) {
   return (
     <>
       <div key={index} className="endpoint-row">
@@ -28,7 +37,7 @@ export function EndpointItem({index, title, description, endpointEnabled, metric
       {endpointEnabled && metric && (
         <div className="slider-wrapper">
           <Slider
-            value={sliderValue}
+            value={metric.sliderValue}
             onChange={handleSliderUpdate}
             onChangeComplete={handleSliderUpdateComplete}
             min={metric.min}
@@ -40,6 +49,4 @@ export function EndpointItem({index, title, description, endpointEnabled, metric
       {index + 1 < numEndpoints && <hr />}
     </>
   );
-
-
 }

--- a/packages/admin-ui/src/pages/notifications/tabs/Settings/EndpointItem.tsx
+++ b/packages/admin-ui/src/pages/notifications/tabs/Settings/EndpointItem.tsx
@@ -1,84 +1,45 @@
-import React, { useState } from "react";
-import { Endpoint } from "@dappnode/types";
+import React from "react";
 import Switch from "components/Switch";
 import Slider from "components/Slider";
 
 interface EndpointItemProps {
-  endpoint: Endpoint;
+  title: string;
+  description: string;
+  endpointEnabled: boolean;
+  metric: any;
   index: number;
   numEndpoints: number;
-  setPkgEndpoints: React.Dispatch<React.SetStateAction<Endpoint[]>>;
+  sliderValue: number;
+  handleEndpointToggle: () => void;
+  handleSliderUpdate: (value: number) => void;
+  handleSliderUpdateComplete: (value: number) => void;
 }
 
-export function EndpointItem({ endpoint, index, numEndpoints, setPkgEndpoints }: EndpointItemProps) {
-  const endpointEnabled = endpoint.enabled;
-
-  const operators = ["<", ">", "==", "!=", ">=", "<="];
-
-  // Extract the operator and number from the condition string from the 1ST CONDITION. Rn, is only supporting 1 slider (from 1st condition) per endpoint
-  const conditionString = endpoint.conditions[0];
-  const operator = operators.find((op) => conditionString.includes(op));
-  const conditionValue = operator
-    ? conditionString
-        .split(operator)
-        .pop()
-        ?.trim() || ""
-    : "0";
-
-  const [sliderValue, setSliderValue] = useState<number>(parseFloat(conditionValue));
-
-  const handleEndpointToggle = () => {
-    setPkgEndpoints((prevEndpoints) =>
-      prevEndpoints.map((ep, i) => (i === index ? { ...ep, enabled: !ep.enabled } : ep))
-    );
-  };
-
-  const handleSliderUpdate = (value: number) => {
-    setSliderValue(value);
-  };
-
-  const handleSliderUpdateComplete = (value: number) => {
-    const updatedCondition = operator
-      ? `${endpoint.conditions[0].split(operator)[0].trim()} ${operator} ${value}`
-      : endpoint.conditions[0];
-
-    setPkgEndpoints((prevEndpoints) =>
-      prevEndpoints.map((ep, i) =>
-        i === index
-          ? {
-              ...ep,
-              conditions: [
-                updatedCondition, // Update ONLY the first condition
-                ...ep.conditions.slice(1)
-              ]
-            }
-          : ep
-      )
-    );
-  };
-
+export function EndpointItem({index, title, description, endpointEnabled, metric, numEndpoints, sliderValue, handleEndpointToggle, handleSliderUpdate, handleSliderUpdateComplete}: EndpointItemProps) {  
   return (
     <>
       <div key={index} className="endpoint-row">
         <div>
-          <strong>{endpoint.definition.title}</strong>
-          <div>{endpoint.definition.description}</div>
+          <strong>{title}</strong>
+          <div>{description}</div>
         </div>
         <Switch checked={endpointEnabled} onToggle={handleEndpointToggle} />
       </div>
-      {endpointEnabled && endpoint.metric && (
+      {endpointEnabled && metric && (
         <div className="slider-wrapper">
           <Slider
             value={sliderValue}
             onChange={handleSliderUpdate}
             onChangeComplete={handleSliderUpdateComplete}
-            min={endpoint.metric.min}
-            max={endpoint.metric.max}
-            unit={endpoint.metric.unit}
+            min={metric.min}
+            max={metric.max}
+            unit={metric.unit}
           />
         </div>
       )}
       {index + 1 < numEndpoints && <hr />}
     </>
   );
+
+
 }

--- a/packages/admin-ui/src/pages/notifications/tabs/Settings/GatusEndpointItem.tsx
+++ b/packages/admin-ui/src/pages/notifications/tabs/Settings/GatusEndpointItem.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
 import { GatusEndpoint } from "@dappnode/types";
-import Switch from "components/Switch";
-import Slider from "components/Slider";
+import { EndpointItem } from "./EndpointItem";
 
 interface GatusEndpointItemProps {
   endpoint: GatusEndpoint;
@@ -59,26 +58,26 @@ export function GatusEndpointItem({ endpoint, index, numEndpoints, setGatusEndpo
 
   return (
     <>
-      <div key={index} className="endpoint-row">
-        <div>
-          <strong>{endpoint.definition.title}</strong>
-          <div>{endpoint.definition.description}</div>
-        </div>
-        <Switch checked={endpointEnabled} onToggle={handleEndpointToggle} />
-      </div>
-      {endpointEnabled && endpoint.metric && (
-        <div className="slider-wrapper">
-          <Slider
-            value={sliderValue}
-            onChange={handleSliderUpdate}
-            onChangeComplete={handleSliderUpdateComplete}
-            min={endpoint.metric.min}
-            max={endpoint.metric.max}
-            unit={endpoint.metric.unit}
-          />
-        </div>
-      )}
-      {index + 1 < numEndpoints && <hr />}
+      <EndpointItem
+        index={index}
+        title={endpoint.definition.title}
+        description={endpoint.definition.description}
+        endpointEnabled={endpointEnabled}
+        handleEndpointToggle={handleEndpointToggle}
+        metric={
+          endpoint.metric
+            ? {
+                min: endpoint.metric.min,
+                max: endpoint.metric.max,
+                unit: endpoint.metric.unit,
+                sliderValue: sliderValue
+              }
+            : undefined
+        }
+        handleSliderUpdate={handleSliderUpdate}
+        handleSliderUpdateComplete={handleSliderUpdateComplete}
+        numEndpoints={numEndpoints}
+      />
     </>
   );
 }

--- a/packages/admin-ui/src/pages/notifications/tabs/Settings/GatusEndpointItem.tsx
+++ b/packages/admin-ui/src/pages/notifications/tabs/Settings/GatusEndpointItem.tsx
@@ -1,0 +1,84 @@
+import React, { useState } from "react";
+import { GatusEndpoint } from "@dappnode/types";
+import Switch from "components/Switch";
+import Slider from "components/Slider";
+
+interface GatusEndpointItemProps {
+  endpoint: GatusEndpoint;
+  index: number;
+  numEndpoints: number;
+  setGatusEndpoints: React.Dispatch<React.SetStateAction<GatusEndpoint[]>>;
+}
+
+export function GatusEndpointItem({ endpoint, index, numEndpoints, setGatusEndpoints }: GatusEndpointItemProps) {
+  const endpointEnabled = endpoint.enabled;
+
+  const operators = ["<", ">", "==", "!=", ">=", "<="];
+
+  // Extract the operator and number from the condition string from the 1ST CONDITION. Rn, is only supporting 1 slider (from 1st condition) per endpoint
+  const conditionString = endpoint.conditions[0];
+  const operator = operators.find((op) => conditionString.includes(op));
+  const conditionValue = operator
+    ? conditionString
+        .split(operator)
+        .pop()
+        ?.trim() || ""
+    : "0";
+
+  const [sliderValue, setSliderValue] = useState<number>(parseFloat(conditionValue));
+
+  const handleEndpointToggle = () => {
+    setGatusEndpoints((prevEndpoints) =>
+      prevEndpoints.map((ep, i) => (i === index ? { ...ep, enabled: !ep.enabled } : ep))
+    );
+  };
+
+  const handleSliderUpdate = (value: number) => {
+    setSliderValue(value);
+  };
+
+  const handleSliderUpdateComplete = (value: number) => {
+    const updatedCondition = operator
+      ? `${endpoint.conditions[0].split(operator)[0].trim()} ${operator} ${value}`
+      : endpoint.conditions[0];
+
+    setGatusEndpoints((prevEndpoints) =>
+      prevEndpoints.map((ep, i) =>
+        i === index
+          ? {
+              ...ep,
+              conditions: [
+                updatedCondition, // Update ONLY the first condition
+                ...ep.conditions.slice(1)
+              ]
+            }
+          : ep
+      )
+    );
+  };
+
+  return (
+    <>
+      <div key={index} className="endpoint-row">
+        <div>
+          <strong>{endpoint.definition.title}</strong>
+          <div>{endpoint.definition.description}</div>
+        </div>
+        <Switch checked={endpointEnabled} onToggle={handleEndpointToggle} />
+      </div>
+      {endpointEnabled && endpoint.metric && (
+        <div className="slider-wrapper">
+          <Slider
+            value={sliderValue}
+            onChange={handleSliderUpdate}
+            onChangeComplete={handleSliderUpdateComplete}
+            min={endpoint.metric.min}
+            max={endpoint.metric.max}
+            unit={endpoint.metric.unit}
+          />
+        </div>
+      )}
+      {index + 1 < numEndpoints && <hr />}
+    </>
+  );
+}

--- a/packages/admin-ui/src/pages/notifications/tabs/Settings/ManagePackageNotifications.tsx
+++ b/packages/admin-ui/src/pages/notifications/tabs/Settings/ManagePackageNotifications.tsx
@@ -11,12 +11,14 @@ interface ManagePackageNotificationsProps {
   dnpName: string;
   gatusEndpoints: GatusEndpoint[];
   customEndpoints: CustomEndpoint[];
+  isCore: boolean;
 }
 
 export function ManagePackageNotifications({
   dnpName,
   gatusEndpoints,
-  customEndpoints
+  customEndpoints,
+  isCore
 }: ManagePackageNotificationsProps) {
   const [endpointsGatus, setEndpointsGatus] = useState([...gatusEndpoints]);
   const [endpointsCustom, setEndpointsCustom] = useState([...customEndpoints]);
@@ -33,10 +35,14 @@ export function ManagePackageNotifications({
   };
 
   useEffect(() => {
-    api.notificationsUpdateEndpoints({ dnpName, notificationsConfig: { endpoints: endpointsGatus } });
+    api.notificationsUpdateEndpoints({ dnpName, notificationsConfig: { endpoints: endpointsGatus }, isCore: isCore });
   }, [endpointsGatus]);
   useEffect(() => {
-    api.notificationsUpdateEndpoints({ dnpName, notificationsConfig: { customEndpoints: endpointsCustom } });
+    api.notificationsUpdateEndpoints({
+      dnpName,
+      notificationsConfig: { customEndpoints: endpointsCustom },
+      isCore: isCore
+    });
   }, [endpointsCustom]);
   return (
     <div key={String(dnpName)} className="notifications-settings">

--- a/packages/admin-ui/src/pages/notifications/tabs/Settings/ManagePackageNotifications.tsx
+++ b/packages/admin-ui/src/pages/notifications/tabs/Settings/ManagePackageNotifications.tsx
@@ -1,0 +1,61 @@
+import React, { useEffect, useState } from "react";
+import SubTitle from "components/SubTitle";
+import Switch from "components/Switch";
+import { EndpointItem } from "./EndpointItem.js";
+import { Endpoint } from "@dappnode/types";
+import { prettyDnpName } from "utils/format";
+import { api } from "api";
+
+interface ManagePackageNotificationsProps {
+  dnpName: string;
+  endpoints: Endpoint[];
+}
+
+export function ManagePackageNotifications({ dnpName, endpoints }: ManagePackageNotificationsProps) {
+  const [pkgEndpoints, setPkgEndpoints] = useState(endpoints);
+  const [pkgNotificationsEnabled, setPkgNotificationsEnabled] = useState(endpoints.some((ep) => ep.enabled));
+
+  // Sync state when `endpoints` prop changes, but keep user modifications
+  useEffect(() => {
+    setPkgEndpoints((prevPkgEndpoints) => {
+      const updatedEndpoints = endpoints.map((newEp) => {
+        const existingEp = prevPkgEndpoints.find((ep) => ep.name === newEp.name);
+        return existingEp ? { ...existingEp, ...newEp } : newEp;
+      });
+      return updatedEndpoints;
+    });
+  }, [endpoints]);
+
+  // Handle switch toggle to enable/disable all endpoints
+  const handlePkgToggle = () => {
+    const newEnabledState = !pkgNotificationsEnabled;
+    setPkgEndpoints((prevPkgEndpoints) => prevPkgEndpoints.map((ep) => ({ ...ep, enabled: newEnabledState })));
+    setPkgNotificationsEnabled(newEnabledState);
+  };
+
+  useEffect(() => {
+    // TODO: Implement timeOut that waits for more config updates before sending the new Endpoints config
+    api.gatusUpdateEndpoints({ dnpName, updatedEndpoints: pkgEndpoints });
+  }, [pkgEndpoints]);
+  return (
+    <div key={String(dnpName)} className="notifications-settings">
+      <div className="title-switch-row">
+        <SubTitle className="notifications-pkg-name">{prettyDnpName(dnpName)}</SubTitle>
+        <Switch checked={pkgNotificationsEnabled} onToggle={handlePkgToggle} />
+      </div>
+      {pkgNotificationsEnabled && (
+        <div className="endpoint-list-card">
+          {pkgEndpoints.map((endpoint, i) => (
+            <EndpointItem
+              key={endpoint.name}
+              endpoint={endpoint}
+              index={i}
+              numEndpoints={pkgEndpoints.length}
+              setPkgEndpoints={setPkgEndpoints}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/admin-ui/src/pages/notifications/tabs/Settings/Settings.tsx
+++ b/packages/admin-ui/src/pages/notifications/tabs/Settings/Settings.tsx
@@ -1,0 +1,42 @@
+import SubTitle from "components/SubTitle";
+import React, { useState } from "react";
+import Switch from "components/Switch";
+import { ManagePackageNotifications } from "./ManagePackageNotifications.js";
+import { useApi } from "api";
+import "./settings.scss";
+
+export function NotificationsSettings() {
+  const [notificationsEnabled, setNotificationsEnabled] = useState(true);
+  const endpointsCall = useApi.gatusGetEndpoints();
+
+  return (
+    <div className="notifications-settings">
+      <div>
+        <div className="title-switch-row">
+          <SubTitle className="notifications-section-title">Enable notifications</SubTitle>
+          <Switch
+            checked={notificationsEnabled}
+            onToggle={() => {
+              setNotificationsEnabled(!notificationsEnabled);
+            }}
+          />
+        </div>
+        <div>Enable notifications to retrieve a registry of notifications on your Dappnode.</div>
+      </div>
+      <br />
+      {notificationsEnabled && (
+        <div>
+          <SubTitle className="notifications-section-title">Manage notifications</SubTitle>
+          <div>Enable, disable and customize notifications individually.</div>
+          <br />
+          <div className="manage-notifications-wrapper">
+            {endpointsCall.data &&
+              Object.entries(endpointsCall.data).map(([dnpName, endpoints]) => (
+                <ManagePackageNotifications key={dnpName} dnpName={dnpName} endpoints={endpoints} />
+              ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/admin-ui/src/pages/notifications/tabs/Settings/Settings.tsx
+++ b/packages/admin-ui/src/pages/notifications/tabs/Settings/Settings.tsx
@@ -37,6 +37,7 @@ export function NotificationsSettings() {
                   dnpName={dnpName}
                   gatusEndpoints={endpoints.endpoints}
                   customEndpoints={endpoints.customEndpoints}
+                  isCore={endpoints.isCore}
                 />
               ))}
           </div>

--- a/packages/admin-ui/src/pages/notifications/tabs/Settings/Settings.tsx
+++ b/packages/admin-ui/src/pages/notifications/tabs/Settings/Settings.tsx
@@ -7,7 +7,7 @@ import "./settings.scss";
 
 export function NotificationsSettings() {
   const [notificationsEnabled, setNotificationsEnabled] = useState(true);
-  const endpointsCall = useApi.gatusGetEndpoints();
+  const endpointsCall = useApi.notificationsGetEndpoints();
 
   return (
     <div className="notifications-settings">
@@ -32,7 +32,12 @@ export function NotificationsSettings() {
           <div className="manage-notifications-wrapper">
             {endpointsCall.data &&
               Object.entries(endpointsCall.data).map(([dnpName, endpoints]) => (
-                <ManagePackageNotifications key={dnpName} dnpName={dnpName} endpoints={endpoints} />
+                <ManagePackageNotifications
+                  key={dnpName}
+                  dnpName={dnpName}
+                  gatusEndpoints={endpoints.endpoints}
+                  customEndpoints={endpoints.customEndpoints}
+                />
               ))}
           </div>
         </div>

--- a/packages/admin-ui/src/pages/notifications/tabs/Settings/settings.scss
+++ b/packages/admin-ui/src/pages/notifications/tabs/Settings/settings.scss
@@ -1,0 +1,59 @@
+.notifications-settings {
+    .title-switch-row {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      gap: 10px;
+    }
+    .notifications-section-title {
+      margin: 0.5rem 0;
+    }
+  
+    .manage-notifications-wrapper {
+      display: flex;
+      flex-direction: column;
+      gap: 15px;
+    }
+  
+    .notifications-pkg-name {
+      font-size: 1.2rem;
+      margin: 0.5rem 0;
+    }
+  
+    .endpoint-list-card {
+      border-radius: 10px;
+      background-color: #e9ecef;
+      padding: 20px 15px;
+      display: flex;
+      flex-direction: column;
+  
+      .endpoint-row {
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+      }
+  
+      hr {
+        width: 100%;
+      }
+  
+      .slider-wrapper{
+        padding-top: 15px;
+        width: 30%;
+  
+        @media (max-width: 60rem) {
+          width: 100%;
+        }
+      }
+    }
+  }
+  
+  #dark {
+    .notifications-settings {
+      .endpoint-list-card {
+        background-color: var(--color-dark-card);
+        color: var(--color-dark-maintext);
+      }
+    }
+  }
+  


### PR DESCRIPTION
Implementing `Settings` notifications subtab. Supports gatus and custom endpoints.