### PR TITLE
Local proxy warning banner

### DIFF
--- a/packages/admin-ui/src/App.tsx
+++ b/packages/admin-ui/src/App.tsx
@@ -18,6 +18,7 @@ import { NoConnection } from "start-pages/NoConnection";
 import { AppContextIface, Theme } from "types";
 import Smooth from "components/Smooth";
 import { PwaPermissionsAlert, PwaPermissionsModal } from "components/PwaPermissions";
+import { LocalProxyBanner } from "pages/wifi/components/localProxying/LocalProxyBanner";
 
 export const AppContext = React.createContext<AppContextIface>({
   theme: "light",
@@ -89,6 +90,7 @@ function MainApp({ username }: { username: string }) {
         <TopBar username={username} appContext={appContext} />
         <div id="main">
           <ErrorBoundary>
+            <LocalProxyBanner />
             <NotificationsMain />
           </ErrorBoundary>
           <PwaPermissionsAlert />

--- a/packages/admin-ui/src/pages/wifi/components/localProxying/LocalProxyBanner.tsx
+++ b/packages/admin-ui/src/pages/wifi/components/localProxying/LocalProxyBanner.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { Alert } from "react-bootstrap";
+import { adminUiLocalDomain } from "params";
+
+export function LocalProxyBanner() {
+  return (
+    window.location.origin === adminUiLocalDomain && (
+      <Alert variant="danger">
+        <Alert.Heading>Local Proxy Connection</Alert.Heading>
+        <div>
+          Local proxy is less reliable and only gives access to the Dappmanager UI. It won't load other Dappnode
+          services. Use it <b>only as a fallback</b> method.
+        </div>
+      </Alert>
+    )
+  );
+}

--- a/packages/admin-ui/src/pages/wifi/components/localProxying/LocalProxying.tsx
+++ b/packages/admin-ui/src/pages/wifi/components/localProxying/LocalProxying.tsx
@@ -75,15 +75,14 @@ export function LocalProxying() {
     <>
       {localProxyingStatus.data ? (
         <>
-          {window.location.origin !== adminUiLocalDomain && (
-            <AlertDismissible variant="warning">
-              <p>
-                Note that connecting via local proxy is less reliable than using a VPN or Wi-fi hotspot. The local proxy
-                only provides access to the Dappmanager UI and does not grant access to other domains served through
-                your Dappnode, such as client interfaces or other package UIs.
-              </p>
-            </AlertDismissible>
-          )}
+          <AlertDismissible variant="warning">
+            <p>
+              Note that connecting via local proxy is less reliable than using a VPN or Wi-fi hotspot, and should be
+              used <b>only as a fallback</b> method. It only provides access to the Dappmanager UI and does not grant
+              access to other domains served through your Dappnode, such as client interfaces or other package UIs.
+            </p>
+          </AlertDismissible>
+
           <Card spacing>
             <p>
               If you are connected to the same router as your Dappnode you can use this page at{" "}


### PR DESCRIPTION
Adding a warning banner across all tabs to inform users that the local proxy connection should only be used as a fallback. The banner appears only when the user is connected through the local proxy.