### PR TITLE
Add support for SKIP_COMPOSE_VALIDATION and update dependencies

### DIFF
--- a/packages/dockerCompose/package.json
+++ b/packages/dockerCompose/package.json
@@ -18,6 +18,7 @@
     "dev": "tsc -w"
   },
   "dependencies": {
+    "@dappnode/schemas": "workspace:^0.1.0",
     "@dappnode/types": "workspace:^0.1.0",
     "@dappnode/utils": "workspace:^0.1.0",
     "lodash-es": "^4.17.21"

--- a/packages/dockerCompose/src/setDappnodeComposeDefaults.ts
+++ b/packages/dockerCompose/src/setDappnodeComposeDefaults.ts
@@ -1,6 +1,7 @@
 import { mapValues, toPairs, sortBy, fromPairs, pick } from "lodash-es";
 import { getPrivateNetworkAliases, getIsCore, parseEnvironment, getIsMonoService } from "@dappnode/utils";
 import { params } from "@dappnode/params";
+import { dockerParams } from "@dappnode/schemas";
 import { cleanCompose } from "./clean.js";
 import { parseServiceNetworks } from "./networks.js";
 import {
@@ -28,6 +29,13 @@ export function setDappnodeComposeDefaults(composeUnsafe: Compose, manifest: Man
     version: ensureMinimumComposeVersion(composeUnsafe.version),
 
     services: mapValues(composeUnsafe.services, (serviceUnsafe, serviceName) => {
+      const pickedServiceKeys = dockerParams.SKIP_COMPOSE_VALIDATION
+        ? serviceUnsafe
+        : pick(
+            serviceUnsafe,
+            dockerComposeSafeKeys.filter((safeKey) => safeKey !== "build")
+          );
+
       return sortServiceKeys({
         // OVERRIDABLE VALUES: values that in case of not been set, it will take the following values
         logging: {
@@ -40,10 +48,7 @@ export function setDappnodeComposeDefaults(composeUnsafe: Compose, manifest: Man
         restart: "unless-stopped",
 
         // SAFE KEYS: values that are whitelisted
-        ...pick(
-          serviceUnsafe,
-          dockerComposeSafeKeys.filter((safeKey) => safeKey !== "build")
-        ),
+        ...pickedServiceKeys,
 
         // MANDATORY VALUES: values that will be overwritten with dappnode defaults
         container_name: getContainerName({ dnpName, serviceName, isCore }),

--- a/packages/dockerCompose/test/unit/helpers/checkSkipComposeValidationPick.ts
+++ b/packages/dockerCompose/test/unit/helpers/checkSkipComposeValidationPick.ts
@@ -1,0 +1,47 @@
+import { Compose, Manifest } from "@dappnode/types";
+import { setDappnodeComposeDefaults } from "../../../src/setDappnodeComposeDefaults.js";
+
+const expectedEnvFilePresent = process.argv[2] === "true";
+
+const manifest: Manifest = {
+  name: "some-package.dnp.dappnode.eth",
+  version: "0.1.0",
+  type: "service",
+  architectures: ["linux/amd64"]
+};
+
+const composeWithNonWhitelistedKey: Compose = {
+  version: "3.5",
+  services: {
+    app: {
+      image: "app.some-package.dnp.dappnode.eth:0.1.0",
+      // Non-whitelisted key (NOT in dockerComposeSafeKeys)
+      env_file: ["./secrets.env"],
+      environment: {
+        FOO: "bar"
+      }
+    }
+  },
+  volumes: {
+    appdata: {}
+  }
+};
+
+const safeCompose = setDappnodeComposeDefaults(composeWithNonWhitelistedKey, manifest);
+const envFilePresent = Object.prototype.hasOwnProperty.call(safeCompose.services.app, "env_file");
+
+if (envFilePresent !== expectedEnvFilePresent) {
+  console.error(
+    JSON.stringify(
+      {
+        SKIP_COMPOSE_VALIDATION: process.env.SKIP_COMPOSE_VALIDATION,
+        expectedEnvFilePresent,
+        envFilePresent,
+        serviceKeys: Object.keys(safeCompose.services.app)
+      },
+      null,
+      2
+    )
+  );
+  process.exit(1);
+}

--- a/packages/dockerCompose/test/unit/skipComposeValidationPick.test.ts
+++ b/packages/dockerCompose/test/unit/skipComposeValidationPick.test.ts
@@ -1,0 +1,40 @@
+import "mocha";
+import { expect } from "chai";
+import { spawnSync } from "child_process";
+
+describe("setDappnodeComposeDefaults respects SKIP_COMPOSE_VALIDATION", () => {
+  function runCheck({
+    skipComposeValidation,
+    expectEnvFile
+  }: {
+    skipComposeValidation: string;
+    expectEnvFile: boolean;
+  }) {
+    const helperUrl = new URL("./helpers/checkSkipComposeValidationPick.ts", import.meta.url);
+    const helperPath = helperUrl.pathname;
+
+    const res = spawnSync(
+      process.execPath,
+      ["--experimental-specifier-resolution=node", "--import=tsx/esm", helperPath, String(expectEnvFile)],
+      {
+        env: {
+          ...process.env,
+          SKIP_COMPOSE_VALIDATION: skipComposeValidation
+        },
+        encoding: "utf8"
+      }
+    );
+
+    if (res.status !== 0) {
+      throw new Error(`child process failed\nstdout:\n${res.stdout || ""}\nstderr:\n${res.stderr || ""}`);
+    }
+  }
+
+  it("picks non-whitelisted keys when SKIP_COMPOSE_VALIDATION=true", () => {
+    expect(() => runCheck({ skipComposeValidation: "true", expectEnvFile: true })).to.not.throw();
+  });
+
+  it("does not pick non-whitelisted keys when SKIP_COMPOSE_VALIDATION=false", () => {
+    expect(() => runCheck({ skipComposeValidation: "false", expectEnvFile: false })).to.not.throw();
+  });
+});

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -3,3 +3,4 @@ export { validateManifestSchema } from "./validateManifestSchema.js";
 export { validateSetupWizardSchema } from "./validateSetupWizardSchema.js";
 export { validateDappnodeCompose } from "./validateDappnodeCompose.js";
 export { validateNotificationsSchema } from "./validateNotificationsSchema.js";
+export { dockerParams } from "./params.js";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1162,6 +1162,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@dappnode/dockercompose@workspace:packages/dockerCompose"
   dependencies:
+    "@dappnode/schemas": "workspace:^0.1.0"
     "@dappnode/types": "workspace:^0.1.0"
     "@dappnode/utils": "workspace:^0.1.0"
     "@types/lodash-es": "npm:^4.17.9"


### PR DESCRIPTION
## Context

This update introduces support for the `SKIP_COMPOSE_VALIDATION` environment variable, allowing non-whitelisted keys in Docker Compose configurations. It also updates dependencies to ensure compatibility with the latest versions.

## Approach

The solution modifies the `setDappnodeComposeDefaults` function to conditionally include non-whitelisted keys based on the `SKIP_COMPOSE_VALIDATION` variable. Additionally, it adds tests to verify this new behavior.

## Test instructions

1. Set the `SKIP_COMPOSE_VALIDATION` environment variable to `true` or `false`.
2. Run the tests to ensure that the behavior of including or excluding non-whitelisted keys works as expected.
3. Verify that the application functions correctly with the updated dependencies.

