### PR TITLE
Initialize endpoints set by pkg

### DIFF
--- a/packages/notifications/src/manifest.ts
+++ b/packages/notifications/src/manifest.ts
@@ -22,10 +22,12 @@ export class NotificationsManifest {
 
       if (!manifest.notifications) continue;
 
+      if (!notificationsEndpoints[pkg.dnpName]) {
+        notificationsEndpoints[pkg.dnpName] = { endpoints: [], customEndpoints: [], isCore: isCore };
+      }
       const { endpoints, customEndpoints } = manifest.notifications;
       if (endpoints) notificationsEndpoints[dnpName].endpoints = endpoints;
       if (customEndpoints) notificationsEndpoints[dnpName].customEndpoints = customEndpoints;
-      notificationsEndpoints[dnpName].isCore = isCore;
     }
 
     return notificationsEndpoints;


### PR DESCRIPTION
Ensures `notificationsEndpoints[pkg.dnpName]` is initialized before assigning properties in `getNotifications` method