### PR TITLE
Resolved core update notification

### DIFF
--- a/packages/admin-ui/src/components/NotificationsMain.tsx
+++ b/packages/admin-ui/src/components/NotificationsMain.tsx
@@ -33,6 +33,15 @@ export default function NotificationsView() {
     }
   }, [notificationsCall.data]);
 
+  //Revalidate every minute
+  useEffect(() => {
+    const interval = setInterval(() => {
+      notificationsCall.revalidate();
+    }, 60 * 1000); // Re-fecthes banner notifications every minute
+
+    return () => clearInterval(interval);
+  }, []);
+
   /**
    * filters notifications:
    * 1. Filters out notifications that have errors

--- a/packages/admin-ui/src/components/topbar/dropdownMenus/Notifications.tsx
+++ b/packages/admin-ui/src/components/topbar/dropdownMenus/Notifications.tsx
@@ -13,7 +13,7 @@ export default function Notifications() {
   useEffect(() => {
     const interval = setInterval(() => {
       unseenNotificationsReq.revalidate();
-    }, 60 * 1000); // Updates the new norifications "blue dot" every minute
+    }, 60 * 1000); // Updates the new notifications "blue dot" every minute
 
     return () => {
       clearInterval(interval);

--- a/packages/installer/src/calls/packageInstall.ts
+++ b/packages/installer/src/calls/packageInstall.ts
@@ -17,6 +17,7 @@ import { logs, getLogUi, logUiClear } from "@dappnode/logger";
 import { Routes } from "@dappnode/types";
 import { PackageRequest } from "@dappnode/types";
 import { DappnodeInstaller } from "../dappnodeInstaller.js";
+import { sendCoreInstalledResolvedNotification } from "../installer/sendCoreInstallResolvedNotification.js";
 
 /**
  * Installs a DAppNode Package.
@@ -98,6 +99,7 @@ export async function packageInstall(
 
       await postInstallClean(packagesData, log);
       afterInstall(dnpNames);
+      await sendCoreInstalledResolvedNotification(packagesData);
       logUiClear({ id });
     } catch (e) {
       afterInstall(dnpNames);

--- a/packages/installer/src/installer/sendCoreInstallResolvedNotification.ts
+++ b/packages/installer/src/installer/sendCoreInstallResolvedNotification.ts
@@ -1,27 +1,36 @@
 import { Category, InstallPackageData, Priority, Status } from "@dappnode/types";
 import { logs } from "@dappnode/logger";
 import { notifications } from "@dappnode/notifications";
+import { params } from "@dappnode/params";
 
 /**
  * Send resolved notification for core packages once installed
  * @param packagesData
  */
 export async function sendCoreInstalledResolvedNotification(packagesData: InstallPackageData[]): Promise<void> {
-  if (packagesData.some((p) => p.isCore)) {
-    for (const pkg of packagesData.filter((p) => p.isCore)) {
-      await notifications
-        .sendNotification({
-          title: `Installation of ${pkg.dnpName} completed`,
-          dnpName: pkg.dnpName,
-          body: `The installation of ${pkg.dnpName} (${pkg.semVersion}) has been completed successfully.`,
-          category: Category.system,
-          priority: Priority.low,
-          status: Status.resolved,
-          isBanner: false,
-          isRemote: false,
-          correlationId: "dappmanager-update-systemPkg"
-        })
-        .catch((e) => logs.error("Error sending core package installation notification", e));
-    }
+  if (packagesData.some((p) => p.dnpName === params.coreDnpName)) {
+    const title = "System update completed successfully";
+    const body = formatNotificationBody({ packages: packagesData });
+
+    await notifications
+      .sendNotification({
+        title: title,
+        dnpName: params.coreDnpName,
+        body: body,
+        category: Category.system,
+        priority: Priority.low,
+        status: Status.resolved,
+        isBanner: false,
+        isRemote: false,
+        correlationId: "dappmanager-update-systemPkg"
+      })
+      .catch((e) => logs.error("Error sending core package installation notification", e));
   }
+}
+
+function formatNotificationBody({ packages }: { packages: InstallPackageData[] }): string {
+  return [
+    "The installation of the following packages has been completed successfully:",
+    packages.map((p) => ` - ${p.dnpName}: ${p.semVersion}`).join("\n")
+  ].join("\n\n");
 }

--- a/packages/installer/src/installer/sendCoreInstallResolvedNotification.ts
+++ b/packages/installer/src/installer/sendCoreInstallResolvedNotification.ts
@@ -1,0 +1,27 @@
+import { Category, InstallPackageData, Priority, Status } from "@dappnode/types";
+import { logs } from "@dappnode/logger";
+import { notifications } from "@dappnode/notifications";
+
+/**
+ * Send resolved notification for core packages once installed
+ * @param packagesData
+ */
+export async function sendCoreInstalledResolvedNotification(packagesData: InstallPackageData[]): Promise<void> {
+  if (packagesData.some((p) => p.isCore)) {
+    for (const pkg of packagesData.filter((p) => p.isCore)) {
+      await notifications
+        .sendNotification({
+          title: `Installation of ${pkg.dnpName} completed`,
+          dnpName: pkg.dnpName,
+          body: `The installation of ${pkg.dnpName} (${pkg.semVersion}) has been completed successfully.`,
+          category: Category.system,
+          priority: Priority.low,
+          status: Status.resolved,
+          isBanner: false,
+          isRemote: false,
+          correlationId: "dappmanager-update-systemPkg"
+        })
+        .catch((e) => logs.error("Error sending core package installation notification", e));
+    }
+  }
+}


### PR DESCRIPTION
After a core update is completed, a "resolved core update" notification is sent, which removes the previously displayed "triggered core update" banner. This prevents confusion for users after a successful update. Additionally, banner notifications are now refreshed every minute to ensure they stay up to date.