### PR TITLE
fix tooltips

### DIFF
--- a/packages/admin-ui/src/pages/notifications/tabs/Devices/DevicesSubs.tsx
+++ b/packages/admin-ui/src/pages/notifications/tabs/Devices/DevicesSubs.tsx
@@ -170,7 +170,9 @@ function SubscriptionCard({
             <span>{sub.alias}</span>
             {browserSubEndpoint && browserSubEndpoint === sub.endpoint && (
               <OverlayTrigger overlay={<Tooltip id="current-device">Current Device</Tooltip>} placement="top">
-                <MdBeenhere className="current-tag" />
+                <span>
+                  <MdBeenhere className="current-tag" />
+                </span>
               </OverlayTrigger>
             )}
           </>

--- a/packages/admin-ui/src/pages/premium/components/BackupNode.tsx
+++ b/packages/admin-ui/src/pages/premium/components/BackupNode.tsx
@@ -89,7 +89,9 @@ export function BackupNode({ isActivated: isPremium, hashedLicense }: { isActiva
           }
           placement="top"
         >
-          <MdInfoOutline className="tooltip-icon" />
+          <span>
+            <MdInfoOutline className="tooltip-icon" />
+          </span>
         </OverlayTrigger>
       </h5>
 
@@ -140,9 +142,10 @@ export function BackupNode({ isActivated: isPremium, hashedLicense }: { isActiva
                 The number of active validators per network supported by the backup service
               </Tooltip>
             }
-            placement="top"
           >
-            <MdInfoOutline className="tooltip-icon" />
+            <span>
+              <MdInfoOutline className="tooltip-icon" />
+            </span>
           </OverlayTrigger>
         </h5>
 
@@ -176,7 +179,9 @@ export function BackupNode({ isActivated: isPremium, hashedLicense }: { isActiva
                         }
                         placement="top"
                       >
-                        <MdWarningAmber className="tooltip-beacon-api-error" />
+                        <span>
+                          <MdWarningAmber className="tooltip-beacon-api-error" />
+                        </span>
                       </OverlayTrigger>
                     )}
                     / {validatorLimit ?? "—"} validators


### PR DESCRIPTION
Wrap icons in a `<span>` so `OverlayTrigger` has a real DOM node to attach. React-Bootstrap v2 tooltips need their child to accept a ref. SVG icon components often don’t, so the `span` fixes hover/focus behavior