### PR TITLE
Merge endpoints config on installer

### DIFF
--- a/packages/admin-ui/src/__mock-backend__/index.ts
+++ b/packages/admin-ui/src/__mock-backend__/index.ts
@@ -391,7 +391,10 @@ export const otherCalls: Omit<Routes, keyof typeof namedSpacedCalls> = {
     return { "geth.dnp.dappnode.eth": { endpoints: [], customEndpoints: [], isCore: false } };
   },
   notificationsUpdateEndpoints: async () => {},
-  notificationsGetAll: async () => []
+  notificationsGetAll: async () => [],
+  notificationsApplyPreviousEndpoints: async () => {
+    return { endpoints: [], customEndpoints: [] };
+  },
 };
 
 export const calls: Routes = {

--- a/packages/admin-ui/src/pages/installer/components/InstallDnpView.tsx
+++ b/packages/admin-ui/src/pages/installer/components/InstallDnpView.tsx
@@ -74,6 +74,20 @@ const InstallDnpView: React.FC<InstallDnpViewProps> = ({ dnp, progressLogs }) =>
     manifest.notifications?.customEndpoints || []
   );
 
+  const mergedNotificationsConfig = useApi.notificationsApplyPreviousEndpoints({
+    dnpName: dnpName,
+    isCore,
+    newNotificationsConfig: manifest.notifications || {}
+  });
+
+  useEffect(() => {
+    if (mergedNotificationsConfig.data) {
+      const { endpoints: newEndpoints, customEndpoints: newCustomEndpoints } = mergedNotificationsConfig.data;
+      setEndpoints(newEndpoints || []);
+      setCustomEndpoints(newCustomEndpoints || []);
+    }
+  }, [mergedNotificationsConfig.data]);
+
   useEffect(() => {
     setUserSettings(settings || {});
   }, [settings, setUserSettings]);

--- a/packages/dappmanager/src/calls/index.ts
+++ b/packages/dappmanager/src/calls/index.ts
@@ -22,7 +22,7 @@ export { getCoreVersion } from "./getCoreVersion.js";
 export { getUserActionLogs } from "./getUserActionLogs.js";
 export { getHostUptime } from "./getHostUptime.js";
 export { getIsConnectedToInternet } from "./getIsConnectedToInternet.js";
-export { notificationsGetAllEndpoints, notificationsUpdateEndpoints, notificationsGetAll } from "./notifications.js";
+export { notificationsGetAllEndpoints, notificationsUpdateEndpoints, notificationsGetAll, notificationsApplyPreviousEndpoints } from "./notifications.js";
 export * from "./httpsPortal.js";
 export { ipfsTest } from "./ipfsTest.js";
 export { ipfsClientTargetSet } from "./ipfsClientTargetSet.js";

--- a/packages/dappmanager/src/calls/notifications.ts
+++ b/packages/dappmanager/src/calls/notifications.ts
@@ -32,3 +32,18 @@ export async function notificationsUpdateEndpoints({
 }): Promise<void> {
   await notifications.updateEndpoints(dnpName, isCore, notificationsConfig);
 }
+
+/**
+ * Joins new endpoints with previous ones
+ */
+export async function notificationsApplyPreviousEndpoints({
+  dnpName,
+  isCore,
+  newNotificationsConfig
+}: {
+  dnpName: string;
+  isCore: boolean;
+  newNotificationsConfig: NotificationsConfig;
+}): Promise<NotificationsConfig> {
+  return await notifications.applyPreviousEndpoints(dnpName, isCore, newNotificationsConfig);
+}

--- a/packages/types/src/routes.ts
+++ b/packages/types/src/routes.ts
@@ -284,6 +284,15 @@ export interface Routes {
   }) => Promise<void>;
 
   /**
+   * Applies the previous endpoints configuration to the new ones if their names match
+   */
+  notificationsApplyPreviousEndpoints: (kwargs: {
+    dnpName: string;
+    isCore: boolean;
+    newNotificationsConfig: NotificationsConfig;
+  }) => Promise<NotificationsConfig>;
+
+  /**
    * Returns the user action logs. This logs are stored in a different
    * file and format, and are meant to ease user support
    * The list is ordered from newest to oldest. Newest log has index = 0
@@ -715,6 +724,7 @@ export const routesData: { [P in keyof Routes]: RouteData } = {
   notificationsGetAll: { log: true },
   notificationsGetAllEndpoints: { log: true },
   notificationsUpdateEndpoints: { log: true },
+  notificationsApplyPreviousEndpoints: {},
   getUserActionLogs: {},
   getHostUptime: {},
   httpsPortalMappingAdd: { log: true },


### PR DESCRIPTION
Persist user's notifications settings on installer if "new manifest" endpoints' names match