### PR TITLE
update checkpoint sync & ipfs URLS

### DIFF
--- a/packages/admin-ui/src/__mock-backend__/index.ts
+++ b/packages/admin-ui/src/__mock-backend__/index.ts
@@ -224,7 +224,7 @@ export const otherCalls: Omit<Routes, keyof typeof namedSpacedCalls> = {
   ipfsClientTargetSet: async () => {},
   ipfsClientTargetGet: async () => ({
     ipfsClientTarget: IpfsClientTarget.remote,
-    ipfsGateway: "https://gateway.ipfs.dappnode.io"
+    ipfsGateway: "https://ipfs-gateway.dappnode.net"
   }),
   enableEthicalMetrics: async () => {},
   getEthicalMetricsConfig: async () => ({

--- a/packages/admin-ui/src/components/IpfsClient.tsx
+++ b/packages/admin-ui/src/components/IpfsClient.tsx
@@ -67,7 +67,7 @@ export function IpfsClient({
 
               {option === "remote" && (
                 <Input
-                  placeholder="https://gateway.ipfs.dappnode.io"
+                  placeholder="https://ipfs-gateway.dappnode.net"
                   value={gatewayTarget || ""}
                   onValueChange={onGatewayTargetChange}
                 />

--- a/packages/admin-ui/src/params.ts
+++ b/packages/admin-ui/src/params.ts
@@ -147,7 +147,7 @@ export const dappnodeVolumeGroup = "rootvg";
 export const dappnodeLogicalVolume = "root";
 
 // IPFS
-export const IPFS_DAPPNODE_GATEWAY = "https://gateway.ipfs.dappnode.io";
+export const IPFS_DAPPNODE_GATEWAY = "https://ipfs-gateway.dappnode.net";
 export const IPFS_GATEWAY_CHECKER = "https://ipfs.github.io/public-gateway-checker/";
 
 // VPN

--- a/packages/daemons/src/repositoryHealth/index.ts
+++ b/packages/daemons/src/repositoryHealth/index.ts
@@ -25,7 +25,7 @@ async function checkIpfsHealth(): Promise<void> {
 
   try {
     // check health by fetching CID of empty directory QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn. Most of ipfs nodes should have it.
-    // checked against: https://ipfs.io https://gateway-dev.ipfs.dappnode.io https://gateway.ipfs.dappnode.io
+    // checked against: https://ipfs.io https://gateway-dev.ipfs.dappnode.io https://ipfs-gateway.dappnode.net
     const res = await fetch(`${ipfsUrl}/ipfs/QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn`, {
       method: "GET",
       headers: { "Content-Type": "application/json" },

--- a/packages/dockerApi/test/unit/parseContainerInfo.test.ts
+++ b/packages/dockerApi/test/unit/parseContainerInfo.test.ts
@@ -384,7 +384,7 @@ describe("modules / docker / parseContainerInfo", function () {
         running: true,
         exitCode: null,
         dependencies: {},
-        avatarUrl: "https://gateway.ipfs.dappnode.io/ipfs/QmQnHxr4YAVdtqzHnsDYvmXizxptSYyaj3YwTjoiLshVwF",
+        avatarUrl: "https://ipfs-gateway.dappnode.net/ipfs/QmQnHxr4YAVdtqzHnsDYvmXizxptSYyaj3YwTjoiLshVwF",
         origin: "/ipfs/QmeBfnwgsNcEmbmxENBWtgkv5YZsAhiaDsoYd7nMTV1wKV",
         chain: "ethereum",
         canBeFullnode: false,
@@ -765,7 +765,7 @@ describe("modules / docker / parseContainerInfo", function () {
         canBeFullnode: false
       },
       {
-        avatarUrl: "https://gateway.ipfs.dappnode.io/ipfs/QmaZZVsVqaWwVLe36HhvKj3QEPt7hM1GL8kemNvsZd5F5x",
+        avatarUrl: "https://ipfs-gateway.dappnode.net/ipfs/QmaZZVsVqaWwVLe36HhvKj3QEPt7hM1GL8kemNvsZd5F5x",
         canBeFullnode: false,
         containerId: "ba4765113dd6016da8b35dfe367493186f3bfd34d88eca03ccf894f7045710fa",
         containerName: "DAppNodePackage-grafana.dms.dnp.dappnode.eth",

--- a/packages/params/src/params.ts
+++ b/packages/params/src/params.ts
@@ -165,11 +165,11 @@ export const params = {
   IPFS_HOST: process.env.IPFS_HOST || process.env.IPFS_REDIRECT,
   IPFS_TIMEOUT: 0.5 * MINUTE,
   IPFS_LOCAL: "http://ipfs.dappnode:8080",
-  IPFS_REMOTE: "https://gateway.ipfs.dappnode.io",
+  IPFS_REMOTE: "https://ipfs-gateway.dappnode.net",
 
   // Web3 parameters
   ETH_MAINNET_RPC_URL_REMOTE: process.env.ETH_MAINNET_RPC_URL_REMOTE || "https://web3.dappnode.net",
-  ETH_MAINNET_CHECKPOINTSYNC_URL_REMOTE: "https://checkpoint-sync.dappnode.io",
+  ETH_MAINNET_CHECKPOINTSYNC_URL_REMOTE: "https://checkpoint-sync.dappnode.net",
 
   // Prysm legacy specs for: prater, gnosis and mainnet
   prysmLegacySpecs: [

--- a/packages/toolkit/test/repository/repository.test.ts
+++ b/packages/toolkit/test/repository/repository.test.ts
@@ -10,7 +10,7 @@ import { ethers } from "ethers";
 describe.skip("Dappnode Repository", function () {
   const ipfsUrls = [
     //"https://api.ipfs.dappnode.io",
-    "https://gateway.ipfs.dappnode.io"
+    "https://ipfs-gateway.dappnode.net"
   ];
 
   const prysmDnpName = "prysm.dnp.dappnode.eth";

--- a/packages/utils/src/stakerUtils.ts
+++ b/packages/utils/src/stakerUtils.ts
@@ -44,18 +44,18 @@ export function getDefaultConsensusUserSettings({ network }: { network: Network 
 
 const getDefaultCheckpointSync = (network: Network): string =>
   network === "mainnet"
-    ? "https://checkpoint-sync.dappnode.io"
+    ? "https://checkpoint-sync.dappnode.net"
     : network === "prater"
-      ? "https://checkpoint-sync-prater.dappnode.io"
+      ? "https://checkpoint-sync-prater.dappnode.net"
       : network === "gnosis"
-        ? "https://checkpoint-sync-gnosis.dappnode.io"
+        ? "https://checkpoint-sync-gnosis.dappnode.net"
         : network === "holesky"
-          ? "https://checkpoint-sync-holesky.dappnode.io"
+          ? "https://checkpoint-sync-holesky.dappnode.net"
           : network === "hoodi"
-            ? "https://checkpoint-sync-hoodi.dappnode.io"
+            ? "https://checkpoint-sync-hoodi.dappnode.net"
             : network === "lukso"
               ? "https://checkpoints.mainnet.lukso.network"
               : network === "sepolia"
-                ? "https://checkpoint-sync.sepolia.ethpandaops.io"
+                ? "https://checkpoint-sync-sepolia.dappnode.net"
                 : "";
                 


### PR DESCRIPTION
This pull request updates all references to the Dappnode IPFS gateway and checkpoint sync endpoints throughout the codebase to use the new `*.dappnode.net` domain, replacing the previous `*.dappnode.io` addresses. 