### PR TITLE
Add env `TEST` to compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - DISABLE_UPNP=
       - ALWAYS_DAPPGETBASIC=
       - SKIP_COMPOSE_VALIDATION=
-      - DEV=
+      - TEST=
     networks:
       dncore_network:
         aliases:


### PR DESCRIPTION
Add env `TEST` to compose file so it does not get removed in core updates. This env is required by the github self hosted runner in charge of running the staker pkgs integration tests

