### PR TITLE
Skip smart contract resolver name

### DIFF
--- a/packages/daemons/src/autoUpdates/updateMyPackages.ts
+++ b/packages/daemons/src/autoUpdates/updateMyPackages.ts
@@ -29,15 +29,6 @@ export async function checkNewPackagesVersion(dappnodeInstaller: DappnodeInstall
         continue;
       }
 
-      // MUST exist an APM repo with the package dnpName
-      // Check here instead of the if statement to be inside the try / catch
-      try {
-        await dappnodeInstaller.getRepoContract(dnpName);
-      } catch (e) {
-        logs.warn(`Error checking ${dnpName} version`, e);
-        continue;
-      }
-
       const { version: newVersion } = await dappnodeInstaller.getVersionAndIpfsHash({
         dnpNameOrHash: dnpName
       });


### PR DESCRIPTION
Skip smart contract resolver name when updating packages in auto update daemon. This would decrease significateively the total number of HTTP requests executed to the ETH node. From 400 to 100 HTTP requests
