### PR TITLE
Switch docker networks order in daemon

### DIFF
--- a/packages/daemons/src/dockerNetworkConfigs/index.ts
+++ b/packages/daemons/src/dockerNetworkConfigs/index.ts
@@ -17,17 +17,21 @@ async function ensureDockerNetworkConfigs(
   signer: Signer,
   mevBoost: MevBoost
 ): Promise<void> {
+  /**
+   * Set first dnprivate_network and second dncore_network since its more likely to
+   * happen the IP collision while in the dncore_network is very unlikely to happen.
+   */
   const networksConfigs = [
+    {
+      networkName: params.DOCKER_PRIVATE_NETWORK_NEW_NAME,
+      subnet: params.DOCKER_NETWORK_NEW_SUBNET,
+      bindIp: params.BIND_NEW_IP
+    },
     {
       networkName: params.DOCKER_PRIVATE_NETWORK_NAME,
       subnet: params.DOCKER_NETWORK_SUBNET,
       dappmanagerIp: params.DAPPMANAGER_IP,
       bindIp: params.BIND_IP
-    },
-    {
-      networkName: params.DOCKER_PRIVATE_NETWORK_NEW_NAME,
-      subnet: params.DOCKER_NETWORK_NEW_SUBNET,
-      bindIp: params.BIND_NEW_IP
     }
   ];
 


### PR DESCRIPTION
Iterate first over the `dnprivate_network` and then over the `dncore_network` to avoid raising IP collision errors when starting containers.