### PR TITLE
Restart tailsclae volumes when changing env in tailscale

### DIFF
--- a/packages/dappmanager/src/calls/packageSetEnvironment.ts
+++ b/packages/dappmanager/src/calls/packageSetEnvironment.ts
@@ -1,5 +1,8 @@
 import { PackageEnvs } from "@dappnode/types";
 import { packageSetEnvironment as _packageSetEnvironment } from "@dappnode/installer";
+import { packageRestartVolumes } from "./packageRestartVolumes.js";
+import { logs } from "@dappnode/logger";
+import { params } from "@dappnode/params";
 
 /**
  * Updates the .env file of a package. If requested, also re-ups it
@@ -12,4 +15,11 @@ export async function packageSetEnvironment({
   environmentByService: { [serviceName: string]: PackageEnvs };
 }): Promise<void> {
   await _packageSetEnvironment({ dnpName, environmentByService });
+
+  if (dnpName === params.TAILSCALE_DNP_NAME) {
+    logs.info("Restarting Tailscale volumes");
+    await packageRestartVolumes({
+      dnpName
+    });
+  }
 }

--- a/packages/params/src/params.ts
+++ b/packages/params/src/params.ts
@@ -105,6 +105,9 @@ export const params = {
   HTTPS_PORTAL_MAIN_SERVICE: "https.dnp.dappnode.eth",
   HTTPS_PORTAL_LOCAL_PROXYING_ENVNAME: "LOCAL_PROXYING",
 
+  // Tailscale params
+  TAILSCALE_DNP_NAME: "tailscale.dnp.dappnode.eth",
+
   // Wireguard params
   WIREGUARD_DNP_NAME: "wireguard.dnp.dappnode.eth",
   WIREGUARD_ISCORE: true,


### PR DESCRIPTION
Tailscale initializes disk based on the auth key. When changing the tailsclae env auth key a remove of the volumes is required so the db gets initialized again