### PR TITLE
Throw error before calling `cleanup`

### DIFF
--- a/packages/installer/src/dappGet/aggregate/index.ts
+++ b/packages/installer/src/dappGet/aggregate/index.ts
@@ -82,13 +82,16 @@ export default async function aggregate({
     dappGetFetcher // #### Injected dependency
   });
 
+  // Clean up the dnps graph only once after all aggregation is done
+  // IMPORTANT: This must be done right after all dependencies are aggregated
+  cleanupDnps(dnps);
+
   // If no resolvable packages or dependencies were found, throw an error
   if (Object.keys(dnps).length === 0) {
-      throw new Error(`A dependency of the requested package "${req.name}" (version range: "${req.ver}") could not be resolved`);
+    throw new Error(
+      `A dependency of the requested package "${req.name}" (version range: "${req.ver}") could not be resolved`
+    );
   }
-
-  // Clean up the dnps graph only once after all aggregation is done
-  cleanupDnps(dnps);
 
   const relevantInstalledDnps = getRelevantInstalledDnps({
     // requestedDnps = ["A", "B", "C"]


### PR DESCRIPTION
Throw error before calling `cleanup` otherwise the exception where no dependency that satisfies the veresion range could be fetched is araised