### PR TITLE
Set dappmanager IP only in `dncore_network`

### DIFF
--- a/packages/daemons/src/dockerNetworkConfigs/index.ts
+++ b/packages/daemons/src/dockerNetworkConfigs/index.ts
@@ -27,7 +27,6 @@ async function ensureDockerNetworkConfigs(
     {
       networkName: params.DOCKER_PRIVATE_NETWORK_NEW_NAME,
       subnet: params.DOCKER_NETWORK_NEW_SUBNET,
-      dappmanagerIp: params.DAPPMANAGER_NEW_IP,
       bindIp: params.BIND_NEW_IP
     }
   ];
@@ -68,7 +67,7 @@ async function ensureDockerNetworkConfig({
 }: {
   networkName: string;
   subnet: string;
-  dappmanagerIp: string;
+  dappmanagerIp?: string;
   bindIp: string;
 }): Promise<void> {
   // 1. create the new docker network

--- a/packages/params/src/params.ts
+++ b/packages/params/src/params.ts
@@ -131,7 +131,6 @@ export const params = {
   BIND_IP: "172.33.1.2",
   BIND_NEW_IP: "10.20.0.2",
   DAPPMANAGER_IP: "172.33.1.7",
-  DAPPMANAGER_NEW_IP: "10.20.0.7",
 
   // Docker compose parameters
   // Use of new compose file feature: network name


### PR DESCRIPTION
Set dappmanager IP 172.33.1.7 in `dncore_network`.
Set bind IP 172.33.1.2 in `dncore_network` and bind IP 10.20.0.2 in `dnprivate_network`

Thsi approach should ensure dappmanager container to always start without IP collision (the `dncore_network` subnet is big enough) and rely on dappmanager to ensure bind starts with proper IP