### PR TITLE
Adds functionality to disable UPnP on package-by-package basis

### DIFF
--- a/packages/daemons/src/natRenewal/index.ts
+++ b/packages/daemons/src/natRenewal/index.ts
@@ -48,7 +48,7 @@ async function natRenewal(): Promise<void> {
 
     // Fetch portsToOpen and store them in the DB
     const containers = await listPackageContainers();
-    const portsToOpen = getPortsToOpen(containers);
+    const portsToOpen = await getPortsToOpen(containers);
     db.portsToOpen.set(portsToOpen);
     if (isFirstRun)
       logs.info("NAT renewal portsToOpen\n", portsToOpen.map((p) => `${p.portNumber}/${p.protocol}`).join(", "));

--- a/packages/types/src/manifest.ts
+++ b/packages/types/src/manifest.ts
@@ -95,6 +95,7 @@ export interface Manifest {
 
   // Network metadata
   exposable?: ExposableServiceManifestInfo[];
+  upnpDisable?: boolean | number[];
 
   // setupWizard for compacted manifests in core packages
   setupWizard?: SetupWizard;


### PR DESCRIPTION
<!-- For DAppNode core members, once the Pull Request is created, do not forget to:
1.  Link issues to the PR if available
2.  Mention dappnode core members
3.  Add proper labels
-->

## Context

Now, there is no way to expose ports just locally on package-by-package basis. If there are ports defined in compose Dappmanager is always trying to make upnp call to router to do port forwarding. There is possibility to disable upnp all together, but that is not good enough.

## Approach

When parsing what ports to open Dappmanager goes through blacklist of ports defined in manifest and skips them if found

## Test instructions

Install this Dappmanager and package which implements this feature (e.g. Pi hole).
 - Make sure that logs say that ports are skipped
 - Check on your router that ports are not exposed
