### PR TITLE
Add debug mode for development environment

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -30,7 +30,10 @@ COPY package.json yarn.lock .yarnrc.yml tsconfig.json ./
 COPY packages packages
 
 # link instructions must be executed in runtime due to the way the volumes are mounted
-ENTRYPOINT ["/bin/sh", "-c", "ln -sf /app/packages/admin-ui/build/ /app/packages/dappmanager/dist && \
+ENTRYPOINT ["/bin/sh", "-lc", "\
+  ln -sf /app/packages/admin-ui/build/ /app/packages/dappmanager/dist && \
   ln -sf /usr/src/app/dnp_repo/ /app/packages/dappmanager && \
   ln -sf /usr/src/app/DNCORE/ /app/packages/dappmanager && \
-  yarn && yarn build && yarn run dev"]
+  yarn && yarn build && \
+  yarn workspace @dappnode/dappmanager run dev:debug \
+"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
     image: "dappmanager.dnp.dappnode.eth:0.2.71"
     container_name: DAppNodeCore-dappmanager.dnp.dappnode.eth
     restart: always
+    ports:
+      - 9229:9229
     volumes:
       - "/run/dbus/system_bus_socket:/run/dbus/system_bus_socket"
       - "dappmanagerdnpdappnodeeth_data:/usr/src/app/dnp_repo/"

--- a/packages/dappmanager/package.json
+++ b/packages/dappmanager/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "node dist/index.js",
     "dev": "tsx --watch src/index.ts",
+    "dev:debug": "NODE_ENV=development NODE_OPTIONS='--enable-source-maps' node --inspect-brk=0.0.0.0:9229 dist/index.js",
     "build": "tsc -p tsconfig.json",
     "watch-ts": "tsc -w",
     "file": "node",

--- a/vscode/launch.json
+++ b/vscode/launch.json
@@ -1,0 +1,32 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Attach: dappmanager (Docker 9229)",
+      "type": "node",
+      "request": "attach",
+      "address": "localhost",
+      "port": 9229,
+      "restart": true,
+      "sourceMaps": true,
+
+      // Map the whole repo to /app (covers all packages)
+      "localRoot": "${workspaceFolder}",
+      "remoteRoot": "/app",
+
+      // Only look at JS emitted by your server package to avoid noise
+      "outFiles": ["${workspaceFolder}/packages/*/dist/**/*.js"],
+      "skipFiles": ["<node_internals>/**", "**/node_modules/**"],
+
+      // 👇 Critical: rewrite any stale absolute prefixes to your local repo
+      "sourceMapPathOverrides": {
+        "/root/DNP_DAPPMANAGER/*": "${workspaceFolder}/*",
+        "/usr/src/app/*": "${workspaceFolder}/*",
+        "/app/*": "${workspaceFolder}/*"
+      },
+
+      // Uncomment to see mapping decisions if it still won’t bind:
+      "trace": true
+    }
+  ]
+}


### PR DESCRIPTION
Introduce a debug mode that allows for easier troubleshooting during development by enabling source maps and attaching a debugger on port 9229. Update entrypoint and scripts to support this feature.