### PR TITLE
Skip sdk build action if dependabot actor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: npx @dappnode/dappnodesdk github-action build
+      - name: Build
+        if: github.actor != 'dependabot[bot]'
+        run: npx @dappnode/dappnodesdk github-action build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PINATA_API_KEY: ${{ secrets.PINATA_API_KEY }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - "master"
+      - "develop"
       - "v[0-9]+.[0-9]+.[0-9]+"
     paths-ignore:
       - "README.md"


### PR DESCRIPTION
GitHub Actions does not pass organization or repository secrets to workflows triggered by Dependabot by default, for security reasons. The sdk action build requires some secrets