### PR TITLE
Set stakerConfigGet argument as object

### DIFF
--- a/packages/admin-ui/src/__mock-backend__/stakerConfig.ts
+++ b/packages/admin-ui/src/__mock-backend__/stakerConfig.ts
@@ -2,7 +2,7 @@ import { Routes, Network } from "@dappnode/types";
 
 export const stakerConfig: Pick<Routes, "stakerConfigGet" | "stakerConfigSet"> = {
   stakerConfigSet: async () => {},
-  stakerConfigGet: async <T extends Network>(network: T) => {
+  stakerConfigGet: async ({ network }: { network: Network }) => {
     switch (network) {
       case "mainnet":
         return {

--- a/packages/admin-ui/src/pages/stakers/components/StakerNetwork.tsx
+++ b/packages/admin-ui/src/pages/stakers/components/StakerNetwork.tsx
@@ -3,7 +3,6 @@ import SubTitle from "components/SubTitle";
 import { withToast } from "components/toast/Toast";
 import Col from "react-bootstrap/Col";
 import Row from "react-bootstrap/Row";
-import { StakerConfigGet } from "@dappnode/types";
 import { api, useApi } from "api";
 import ErrorView from "components/ErrorView";
 import { confirm } from "components/ConfirmDialog";
@@ -14,7 +13,6 @@ import ExecutionClient from "./columns/ExecutionClient";
 import Button from "components/Button";
 import { disclaimer } from "../data";
 import Loading from "components/Loading";
-import { responseInterface } from "swr";
 import { Alert } from "react-bootstrap";
 import "./stakers.scss";
 import { AppContext } from "App";
@@ -29,7 +27,7 @@ export default function StakerNetwork({ network, description }: { network: Netwo
   // Context
   const { theme } = React.useContext(AppContext);
 
-  const currentStakerConfigReq = useApi.stakerConfigGet(network) as responseInterface<StakerConfigGet, Error>;
+  const currentStakerConfigReq = useApi.stakerConfigGet({ network });
 
   // hooks
   const {
@@ -127,7 +125,7 @@ export default function StakerNetwork({ network, description }: { network: Netwo
           </p>
         </AlertDismissible>
       )}
-      
+
       {network === "holesky" && (
         <AlertDismissible variant="warning">
           <p>

--- a/packages/dappmanager/src/calls/stakerConfig.ts
+++ b/packages/dappmanager/src/calls/stakerConfig.ts
@@ -23,7 +23,7 @@ export async function stakerConfigSet({ stakerConfig }: { stakerConfig: StakerCo
  * Returns the current staker configuration: execution and consensus clients,
  * remote signer, mev boost, graffiti, fee recipient address and checkpoint sync url
  */
-export async function stakerConfigGet(network: Network): Promise<StakerConfigGet> {
+export async function stakerConfigGet({ network }: { network: Network }): Promise<StakerConfigGet> {
   return await Promise.all([
     await execution.getAllExecutions(network),
     await consensus.getAllConsensus(network),

--- a/packages/types/src/routes.ts
+++ b/packages/types/src/routes.ts
@@ -120,7 +120,7 @@ export interface Routes {
   }) => Promise<void>;
 
   /** Gets the staker configuration for a given network */
-  stakerConfigGet: <T extends Network>(network: T) => Promise<StakerConfigGet>;
+  stakerConfigGet: (kwargs: { network: Network }) => Promise<StakerConfigGet>;
 
   /** Sets the staker configuration for a given network */
   stakerConfigSet: (kwargs: { stakerConfig: StakerConfigSet }) => Promise<void>;


### PR DESCRIPTION
Set stakerConfigGet argument as object. This will fix the allowance of calling the endpoint when running dappmanager with env `TEST=true` as follows:


```bash
curl -X POST http://172.33.1.7:7000/stakerConfigGet \
  -H "Content-Type: application/json" \
  -d '{"network": "mainnet"}'
```