### PR TITLE
Package updates card style

### DIFF
--- a/packages/admin-ui/src/pages/dashboard/components/PackageUpdates.tsx
+++ b/packages/admin-ui/src/pages/dashboard/components/PackageUpdates.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import Alert from "react-bootstrap/esm/Alert";
 import { useApi } from "api";
 import { getInstallerPath } from "pages/installer";
 import { UpdateAvailable } from "@dappnode/types";
@@ -37,10 +36,10 @@ export function PackageUpdates() {
   return (
     <div className="dashboard-cards">
       <div className="package-updates">
-        {updatesAvailable.length === 0 ? (
-          <Alert className="package-updates-card" variant="success">
+        {updatesAvailable.length !== 0 ? (
+          <div className="card card-body" >
             All packages are up to date
-          </Alert>
+          </div>
         ) : (
           <>
             {updatesAvailable.map((update) => (

--- a/packages/admin-ui/src/pages/dashboard/components/PackageUpdates.tsx
+++ b/packages/admin-ui/src/pages/dashboard/components/PackageUpdates.tsx
@@ -36,7 +36,7 @@ export function PackageUpdates() {
   return (
     <div className="dashboard-cards">
       <div className="package-updates">
-        {updatesAvailable.length !== 0 ? (
+        {updatesAvailable.length === 0 ? (
           <div className="card card-body" >
             All packages are up to date
           </div>


### PR DESCRIPTION
Apply the same card style as the other `/dashboard` cards when no package updates are found