### PR TITLE
Potential fix for code scanning alert no. 8: Server-side request forgery

### DIFF
--- a/packages/dappmanager/src/calls/wireguard.ts
+++ b/packages/dappmanager/src/calls/wireguard.ts
@@ -53,6 +53,11 @@ class WireguardClient {
   // - local:     '/dappnode_admin?local'
   // - local qr:  '/dappnode_admin?local&qr'
   async getDeviceCredentials(device: string): Promise<WireguardDeviceCredentials> {
+    // SSRF fix: Only allow devices that exist in the allowed devices list
+    const devices = this.getDevices();
+    if (!devices.includes(device)) {
+      throw Error(`Device '${device}' is not registered or allowed`);
+    }
     const url = urlJoin(WIREGUARD_API_URL, device);
     const remoteConfigUrl = url;
     const localConfigUrl = `${url}?local=true`;


### PR DESCRIPTION
Potential fix for [https://github.com/dappnode/DNP_DAPPMANAGER/security/code-scanning/8](https://github.com/dappnode/DNP_DAPPMANAGER/security/code-scanning/8)

To fix the SSRF vulnerability, restrict the use of the `device` parameter when constructing outgoing URLs. The safest way is to only permit requests for devices that are already registered (i.e., present in the list returned by `getDevices()`), so unregistered or fabricated device names cannot be used to target arbitrary endpoints of the backend API service. Specifically, in `WireguardClient.getDeviceCredentials`, check if the passed device name is present in the wireguard devices list before constructing and calling the backend API endpoint. If the device is not permitted, throw an error.

**Files/regions to change:**  
- In `WireguardClient.getDeviceCredentials()` method (in `packages/dappmanager/src/calls/wireguard.ts`): Before URL construction and API calls, check that the device exists in the output of `getDevices()`.  
- No need to change validation regex, but placement and enforced existence must be checked.
- No changes in other files required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
