### PR TITLE
Dappstore single category filtering

### DIFF
--- a/packages/admin-ui/src/pages/installer/components/aiDappstore/InstallerAiBanner.tsx
+++ b/packages/admin-ui/src/pages/installer/components/aiDappstore/InstallerAiBanner.tsx
@@ -1,25 +1,18 @@
 import Card from "components/Card";
 import React from "react";
-import { SelectedCategories } from "pages/installer/types";
 import aiStars from "img/ai_stars.png";
 import "./installerAiBanner.scss";
 
-export function InstallerAIBanner({
-  selectedCategories,
-  setSelectedCategories
-}: {
-  selectedCategories: SelectedCategories;
-  setSelectedCategories: (categories: SelectedCategories) => void;
-}) {
+export function InstallerAIBanner({ onCategoryChange }: { onCategoryChange: (category: string) => void }) {
   return (
-    <div className="installer-ai-banner group">
+    <div
+      className="installer-ai-banner group"
+      onClick={() => {
+        onCategoryChange("AI");
+      }}
+    >
       <Card>
-        <div
-          className="ai-banner-row"
-          onClick={() => {
-            setSelectedCategories({ ...selectedCategories, AI: !selectedCategories.AI });
-          }}
-        >
+        <div className="ai-banner-row">
           <img src={aiStars} alt="AI DAppNode Installer Banner" width={50} height={50} />
           <div>
             <h2>AI Toolkit</h2>

--- a/packages/admin-ui/src/pages/installer/components/dappnodeDappstore/InstallerDnp.tsx
+++ b/packages/admin-ui/src/pages/installer/components/dappnodeDappstore/InstallerDnp.tsx
@@ -93,8 +93,19 @@ export const InstallerDnp: React.FC = () => {
     }
   }
 
+  // Toggle category: sets only one category to true at a time
   function onCategoryChange(category: string) {
-    setSelectedCategories((x) => ({ ...x, [category]: !x[category] }));
+    setSelectedCategories((x) => {
+      const newCategories = { ...x, [category]: !x[category] };
+
+      // If the category has been set to true, set all others to false
+      if (newCategories[category]) {
+        Object.keys(newCategories).forEach((key) => {
+          if (key !== category) newCategories[key] = false;
+        });
+      }
+      return newCategories;
+    });
   }
 
   const directoryFiltered = filterDirectory({
@@ -148,12 +159,7 @@ export const InstallerDnp: React.FC = () => {
           <NoPackageFound query={query} />
         ) : (
           <>
-            {!selectedCategories.AI && (
-              <InstallerAIBanner
-                selectedCategories={selectedCategories}
-                setSelectedCategories={setSelectedCategories}
-              />
-            )}
+            {!selectedCategories.AI && <InstallerAIBanner onCategoryChange={onCategoryChange} />}
             <div className="dnps-container">
               {/* <DnpStore directory={dnpsFeatured} openDnp={openDnp} featured /> */}
               <DnpStore directory={dnpsNormal} openDnp={openDnp} />

--- a/packages/admin-ui/src/pages/installer/helpers/filterDirectory.ts
+++ b/packages/admin-ui/src/pages/installer/helpers/filterDirectory.ts
@@ -25,14 +25,19 @@ export default function filterDirectory({
   query: string;
   selectedCategories: SelectedCategories;
 }): DirectoryItem[] {
-  const isSomeCategorySelected = Object.values(selectedCategories).reduce((acc, val) => acc || val, false);
+  const selected = Object.keys(selectedCategories).filter((key) => selectedCategories[key]);
+  const isAnyCategorySelected = selected.length > 0;
+
   return directory
     .filter((dnp) => !query || includesSafe(dnp, query))
-    .filter(
-      (dnp) =>
-        !isSomeCategorySelected ||
-        (dnp.status === "ok" && (dnp.categories || []).some((category) => selectedCategories[category]))
-    );
+    .filter((dnp) => {
+      if (!isAnyCategorySelected) return true;
+      if (dnp.status !== "ok") return false;
+
+      const dnpCategories = dnp.categories || [];
+      // Must contain *any* selected categories
+      return selected.some((cat) => dnpCategories.includes(cat));
+    });
 }
 
 /**


### PR DESCRIPTION
Now the Dappstore's category filter works as **Single-category selection** (Only one category can be selected at a time), instead of **Inclusive categories selection** (Selecting multiple categories shows all packages that belong to at least one of the selected categories)