### PR TITLE
Notifications general switch

### DIFF
--- a/packages/admin-ui/src/pages/installer/components/InstallDnpView.tsx
+++ b/packages/admin-ui/src/pages/installer/components/InstallDnpView.tsx
@@ -29,7 +29,7 @@ import { diff } from "semver";
 import Button from "components/Button";
 import { pathName as systemPathName, subPaths as systemSubPaths } from "pages/system/data";
 import { Notifications } from "./Steps/Notifications";
-import { notificationsPkgName } from "params";
+import { notificationsDnpName } from "params";
 
 interface InstallDnpViewProps {
   dnp: RequestedDnp;
@@ -214,7 +214,7 @@ const InstallDnpView: React.FC<InstallDnpViewProps> = ({ dnp, progressLogs }) =>
 
   const dnpsRequest = useApi.packagesGet();
   const installedDnps = dnpsRequest.data;
-  const isNotificationsPkgInstalled = installedDnps?.some((dnp) => dnp.dnpName === notificationsPkgName);
+  const isNotificationsPkgInstalled = installedDnps?.some((dnp) => dnp.dnpName === notificationsDnpName);
 
   const disableInstallation =
     !isEmpty(progressLogs) || requiresCoreUpdate || requiresDockerUpdate || packagesToBeUninstalled.length > 0;

--- a/packages/admin-ui/src/pages/notifications/NotificationsRoot.tsx
+++ b/packages/admin-ui/src/pages/notifications/NotificationsRoot.tsx
@@ -9,13 +9,13 @@ import Title from "components/Title";
 import { renderResponse } from "components/SwrRender";
 import { Inbox } from "./tabs/Inbox/Inbox";
 import { NotificationsSettings } from "./tabs/Settings/Settings";
-import { notificationsPkgName } from "params";
+import { notificationsDnpName } from "params";
 import { LegacyNotifications } from "./tabs/Legacy";
 
 export const NotificationsRoot: React.FC = () => {
   const dnpsRequest = useApi.packagesGet();
   return renderResponse(dnpsRequest, ["Loading notifications"], (dnps) => {
-    const isNotificationsPkgInstalled = dnps?.some((dnp) => dnp.dnpName === notificationsPkgName);
+    const isNotificationsPkgInstalled = dnps?.some((dnp) => dnp.dnpName === notificationsDnpName);
 
     const availableRoutes: {
       name: string;
@@ -25,16 +25,12 @@ export const NotificationsRoot: React.FC = () => {
       {
         name: "Inbox",
         subPath: subPaths.inbox,
-        component: isNotificationsPkgInstalled
-          ? Inbox
-          : () => <InstallNotificationsPkg pkgName={notificationsPkgName} />
+        component: isNotificationsPkgInstalled ? Inbox : () => <InstallNotificationsPkg />
       },
       {
         name: "Settings",
         subPath: subPaths.settings,
-        component: isNotificationsPkgInstalled
-          ? NotificationsSettings
-          : () => <InstallNotificationsPkg pkgName={notificationsPkgName} />
+        component: isNotificationsPkgInstalled ? NotificationsSettings : () => <InstallNotificationsPkg />
       },
       {
         name: "Legacy",

--- a/packages/admin-ui/src/pages/notifications/tabs/InstallNotifications/InstallNotifications.tsx
+++ b/packages/admin-ui/src/pages/notifications/tabs/InstallNotifications/InstallNotifications.tsx
@@ -6,19 +6,17 @@ import SubTitle from "components/SubTitle";
 import Card from "components/Card";
 
 import "./installNotifications.scss";
+import { notificationsDnpName } from "params";
 
-interface InstallNotificationsPkgProps {
-  pkgName: string;
-}
 
-export const InstallNotificationsPkg: React.FC<InstallNotificationsPkgProps> = ({ pkgName }) => {
-  const installerPath = getInstallerPath(pkgName);
+export const InstallNotificationsPkg: React.FC = () => {
+  const installerPath = getInstallerPath(notificationsDnpName);
 
   return (
     <Card className="install-notifications-card">
       <SubTitle>Install notifications package</SubTitle>
       <p>To receive notifications on your Dappnode, you must install the Notifications Dappnode Package.</p>
-      <NavLink to={installerPath + "/" + pkgName}>
+      <NavLink to={installerPath + "/" + notificationsDnpName}>
         <Button variant="dappnode">Install</Button>
       </NavLink>
     </Card>

--- a/packages/admin-ui/src/pages/notifications/tabs/Settings/Settings.tsx
+++ b/packages/admin-ui/src/pages/notifications/tabs/Settings/Settings.tsx
@@ -33,11 +33,7 @@ export function NotificationsSettings() {
 
   useEffect(() => {
     if (notificationsDnp.data) {
-      console.log("notificationsDnp.data", notificationsDnp.data);
-
       const isStopped = notificationsDnp.data.containers.some((c) => c.state !== "running");
-      console.log("isStopped", isStopped);
-
       setNotificationsDisabled(isStopped);
     }
   }, [notificationsDnp.data]);

--- a/packages/admin-ui/src/pages/notifications/tabs/Settings/Settings.tsx
+++ b/packages/admin-ui/src/pages/notifications/tabs/Settings/Settings.tsx
@@ -2,9 +2,13 @@ import SubTitle from "components/SubTitle";
 import React, { useEffect, useState } from "react";
 import Switch from "components/Switch";
 import { ManagePackageNotifications } from "./ManagePackageNotifications.js";
-import { useApi } from "api";
+import { api, useApi } from "api";
 import { CustomEndpoint, GatusEndpoint } from "@dappnode/types";
 import "./settings.scss";
+import { notificationsDnpName } from "params.js";
+import { confirm } from "components/ConfirmDialog";
+import { withToast } from "components/toast/Toast";
+import { continueIfCalleDisconnected } from "api/utils";
 
 interface EndpointsData {
   [dnpName: string]: {
@@ -15,9 +19,10 @@ interface EndpointsData {
 }
 
 export function NotificationsSettings() {
-  const [notificationsEnabled, setNotificationsEnabled] = useState(true);
+  const [notificationsDisabled, setNotificationsDisabled] = useState<boolean>(false);
   const [endpointsData, setEndpointsData] = useState<EndpointsData | undefined>();
   const endpointsCall = useApi.notificationsGetAllEndpoints();
+  const notificationsDnp = useApi.packageGet({ dnpName: notificationsDnpName });
 
   useEffect(() => {
     // Fetch the latest endpoints data when the component is mounted
@@ -26,22 +31,65 @@ export function NotificationsSettings() {
     }
   }, [endpointsCall.data]);
 
+  useEffect(() => {
+    if (notificationsDnp.data) {
+      console.log("notificationsDnp.data", notificationsDnp.data);
+
+      const isStopped = notificationsDnp.data.containers.some((c) => c.state !== "running");
+      console.log("isStopped", isStopped);
+
+      setNotificationsDisabled(isStopped);
+    }
+  }, [notificationsDnp.data]);
+
+  async function startStopNotifications(): Promise<void> {
+    try {
+      if (notificationsDnp.data) {
+        if (!notificationsDisabled)
+          await new Promise<void>((resolve) => {
+            confirm({
+              title: `Pause notifications package`,
+              text: `Attention, the notifications package may alert you to critical issues if they arise. Pausing this package could result in missing important notifications.`,
+              label: "Pause",
+              onClick: resolve
+            });
+          });
+
+        await withToast(
+          continueIfCalleDisconnected(
+            () => api.packageStartStop({ dnpName: notificationsDnpName }),
+            notificationsDnpName
+          ),
+          {
+            message: notificationsDisabled ? "Enabling notifications" : "Disabling notifications",
+            onSuccess: notificationsDisabled ? "Notifications Enabled" : "Notifications disabled"
+          }
+        );
+
+        notificationsDnp.revalidate();
+      }
+    } catch (e) {
+      console.error(`Error on start/stop notifications package: ${e}`);
+    }
+  }
+
   return (
     <div className="notifications-settings">
       <div>
         <div className="title-switch-row">
           <SubTitle className="notifications-section-title">Enable notifications</SubTitle>
           <Switch
-            checked={notificationsEnabled}
+            checked={!notificationsDisabled}
+            disabled={notificationsDnp.isValidating}
             onToggle={() => {
-              setNotificationsEnabled(!notificationsEnabled);
+              startStopNotifications();
             }}
           />
         </div>
         <div>Enable notifications to retrieve a registry of notifications on your Dappnode.</div>
       </div>
       <br />
-      {notificationsEnabled && (
+      {!notificationsDisabled && !notificationsDnp.isValidating && (
         <div>
           <SubTitle className="notifications-section-title">Manage notifications</SubTitle>
           <div>Enable, disable and customize notifications individually.</div>

--- a/packages/admin-ui/src/params.ts
+++ b/packages/admin-ui/src/params.ts
@@ -51,6 +51,7 @@ export const ipfsDnpName = "ipfs.dnp.dappnode.eth";
 export const coreDnpName = "core.dnp.dappnode.eth";
 export const bindDnpName = "bind.dnp.dappnode.eth";
 export const vpnDnpName = "vpn.dnp.dappnode.eth";
+export const notificationsDnpName = "notifications.dnp.dappnode.eth";
 export const dappmanagerDnpName = "dappmanager.dnp.dappnode.eth";
 export const mandatoryCoreDnps = [
   dappmanagerDnpName,
@@ -131,6 +132,3 @@ export const IPFS_GATEWAY_CHECKER = "https://ipfs.github.io/public-gateway-check
 export const MAIN_ADMIN_NAME = "dappnode_admin";
 
 // Support, where to send issues
-
-// Notifications
-export const notificationsPkgName = "notifications.dnp.dappnode.eth";

--- a/packages/dappmanager/src/calls/packageStartStop.ts
+++ b/packages/dappmanager/src/calls/packageStartStop.ts
@@ -6,7 +6,7 @@ import { getServicesSharingPid } from "@dappnode/utils";
 import { ComposeFileEditor } from "@dappnode/dockercompose";
 import { PackageContainer } from "@dappnode/types";
 
-const dnpsAllowedToStop = [params.ipfsDnpName, params.wifiDnpName, params.HTTPS_PORTAL_DNPNAME];
+const dnpsAllowedToStop = [params.ipfsDnpName, params.wifiDnpName, params.HTTPS_PORTAL_DNPNAME, params.notificationsDnpName];
 
 /**
  * Stops or starts a package containers

--- a/packages/params/src/params.ts
+++ b/packages/params/src/params.ts
@@ -218,6 +218,7 @@ export const params = {
   wifiContainerName: "DAppNodeCore-wifi.dnp.dappnode.eth",
   ipfsDnpName: "ipfs.dnp.dappnode.eth",
   ipfsContainerName: "DAppNodeCore-ipfs.dnp.dappnode.eth",
+  notificationsDnpName: "notifications.dnp.dappnode.eth",
   vpnDataVolume: "dncore_vpndnpdappnodeeth_data",
   wireguardContainerName: "DAppNodeCore-wireguard.wireguard.dnp.dappnode.eth",
   restartContainerName: "DAppNodeTool-restart.dnp.dappnode.eth",


### PR DESCRIPTION
If the general notifications switch is toggled, now it starts / stops the notifications package. Also, before disabling the switch a modal pops up alerting the user about its consecuences.