### PR TITLE
improve CI workflow timing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "22"
+          cache: "yarn"
       - run: yarn
       - run: yarn build
       - run: yarn test

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -39,6 +39,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "22"
+          cache: "yarn"
           registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies and build

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,20 +9,34 @@ COPY .git dappnode_package.json docker/getGitData.js ./
 RUN apk add --no-cache git
 RUN node getGitData /usr/src/app/.git-data.json
 
+# Extract only package.json files to preserve dependency layer cache
+FROM ${BASE_IMAGE} AS manifests
+WORKDIR /app
+COPY packages packages
+RUN find packages -mindepth 2 ! -name "package.json" -delete 2>/dev/null; \
+    find packages -empty -delete 2>/dev/null; true
+
 # Build stage
 FROM ${BASE_IMAGE} AS build-src
 ENV VITE_APP_API_URL /
 WORKDIR /app
 
-# Copy and build packages
-COPY package.json yarn.lock .yarnrc.yml tsconfig.json ./
-COPY packages packages
+# Copy dependency manifests only (changes less often, preserves layer cache)
+COPY package.json yarn.lock .yarnrc.yml ./
+COPY --from=manifests /app/packages ./packages
 
 # Install necessary packages required by vite
 RUN apk add --no-cache python3 py3-pip build-base
 # Install corepack to be able to use modern yarn berry
 RUN corepack enable
+
+# Since we copied dependency manifests only, if there are changes in source code,
+# that don't change dependencies, we can reuse the cached layer with installed dependencies.
 RUN yarn install --immutable
+
+# Copy source code and build 
+COPY tsconfig.json ./
+COPY packages packages
 # Build and install production dependencies
 RUN yarn build && \
   yarn workspaces focus --all --production


### PR DESCRIPTION
Improves CI workflow and Docker build process to optimize dependency caching and reduce build times.

Main changes:
- cache Yarn uses in main and npm workflows
- Reestructure Dockerfile to enable layer caching

**CI workflow improvements:**

- Enabled Yarn caching in GitHub Actions by adding the `cache: "yarn"` option to the `setup-node` steps in both `.github/workflows/main.yml` and `.github/workflows/npm.yml`, which helps speed up dependency installation in CI runs. [[1]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R32) [[2]](diffhunk://#diff-8369a85f6d69dea9f5c38438cfcca793a8ee5aa308219e2d1a38f868b236f09aR42)

**Docker build optimization:**

- Refactored the `Dockerfile` to extract only `package.json` files from each workspace into a separate build stage (`manifests`), allowing Docker to cache dependency installation layers more effectively.
- Updated the build stage to first copy only dependency manifests, run `yarn install --immutable`, and then copy the full source code, ensuring that dependency installation is only re-run when manifest files change, not when source files change.