### PR TITLE
Add SKIP_COMPOSE_VALIDATION support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       - IPFS_HOST=
       - DISABLE_UPNP=
       - ALWAYS_DAPPGETBASIC=
+      - SKIP_COMPOSE_VALIDATION=
     networks:
       dncore_network:
         aliases:

--- a/packages/schemas/src/params.ts
+++ b/packages/schemas/src/params.ts
@@ -29,5 +29,6 @@ export const dockerParams = {
     "bind.dappnode"
   ],
   DNS_SERVICE: "172.33.1.2",
-  MINIMUM_COMPOSE_FILE_VERSION: "3.4"
+  MINIMUM_COMPOSE_FILE_VERSION: "3.4",
+  SKIP_COMPOSE_VALIDATION: /true/i.test(process.env.SKIP_COMPOSE_VALIDATION || "")
 };

--- a/packages/schemas/src/validateDappnodeCompose.ts
+++ b/packages/schemas/src/validateDappnodeCompose.ts
@@ -14,6 +14,14 @@ function err(msg: string): void {
  * @param param0
  */
 export function validateDappnodeCompose(compose: Compose, manifest: Manifest): void {
+  // Skip validation if SKIP_COMPOSE_VALIDATION is set to true
+  if (dockerParams.SKIP_COMPOSE_VALIDATION) {
+    console.log(
+      `[WARN] Skipping compose validation for ${manifest.name} because SKIP_COMPOSE_VALIDATION is set to true`
+    );
+    return;
+  }
+
   // clean the errors
   aggregatedError = [];
   const isCore = manifest.type === "dncore";


### PR DESCRIPTION
## Context

> This PR introduces a new environment variable, `SKIP_COMPOSE_VALIDATION`, allowing users to bypass Docker Compose validation. This feature is useful for scenarios where validation may not be necessary.

## Approach

> The implementation checks for the `SKIP_COMPOSE_VALIDATION` variable and skips the validation process if it is set to true, providing a warning message in the console.

## Test instructions

<!-- MANDATORY: please, do not skip this step, it is very important for DAppNode team to have simple and well defined instructions on how to test this PR.
-->

