### PR TITLE
Sidebar dark style fix

### DIFF
--- a/packages/admin-ui/src/components/topbar/TopBar.tsx
+++ b/packages/admin-ui/src/components/topbar/TopBar.tsx
@@ -27,12 +27,7 @@ export const TopBar = ({ username, appContext }: { username: string; appContext:
       {/* Right justified items */}
 
       {appContext.theme === "light" ? (
-        <div className="beta">
-          <span>BETA</span>
-          {/* Theme usage requires more feedback */}
-          {/*<UsageSwitch toggleUsage={toggleUsage} /> */}
-          <ThemeSwitch toggleTheme={appContext.toggleTheme} />
-        </div>
+        <ThemeSwitch toggleTheme={appContext.toggleTheme} />
       ) : (
         <ThemeSwitch toggleTheme={appContext.toggleTheme} />
       )}

--- a/packages/admin-ui/src/components/topbar/topbar.scss
+++ b/packages/admin-ui/src/components/topbar/topbar.scss
@@ -19,20 +19,6 @@
 
 /* Sidenav toggler */
 
-.beta {
-  font-family: "Courier New", Courier, monospace;
-  font-size: 16px;
-  padding: 4px;
-  border: 1px solid #ccc;
-  border-radius: 3px;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  span {
-    padding: 0px 6px 0px 6px;
-  }
-}
-
 .sidenav-toggler {
   font-size: 30px;
   background: none;

--- a/packages/admin-ui/src/light_dark.scss
+++ b/packages/admin-ui/src/light_dark.scss
@@ -188,6 +188,12 @@
         opacity: 1;
       }
     }
+    .sidenav-item {
+      &.selectable:hover,
+      &.selectable.active {
+        background-color: var(--color-dark-card);
+      }
+    }
   }
   #topbar {
     background-color: var(--color-dark-background-topbar);


### PR DESCRIPTION
Updating the background color of sidebar items on hover in dark mode to a darker one for improved readability and color consistency. Also, remove the 'BETA' label from the dark mode theme toggler