### PR TITLE
Beacon api error validators

### DIFF
--- a/packages/admin-ui/src/__mock-backend__/index.ts
+++ b/packages/admin-ui/src/__mock-backend__/index.ts
@@ -445,8 +445,8 @@ export const otherCalls: Omit<Routes, keyof typeof namedSpacedCalls> = {
     hoodi: null
   }),
   validatorsFilterActiveByNetwork: async () => ({
-    mainnet: ["0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"],
-    hoodi: [],
+    mainnet: { validators: ["0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"] },
+    hoodi: { validators: [] },
     gnosis: null
   })
 };

--- a/packages/admin-ui/src/pages/premium/components/BackupNode.tsx
+++ b/packages/admin-ui/src/pages/premium/components/BackupNode.tsx
@@ -14,6 +14,7 @@ import {
   MdOutlineAccessTime,
   MdGroup,
   MdInfoOutline,
+  MdWarningAmber,
   MdErrorOutline
 } from "react-icons/md";
 import { SiEthereum } from "react-icons/si";
@@ -148,14 +149,33 @@ export function BackupNode({ isActivated: isPremium, hashedLicense }: { isActiva
             const count = data.count ?? 0;
             const exceeded = data.limitExceeded;
             const pct = validatorLimit ? Math.min((count / validatorLimit) * 100, 100) : 100;
+            const beaconApiError = data.beaconApiError;
 
             return (
               <div key={String(network)} className="premium-backup-validators-item">
                 <div className="premium-backup-validators-count-row">
-                  <strong className={exceeded ? "color-danger" : undefined}>{capitalize(network)}</strong>
                   <div>
-                    <MdGroup /> <span className={exceeded ? "color-danger" : undefined}>{data.count ?? "0"}</span> /{" "}
-                    {validatorLimit ?? "—"} validators
+                    <strong className={exceeded ? "color-danger" : undefined}>{capitalize(network) + " "} </strong>
+                  </div>
+                  <div>
+                    <MdGroup />{" "}
+                    <span className={exceeded ? "color-danger" : beaconApiError ? "color-warning" : undefined}>
+                      {data.count ?? "0"}
+                    </span>{" "}
+                    {beaconApiError && (
+                      <OverlayTrigger
+                        overlay={
+                          <Tooltip id="beacon-api-error">
+                            Error fetching validators status on {capitalize(network)} network. All keystores imported in
+                            your Web3Signer are being considered as active validators.
+                          </Tooltip>
+                        }
+                        placement="top"
+                      >
+                        <MdWarningAmber className="tooltip-beacon-api-error" />
+                      </OverlayTrigger>
+                    )}
+                    / {validatorLimit ?? "—"} validators
                   </div>
                 </div>
 

--- a/packages/admin-ui/src/pages/premium/components/backupNode.scss
+++ b/packages/admin-ui/src/pages/premium/components/backupNode.scss
@@ -125,8 +125,13 @@
         margin: 0 2px 2px 0;
       }
 
-      .color-danger {
+      .color-danger,
+      .color-warning {
         font-weight: bold;
+      }
+
+      .color-warning {
+        color: darkorange;
       }
 
       .premium-backup-validators-item {
@@ -139,6 +144,12 @@
           flex-direction: row;
           justify-content: space-between;
           align-items: center;
+
+          .tooltip-beacon-api-error {
+            margin-bottom: 3px;
+            font-size: 0.95rem;
+            color: darkorange;
+          }
         }
 
         .premium-backup-validators-limit-bar {
@@ -243,6 +254,10 @@
       .color-danger {
         color: red;
       }
+      .color-warning {
+        color: orange;
+      }
+
       .premium-backup-validators-card {
         .premium-backup-validators-limit-bar {
           background-color: var(--color-dark-background-main);
@@ -252,6 +267,9 @@
               background-color: red;
             }
           }
+        }
+        .tooltip-beacon-api-error {
+          color: orange;
         }
       }
       .premium-backup-error-card {

--- a/packages/dappmanager/src/calls/validatorsFilterActive.ts
+++ b/packages/dappmanager/src/calls/validatorsFilterActive.ts
@@ -55,8 +55,8 @@ export async function validatorsFilterActiveByNetwork({
   networks
 }: {
   networks: Network[];
-}): Promise<Partial<Record<Network, string[] | null>>> {
-  const result: Partial<Record<Network, string[] | null>> = {};
+}): Promise<Partial<Record<Network, { validators: string[]; beaconError?: Error } | null>>> {
+  const result: Partial<Record<Network, { validators: string[]; beaconError?: Error } | null>> = {};
 
   const keystoresByNetwork = await keystoresGetByNetwork({ networks });
 
@@ -80,10 +80,10 @@ export async function validatorsFilterActiveByNetwork({
       const activeSet = new Set(activeSets.flat());
       const activeInInputOrder = pubkeys.filter((pk) => activeSet.has(pk));
 
-      result[network] = activeInInputOrder; // could be []
+      result[network] = { validators: activeInInputOrder }; // could be []
     } catch (err) {
-      // If the beacon request fails for this network returns "null"
-      result[network] = null;
+      // If the beacon request fails for this network returns all the imported keystores
+      result[network] = { validators: pubkeys, beaconError: err as Error };
     }
   }
 

--- a/packages/types/src/routes.ts
+++ b/packages/types/src/routes.ts
@@ -813,7 +813,9 @@ export interface Routes {
    * Returns the active validators by network
    * @param networks Array of networks to retrieve its active validators
    */
-  validatorsFilterActiveByNetwork(kwargs: { networks: Network[] }): Promise<Partial<Record<Network, string[] | null>>>;
+  validatorsFilterActiveByNetwork(kwargs: {
+    networks: Network[];
+  }): Promise<Partial<Record<Network, { validators: string[]; beaconError?: Error } | null>>>;
 
   /**
    * Removes a docker volume by name


### PR DESCRIPTION
Now a warning tooltip is displayed explaining that all imported keystores are treated as "active validators" for the validator limit count if the request to the beacon API fails