### PR TITLE
Add missing core package names to coreDnpNames array

### DIFF
--- a/packages/utils/src/getIsCore.ts
+++ b/packages/utils/src/getIsCore.ts
@@ -15,5 +15,7 @@ const coreDnpNames = [
   params.wifiDnpName,
   params.bindDnpName,
   params.ipfsDnpName,
-  params.HTTPS_PORTAL_DNPNAME
+  params.HTTPS_PORTAL_DNPNAME,
+  params.notificationsDnpName,
+  params.PREMIUM_DNP_NAME
 ];


### PR DESCRIPTION
## Context

> This update adds missing core package names to the coreDnpNames array, ensuring that all relevant DAppNode packages are included.

## Approach

> The solution involves appending the notificationsDnpName and PREMIUM_DNP_NAME to the existing coreDnpNames array.
