### PR TITLE
Connect using IP instead of IPAM

### DIFF
--- a/packages/daemons/src/dockerNetworkConfigs/connectPkgContainers.ts
+++ b/packages/daemons/src/dockerNetworkConfigs/connectPkgContainers.ts
@@ -163,12 +163,10 @@ async function connectPkgContainerRetryOnIpUsed({
   if (maxAttempts > 100) maxAttempts = 100;
   if (maxAttempts < 1) maxAttempts = 1;
   let attemptCount = 0;
-  const networkOptions = {
+  const networkOptions: Dockerode.NetworkConnectOptions = {
     Container: containerName,
     EndpointConfig: {
-      IPAMConfig: {
-        IPv4Address: ip
-      },
+      IPAddress: ip,
       Aliases: aliases
     }
   };


### PR DESCRIPTION
Connect using IP instead of IPAM. Docker uses the IPAM config to reproduce the network configuration in subsequent restarts so if the IP is taken it will exit with error `address already in use`