### PR TITLE
Fix: use header in ETH RPC requests

### DIFF
--- a/packages/toolkit/src/provider.ts
+++ b/packages/toolkit/src/provider.ts
@@ -27,7 +27,7 @@ export class MultiUrlJsonRpcProvider extends JsonRpcProvider {
       });
       return {
         url: ep.url,
-        provider: new JsonRpcProvider(ep.url, "mainnet", { staticNetwork: true }),
+        provider: new JsonRpcProvider(fetchRequest, "mainnet", { staticNetwork: true }),
         beaconchainUrl: ep.beaconchainUrl,
         type: ep.type
       };


### PR DESCRIPTION
Fix usage of header in HTTP requests to the RPC ethereum node