### PR TITLE
fix Nested sub-routing

### DIFF
--- a/packages/admin-ui/src/components/SectionNavigator.tsx
+++ b/packages/admin-ui/src/components/SectionNavigator.tsx
@@ -30,7 +30,11 @@ export const SectionNavigator: React.FC<SectionNavbarProps> = ({ routes, hideNav
       <div className="section-spacing">
         <Routes>
           {routes.map((r) => (
-            <Route key={r.subPath} path={r.subPath} element={r.element} />
+            <React.Fragment key={r.subPath}>
+              <Route path={r.subPath} element={r.element} />
+              {/* catch sub-nested child routes */}
+              <Route path={`${r.subPath}/*`} element={r.element} />
+            </React.Fragment>
           ))}
         </Routes>
       </div>


### PR DESCRIPTION
Updating `SectionNavigator` component so it also catches sub-nested child routes. This fixes the VPN nested sub-routes not rendering bug.