### PR TITLE
Blue dot bell fix

### DIFF
--- a/packages/admin-ui/src/components/topbar/dropdownMenus/Notifications.tsx
+++ b/packages/admin-ui/src/components/topbar/dropdownMenus/Notifications.tsx
@@ -21,7 +21,7 @@ export default function Notifications() {
   }, [unseenNotificationsReq]);
 
   useEffect(() => {
-    if (unseenNotificationsReq.data) {
+    if (unseenNotificationsReq.data !== undefined) {
       setNewNotifications(unseenNotificationsReq.data > 0);
     }
   }, [unseenNotificationsReq.data]);


### PR DESCRIPTION
The blue dot indicating new notifications did not disappear after a minute when the notification count dropped to zero