### PR TITLE
 Overscroll macOS scroll fix in dark mode

### DIFF
--- a/packages/admin-ui/src/App.tsx
+++ b/packages/admin-ui/src/App.tsx
@@ -71,6 +71,17 @@ function MainApp({ username }: { username: string }) {
     toggleTheme: () => setTheme((curr: Theme) => (curr === "light" ? "dark" : "light"))
   };
 
+  useEffect(() => {
+    const html = document.documentElement;
+    const body = document.body;
+
+    html.classList.remove("light", "dark");
+    body.classList.remove("light", "dark");
+
+    html.classList.add(theme);
+    body.classList.add(theme);
+  }, [theme]);
+
   return (
     <AppContext.Provider value={appContext}>
       <div className="body" id={theme}>

--- a/packages/admin-ui/src/light_dark.scss
+++ b/packages/admin-ui/src/light_dark.scss
@@ -1,6 +1,10 @@
 /*
   LIGHT
 */
+html,
+body {
+  background-color: var(--color-light-background-main);
+}
 #light.body {
   background-color: var(--color-light-background-main);
 }
@@ -32,6 +36,10 @@
 /*
   DARK
 */
+html.dark,
+body.dark {
+  background-color: var(--color-dark-background-main);
+}
 #dark.body {
   background-color: var(--color-dark-background-main);
 }


### PR DESCRIPTION
[To be tested in macOS]
On macOS, when you overscroll in dark mode, the viewport peels back to the page’s background (white by default). This PR adds the theme classes to both `<html>` and `<body>` so the corresponding bg color is applied according to the active theme.
