### PR TITLE
Fix bind IP array format

### DIFF
--- a/packages/dockerCompose/src/userSettings.ts
+++ b/packages/dockerCompose/src/userSettings.ts
@@ -189,25 +189,25 @@ export function applyUserSettings(
       const merged: ComposeServiceNetworksObj = {};
 
       // Iterate over the keys of the base networks
-      for (const key in base) {
-        merged[key] = { ...base[key] }; // Start with a shallow copy of the base network
+      for (const networkName in base) {
+        merged[networkName] = { ...base[networkName] }; // Start with a shallow copy of the base network
 
-        if (user[key]) {
+        if (user[networkName]) {
           // If the user has provided overrides for this network, merge them
-          for (const subKey in user[key]) {
+          for (const subKey in user[networkName]) {
             if (subKey === "ipv4_address") {
-              merged[key].ipv4_address = base[key].ipv4_address; // Always take base ipv4_address
+              merged[networkName].ipv4_address = base[networkName].ipv4_address; // Always take base ipv4_address
             } else if (subKey === "aliases") {
               // Merge and deduplicate aliases
-              const baseAliases = base[key].aliases || [];
-              const userAliases = user[key].aliases || [];
-              merged[key].aliases = Array.from(new Set([...baseAliases, ...userAliases]));
+              const baseAliases = base[networkName].aliases || [];
+              const userAliases = user[networkName].aliases || [];
+              merged[networkName].aliases = Array.from(new Set([...baseAliases, ...userAliases]));
             }
           }
         } else {
           // If user doesn't have settings for the network, just copy the base network
-          if (!merged[key].ipv4_address && base[key].ipv4_address) {
-            merged[key].ipv4_address = base[key].ipv4_address;
+          if (!merged[networkName].ipv4_address && base[networkName].ipv4_address) {
+            merged[networkName].ipv4_address = base[networkName].ipv4_address;
           }
         }
       }

--- a/packages/dockerCompose/test/unit/userSettings.test.ts
+++ b/packages/dockerCompose/test/unit/userSettings.test.ts
@@ -653,7 +653,7 @@ describe("applyUserSettings - network merging logic", () => {
     expect(result.services[serviceName].networks).to.deep.equal({ net1: {} });
   });
 
-  it.only("should include user network and base network if both are defined in each", () => {
+  it("should include user network and base network if both are defined in each", () => {
     const serviceName = "test.dnp.dappnode.eth";
     const baseCompose = () => ({
       version: "3.5",

--- a/packages/dockerCompose/test/unit/userSettings.test.ts
+++ b/packages/dockerCompose/test/unit/userSettings.test.ts
@@ -652,4 +652,51 @@ describe("applyUserSettings - network merging logic", () => {
     const result = applyUserSettingsTest(compose, settings, { dnpName: serviceName });
     expect(result.services[serviceName].networks).to.deep.equal({ net1: {} });
   });
+
+  it.only("should include user network and base network if both are defined in each", () => {
+    const serviceName = "test.dnp.dappnode.eth";
+    const baseCompose = () => ({
+      version: "3.5",
+      services: {
+        [serviceName]: {
+          image: "test:latest",
+          container_name: "DAppNodePackage-test",
+          networks: {
+            net1: {
+              ipv4_address: "10.0.0.6",
+              aliases: ["alias3", "alias4"]
+            }
+          }
+        }
+      },
+      networks: { net1: {} }
+    });
+
+    const userSettings = {
+      networks: {
+        rootNetworks: { net1: {}, net2: {} },
+        serviceNetworks: {
+          [serviceName]: {
+            net2: {
+              ipv4_address: "10.0.0.5",
+              aliases: ["alias1", "alias2"]
+            }
+          }
+        }
+      }
+    };
+
+    const compose = baseCompose();
+    const result = applyUserSettingsTest(compose, userSettings, { dnpName: serviceName });
+    expect(result.services[serviceName].networks).to.deep.equal({
+      net1: {
+        ipv4_address: "10.0.0.6",
+        aliases: ["alias3", "alias4"]
+      },
+      net2: {
+        ipv4_address: "10.0.0.5",
+        aliases: ["alias1", "alias2"]
+      }
+    });
+  });
 });


### PR DESCRIPTION
Error reported from users

```bash
Command failed: docker compose -f /usr/src/app/DNCORE/docker-compose-bind.yml config <&- validating /usr/src/app/DNCORE/docker-compose-bind.yml: services.bind.dnp.dappnode.eth.networks.dncore_network.ipv4_address must be a string
```

The function `applyUserSettings` merges both network configuration. If IP is defined then the result when merging more than 1 network configuration with IP defined will result into an array of strings with both IPs, and thats an invalid format for docker compose
