### PR TITLE
Call notification API only if PWA

### DIFF
--- a/packages/admin-ui/src/hooks/PWA/useHandleSubscription.ts
+++ b/packages/admin-ui/src/hooks/PWA/useHandleSubscription.ts
@@ -34,21 +34,26 @@ export function useHandleSubscription(): UseHandleSubscriptionResult {
   const { device, browser, os } = useDeviceInfo();
 
   useEffect(() => {
-    try {
+    if ("Notification" in window) {
       setPermission(Notification.permission);
-    } catch (error) {
-      console.warn("Notification API not supported on this device:", error);
-      setPermission(null);
+    } else {
+      console.warn("Notification not supported");
     }
   }, []);
 
   useEffect(() => {
     const getSub = async () => {
-      const registration = await navigator.serviceWorker?.ready;
-      if (registration) {
-        const sub = await registration.pushManager.getSubscription();
-        setSubscription(sub);
+      if (!("serviceWorker" in navigator)) {
+        console.warn("Service Worker not supported");
+        return;
       }
+      if (!("PushManager" in window)) {
+        console.warn("Push Manager not supported");
+        return;
+      }
+      const registration = await navigator.serviceWorker.ready;
+      const sub = await registration.pushManager.getSubscription();
+      setSubscription(sub);
     };
 
     getSub();

--- a/packages/admin-ui/src/hooks/PWA/useHandleSubscription.ts
+++ b/packages/admin-ui/src/hooks/PWA/useHandleSubscription.ts
@@ -3,7 +3,6 @@ import { api, useApi } from "api";
 import { useState, useEffect, useCallback } from "react";
 import { NotifierSubscription } from "@dappnode/types";
 import useDeviceInfo from "./useDeviceInfo";
-import { usePwaInstall } from "pages/system/components/App/PwaInstallContext";
 
 interface UseHandleSubscriptionResult {
   subscription: PushSubscription | null;
@@ -33,20 +32,15 @@ export function useHandleSubscription(): UseHandleSubscriptionResult {
   const revalidateSubs = () => subscriptionsReq.revalidate();
 
   const { device, browser, os } = useDeviceInfo();
-  const { isPwa } = usePwaInstall();
 
   useEffect(() => {
-    if (isPwa) {
-      try {
-        setPermission(Notification.permission);
-      } catch (error) {
-        console.error("Error accessing Notification permission:", error);
-        setPermission(null);
-      }
-    } else {
+    try {
+      setPermission(Notification.permission);
+    } catch (error) {
+      console.warn("Notification API not supported on this device:", error);
       setPermission(null);
     }
-  }, [isPwa]);
+  }, []);
 
   useEffect(() => {
     const getSub = async () => {


### PR DESCRIPTION
IOS devices does not support Notification API if the PWA has not been installed:
- Only call the Notification API if the app is in standalone mode
- catch error 