### PR TITLE
Fix: set default notifications if not notifications user settings provided

### DIFF
--- a/packages/installer/src/installer/getInstallerPackageData.ts
+++ b/packages/installer/src/installer/getInstallerPackageData.ts
@@ -105,8 +105,8 @@ function getInstallerPackageData(
     manifest: release.manifest.notifications
       ? {
           ...release.manifest,
-          // Apply notitications user settings if any
-          notifications: notificationsSettings
+          // Apply notitications user settings if any otherwise use the default manifest notifications
+          notifications: notificationsSettings ?? release.manifest.notifications
         }
       : manifest,
     // User settings to be applied by the installer


### PR DESCRIPTION
Fix setting default notifications (from `notifications.yaml`) if no notifications user settings provided.

Fixes bug when installing a package without the installer. i.e using stakers UI
