### PR TITLE
mirror content provider

### DIFF
--- a/packages/installer/src/dappnodeInstaller.ts
+++ b/packages/installer/src/dappnodeInstaller.ts
@@ -46,7 +46,15 @@ export function getIpfsUrl(): string {
 
 export class DappnodeInstaller extends DappnodeRepository {
   constructor(ipfsUrl: string, provider: JsonRpcApiProvider) {
-    super(ipfsUrl, provider);
+    super(ipfsUrl, provider, {
+      mirror: params.CONTENT_MIRROR_BASE_URL
+        ? {
+            baseUrl: params.CONTENT_MIRROR_BASE_URL,
+            timeoutMs: params.CONTENT_MIRROR_TIMEOUT_MS,
+            maxBytes: params.CONTENT_MIRROR_MAX_BYTES
+          }
+        : undefined
+    });
   }
 
   private async updateProviders(): Promise<void> {

--- a/packages/installer/src/installer/downloadImages.ts
+++ b/packages/installer/src/installer/downloadImages.ts
@@ -68,13 +68,14 @@ export async function downloadImage(
   hash: string,
   path: string,
   fileSize: number,
-  progress: (n: number) => void
+  progress: (n: number) => void,
+  filename?: string
 ): Promise<void> {
   // TODO: Ensure file is available
 
   // Cat stream to file system
   // Make sure the path is correct and the parent folder exist or is created
-  await dappnodeInstaller.writeFileToFs({ hash, path, fileSize, progress });
+  await dappnodeInstaller.writeFileToFs({ hash, path, fileSize, progress, filename });
 }
 
 export async function getImage(
@@ -96,11 +97,11 @@ export async function getImage(
     logs.debug(`Image at ${path} is invalid: ${e}`);
   }
 
-  const { hash, size } = imageFile;
+  const { hash, size, filename } = imageFile;
 
   switch (imageFile.source) {
     case "ipfs":
-      await downloadImage(dappnodeInstaller, hash, path, size, progress);
+      await downloadImage(dappnodeInstaller, hash, path, size, progress, filename);
       break;
     default:
       throw Error(`Unsupported source ${imageFile.source}`);

--- a/packages/params/src/params.ts
+++ b/packages/params/src/params.ts
@@ -169,6 +169,11 @@ export const params = {
   IPFS_LOCAL: "http://ipfs.dappnode:8080",
   IPFS_REMOTE: "https://ipfs-gateway.dappnode.net",
 
+  // Mirror provider configuration (optional HTTP fallback for IPFS)
+  CONTENT_MIRROR_BASE_URL: process.env.CONTENT_MIRROR_BASE_URL || "https://packages.dappnode.net",
+  CONTENT_MIRROR_TIMEOUT_MS: parseInt(process.env.CONTENT_MIRROR_TIMEOUT_MS || "1800000", 10), // 30 minutes default for large Docker images
+  CONTENT_MIRROR_MAX_BYTES: parseInt(process.env.CONTENT_MIRROR_MAX_BYTES || "10737418240", 10), // 10GB default
+
   // Web3 parameters
   ETH_MAINNET_RPC_URL_REMOTE: process.env.ETH_MAINNET_RPC_URL_REMOTE || "https://web3.dappnode.net",
   ETH_MAINNET_CHECKPOINTSYNC_URL_REMOTE: "https://checkpoint-sync.dappnode.net",

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -27,6 +27,7 @@
     "tsconfig-paths": "^4.2.0"
   },
   "dependencies": {
+    "@dappnode/logger": "workspace:^0.1.0",
     "@dappnode/types": "workspace:^0.1.0",
     "@ipld/car": "^5.4.0",
     "esm": "^3.2.25",

--- a/packages/toolkit/src/repository/contentProvider/index.ts
+++ b/packages/toolkit/src/repository/contentProvider/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Content Provider module for HTTP mirror support
+ *
+ * Provides HTTP-based alternative to IPFS for improved reliability and speed
+ */
+
+export * from "./types.js";
+export * from "./mirrorProvider.js";
+export * from "./utils.js";

--- a/packages/toolkit/src/repository/contentProvider/mirrorProvider.ts
+++ b/packages/toolkit/src/repository/contentProvider/mirrorProvider.ts
@@ -1,0 +1,258 @@
+import { MirrorProvider, MirrorListEntry, MirrorFetchResult, FetchOptions } from "./types.js";
+import { normalizeCid, roundProgress } from "./utils.js";
+
+/**
+ * HTTP-based mirror provider implementation
+ *
+ * Fetches IPFS content from an HTTP mirror service for improved reliability and speed.
+ * Falls back to IPFS when content is unavailable on the mirror.
+ */
+export class HttpMirrorProvider implements MirrorProvider {
+  private baseUrl: string;
+  private timeoutMs: number;
+  private maxBytes: number;
+
+  /**
+   * Create a new HTTP mirror provider
+   *
+   * @param baseUrl - Base URL of the mirror service (e.g., "https://packages.dappnode.net")
+   * @param timeoutMs - Timeout for requests in milliseconds
+   * @param maxBytes - Maximum download size in bytes
+   */
+  constructor(baseUrl: string, timeoutMs: number, maxBytes: number) {
+    this.baseUrl = baseUrl.replace(/\/?$/, ""); // Remove trailing slash
+    this.timeoutMs = timeoutMs;
+    this.maxBytes = maxBytes;
+  }
+
+  /**
+   * List contents of a directory by CID
+   *
+   * Makes a GET request to {baseUrl}/{cid}/ and expects JSON response:
+   * [
+   *   {"name": "file.txt", "type": "file", "size": 123, "cid": "QmXXX", "mtime": "..."},
+   *   ...
+   * ]
+   *
+   * @param cid - Content identifier (directory CID)
+   * @returns Array of entries in the directory
+   * @throws Error if request fails or response is invalid
+   */
+  async list(cid: string): Promise<MirrorListEntry[]> {
+    const normalizedCid = normalizeCid(cid);
+    const url = `${this.baseUrl}/${normalizedCid}/`;
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    try {
+      const response = await fetch(url, {
+        signal: controller.signal,
+        headers: {
+          Accept: "application/json"
+        }
+      });
+
+      if (!response.ok) {
+        throw new Error(`Mirror list failed: ${response.status} ${response.statusText}`);
+      }
+
+      const entries = (await response.json()) as MirrorListEntry[];
+
+      if (!Array.isArray(entries)) {
+        throw new Error("Mirror list response is not an array");
+      }
+
+      return entries;
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  /**
+   * Fetch a specific file from a directory
+   *
+   * Makes a GET request to {baseUrl}/{cid}/{filename}
+   * Supports progress callbacks for large downloads
+   *
+   * @param cid - Content identifier (directory CID)
+   * @param filename - Name of file to fetch
+   * @param options - Optional fetch options (abort signal, progress callback)
+   * @returns Result with bytes or failure reason
+   */
+  async fetchFile(cid: string, filename: string, options: FetchOptions = {}): Promise<MirrorFetchResult> {
+    const normalizedCid = normalizeCid(cid);
+    const url = `${this.baseUrl}/${normalizedCid}/${filename}`;
+
+    return this.fetchUrl(url, options);
+  }
+
+  /**
+   * Fetch content by CID directly (legacy support)
+   *
+   * Makes a GET request to {baseUrl}/{cid}
+   * Used when we don't have a filename (older code paths)
+   *
+   * @param cid - Content identifier
+   * @param options - Optional fetch options
+   * @returns Result with bytes or failure reason
+   */
+  async fetchByCid(cid: string, options: FetchOptions = {}): Promise<MirrorFetchResult> {
+    const normalizedCid = normalizeCid(cid);
+    const url = `${this.baseUrl}/${normalizedCid}`;
+
+    return this.fetchUrl(url, options);
+  }
+
+  /**
+   * Internal method to fetch a URL with timeout and progress tracking
+   *
+   * @param url - URL to fetch
+   * @param options - Fetch options
+   * @returns Result with bytes or failure reason
+   */
+  private async fetchUrl(url: string, options: FetchOptions): Promise<MirrorFetchResult> {
+    const controller = new AbortController();
+    let timeoutId: NodeJS.Timeout | undefined;
+
+    // Use provided signal or create timeout-based abort
+    const signal = options.signal || controller.signal;
+
+    if (!options.signal) {
+      timeoutId = setTimeout(() => controller.abort(), this.timeoutMs);
+    }
+
+    try {
+      const response = await fetch(url, {
+        signal,
+        headers: {
+          Accept: "application/octet-stream"
+        }
+      });
+
+      if (!response.ok) {
+        return {
+          status: "failed",
+          reason: `http_error_${response.status}`
+        };
+      }
+
+      // Extract hostname for observability
+      const urlHost = new URL(url).hostname;
+
+      // Get content length for progress tracking
+      const contentLength = response.headers.get("content-length");
+      const totalBytes = contentLength ? parseInt(contentLength, 10) : undefined;
+
+      // Check size limit
+      if (totalBytes && totalBytes > this.maxBytes) {
+        return {
+          status: "failed",
+          reason: `file_too_large: ${totalBytes} > ${this.maxBytes}`
+        };
+      }
+
+      // Read response body
+      const bytes = await this.readResponseWithProgress(response, totalBytes, options.onProgress);
+
+      // Check size limit after download
+      if (bytes.length > this.maxBytes) {
+        return {
+          status: "failed",
+          reason: `file_too_large: ${bytes.length} > ${this.maxBytes}`
+        };
+      }
+
+      return {
+        status: "success",
+        bytes,
+        urlHost
+      };
+    } catch (error) {
+      // Check if it was aborted due to timeout
+      if (error instanceof Error && error.name === "AbortError") {
+        return {
+          status: "failed",
+          reason: "timeout"
+        };
+      }
+
+      // Network error or other failure
+      return {
+        status: "failed",
+        reason: error instanceof Error ? error.message : "unknown_error"
+      };
+    } finally {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+    }
+  }
+
+  /**
+   * Read response body with progress tracking
+   *
+   * @param response - Fetch response
+   * @param totalBytes - Total size (if known from Content-Length)
+   * @param onProgress - Progress callback
+   * @returns Response bytes
+   */
+  private async readResponseWithProgress(
+    response: Response,
+    totalBytes: number | undefined,
+    onProgress?: (progress: number) => void
+  ): Promise<Uint8Array> {
+    // If no progress callback or unknown size, read directly
+    if (!onProgress || !totalBytes) {
+      const arrayBuffer = await response.arrayBuffer();
+      return new Uint8Array(arrayBuffer);
+    }
+
+    // Read with progress tracking
+    const reader = response.body?.getReader();
+    if (!reader) {
+      throw new Error("Response body is not readable");
+    }
+
+    const chunks: Uint8Array[] = [];
+    let downloadedBytes = 0;
+    let lastReportedProgress = -1;
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+
+        if (done) break;
+
+        chunks.push(value);
+        downloadedBytes += value.length;
+
+        // Report progress (rounded to avoid excessive callbacks)
+        const currentProgress = roundProgress(downloadedBytes, totalBytes);
+        if (currentProgress !== lastReportedProgress) {
+          onProgress(currentProgress);
+          lastReportedProgress = currentProgress;
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+
+    // Concatenate chunks into single Uint8Array
+    const totalLength = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+    const result = new Uint8Array(totalLength);
+    let offset = 0;
+
+    for (const chunk of chunks) {
+      result.set(chunk, offset);
+      offset += chunk.length;
+    }
+
+    // Report 100% on completion
+    if (onProgress && lastReportedProgress < 100) {
+      onProgress(100);
+    }
+
+    return result;
+  }
+}

--- a/packages/toolkit/src/repository/contentProvider/types.ts
+++ b/packages/toolkit/src/repository/contentProvider/types.ts
@@ -1,0 +1,64 @@
+/**
+ * Mirror provider types for HTTP-based content distribution
+ */
+
+/**
+ * Mirror API response for directory listing
+ *
+ * The mirror provides file metadata but not individual file CIDs.
+ * This is acceptable because the package CID itself is verified via signature.json,
+ * and since IPFS CIDs are content-addressed, verifying the package CID inherently
+ * verifies all files within it.
+ */
+export interface MirrorListEntry {
+  name: string;
+  type: "file" | "directory";
+  size: number;
+  mtime: string;
+}
+
+/**
+ * Result type for mirror fetch operations
+ * Using discriminated union for type safety
+ */
+export type MirrorFetchResult =
+  | { status: "success"; bytes: Uint8Array; urlHost: string }
+  | { status: "failed"; reason: string };
+
+/**
+ * Options for download operations
+ */
+export interface FetchOptions {
+  signal?: AbortSignal;
+  onProgress?: (progress: number) => void;
+}
+
+/**
+ * Mirror provider interface
+ * Provides HTTP-based alternative to IPFS for content retrieval
+ */
+export interface MirrorProvider {
+  /**
+   * List contents of a directory by CID
+   * @param cid - Content identifier (IPFS hash)
+   * @returns Array of entries in the directory
+   */
+  list(cid: string): Promise<MirrorListEntry[]>;
+
+  /**
+   * Fetch a specific file from a directory
+   * @param cid - Content identifier (directory CID)
+   * @param filename - Name of file to fetch
+   * @param options - Optional fetch options (abort signal, progress callback)
+   * @returns Result with bytes or failure reason
+   */
+  fetchFile(cid: string, filename: string, options?: FetchOptions): Promise<MirrorFetchResult>;
+
+  /**
+   * Fetch content by CID directly (legacy support)
+   * @param cid - Content identifier
+   * @param options - Optional fetch options
+   * @returns Result with bytes or failure reason
+   */
+  fetchByCid(cid: string, options?: FetchOptions): Promise<MirrorFetchResult>;
+}

--- a/packages/toolkit/src/repository/contentProvider/utils.ts
+++ b/packages/toolkit/src/repository/contentProvider/utils.ts
@@ -1,0 +1,44 @@
+/**
+ * Utility functions for content provider operations
+ */
+
+/**
+ * Normalize a CID by removing IPFS prefixes and slashes
+ *
+ * Examples:
+ * - "/ipfs/QmXXX" → "QmXXX"
+ * - "ipfs/QmXXX" → "QmXXX"
+ * - "QmXXX/" → "QmXXX"
+ * - "QmXXX" → "QmXXX"
+ *
+ * @param cid - CID string potentially with prefixes
+ * @returns Normalized CID string
+ */
+export function normalizeCid(cid: string): string {
+  // Remove /ipfs/ or ipfs/ prefix
+  let normalized = cid.split("ipfs/")[1] || cid;
+
+  // Remove trailing and leading slashes
+  normalized = normalized.replace(/\/+$/, "").replace(/^\/+/, "");
+
+  // Return only the CID part (ignore any subpath)
+  return normalized.split("/")[0];
+}
+
+/**
+ * Round progress percentage to avoid excessive update callbacks
+ *
+ * @param current - Current number of bytes downloaded
+ * @param total - Total number of bytes to download
+ * @param resolution - Resolution for rounding (default: 1 = round to nearest percent)
+ * @returns Rounded progress percentage (0-100)
+ */
+export function roundProgress(current: number, total: number, resolution = 1): number {
+  if (total === 0) return 0;
+
+  const percentage = (current / total) * 100;
+  const rounded = resolution * Math.round(percentage / resolution);
+
+  // Ensure we don't exceed 100%
+  return Math.min(rounded, 100);
+}

--- a/packages/toolkit/src/repository/contentProvider/utils.ts
+++ b/packages/toolkit/src/repository/contentProvider/utils.ts
@@ -18,8 +18,15 @@ export function normalizeCid(cid: string): string {
   // Remove /ipfs/ or ipfs/ prefix
   let normalized = cid.split("ipfs/")[1] || cid;
 
-  // Remove trailing and leading slashes
-  normalized = normalized.replace(/\/+$/, "").replace(/^\/+/, "");
+  // Remove trailing slashes (safe, no ReDoS risk)
+  while (normalized.endsWith("/")) {
+    normalized = normalized.slice(0, -1);
+  }
+
+  // Remove leading slashes (safe, no ReDoS risk)
+  while (normalized.startsWith("/")) {
+    normalized = normalized.slice(1);
+  }
 
   // Return only the CID part (ignore any subpath)
   return normalized.split("/")[0];

--- a/packages/toolkit/src/repository/repository.ts
+++ b/packages/toolkit/src/repository/repository.ts
@@ -29,8 +29,21 @@ import { getReleaseSignatureStatus, serializeIpfsDirectory } from "./releaseSign
 import { isEnsDomain } from "../isEnsDomain.js";
 import { dappnodeRegistry } from "./params.js";
 import { JsonRpcApiProvider } from "ethers";
+import { MirrorProvider, HttpMirrorProvider } from "./contentProvider/index.js";
+import { logs } from "@dappnode/logger";
 
 const source = "ipfs" as const;
+
+/**
+ * Optional configuration for DappnodeRepository
+ */
+export interface DappnodeRepositoryOptions {
+  mirror?: {
+    baseUrl: string;
+    timeoutMs: number;
+    maxBytes: number;
+  };
+}
 
 /**
  * The DappnodeRepository class extends ApmRepository class to provide methods to interact with the IPFS network.
@@ -41,15 +54,26 @@ const source = "ipfs" as const;
 export class DappnodeRepository extends ApmRepository {
   protected gatewayUrl: string;
   protected localIpfsUrl = "http://ipfs.dappnode:5001";
+  private mirrorProvider?: MirrorProvider;
 
   /**
    * Constructs an instance of DappnodeRepository
    * @param ipfsUrl - The URL of the IPFS network node.
-   * @param ethUrl - The URL of the Ethereum node to connect to.
+   * @param provider - The Ethereum JSON-RPC provider.
+   * @param options - Optional configuration (e.g., mirror provider settings).
    */
-  constructor(ipfsUrl: string, provider: JsonRpcApiProvider) {
+  constructor(ipfsUrl: string, provider: JsonRpcApiProvider, options?: DappnodeRepositoryOptions) {
     super(provider);
     this.gatewayUrl = ipfsUrl.replace(/\/?$/, ""); // e.g. "https://gateway.pinata.cloud"
+
+    // Initialize mirror provider if configured
+    if (options?.mirror) {
+      this.mirrorProvider = new HttpMirrorProvider(
+        options.mirror.baseUrl,
+        options.mirror.timeoutMs,
+        options.mirror.maxBytes
+      );
+    }
   }
 
   /**
@@ -238,7 +262,7 @@ export class DappnodeRepository extends ApmRepository {
     // Process matched entries. If multiple files are allowed, and more than one file matches, we parse all of them.
     const { maxSize: maxLength, format } = fileConfig;
     const contents = await Promise.all(
-      matchingEntries.map((entry) => this.writeFileToMemory(entry.cid.toString(), maxLength))
+      matchingEntries.map((entry) => this.writeFileToMemory(entry.cid.toString(), maxLength, entry.name))
     );
 
     // If multiple files are allowed, we return an array of parsed assets.
@@ -249,15 +273,42 @@ export class DappnodeRepository extends ApmRepository {
   /**
    * Downloads the content pointed by the given hash, parses it to UTF8 and returns it as a string.
    * This function is intended for small files.
+   * Tries mirror first (if available and filename provided), then falls back to IPFS.
    *
    * @param hash - The content identifier (CID) of the file to download.
    * @param maxLength - The maximum length of the file in bytes. If the downloaded file exceeds this length, an error is thrown.
+   * @param filename - Optional filename for mirror downloads (directory/filename pattern).
    * @returns The downloaded file content as a UTF8 string.
    * @throws Error when the maximum size is exceeded.
    * @see catString
    * @see catCarReaderToMemory
    */
-  public async writeFileToMemory(hash: string, maxLength?: number): Promise<string> {
+  public async writeFileToMemory(hash: string, maxLength?: number, filename?: string): Promise<string> {
+    const cidStr = this.sanitizeIpfsPath(hash);
+
+    // Try mirror first if available and we have a filename
+    if (this.mirrorProvider && filename) {
+      try {
+        const result = await this.mirrorProvider.fetchFile(cidStr, filename, {});
+
+        if (result.status === "success") {
+          if (maxLength && result.bytes.length >= maxLength) {
+            throw Error(`Maximum size ${maxLength} bytes exceeded`);
+          }
+
+          logs.info(`Downloaded ${filename} from mirror`);
+          const decoder = new TextDecoder("utf-8");
+          return decoder.decode(result.bytes);
+        }
+
+        logs.warn(`Mirror fetch failed for ${filename}: ${result.reason}, falling back to IPFS`);
+      } catch (error) {
+        const errMsg = error instanceof Error ? error.message : "unknown error";
+        logs.warn(`Mirror download error for ${filename}: ${errMsg}, falling back to IPFS`);
+      }
+    }
+
+    // Fallback to IPFS CAR download (existing implementation)
     const chunks: Uint8Array[] = [];
     const { carReader, root } = await this.getAndVerifyContentFromGateway(hash);
     const content = await this.unpackCarReader(carReader, root);
@@ -284,6 +335,7 @@ export class DappnodeRepository extends ApmRepository {
   /**
    * Downloads the content pointed by the given hash and writes it directly to the filesystem.
    * This function is intended for large files, such as Docker images.
+   * Tries mirror first (if available and filename provided), then falls back to IPFS.
    *
    * IMPORTANT: This function is not supported in the browser.
    *
@@ -293,6 +345,7 @@ export class DappnodeRepository extends ApmRepository {
    * @param args.timeout - The maximum time to wait for the download in milliseconds.
    * @param args.fileSize - The expected size of the file in bytes.
    * @param args.progress - An optional function to call with the download progress.
+   * @param args.filename - Optional filename for mirror downloads (directory/filename pattern).
    * @returns A promise that resolves when the file has been written.
    * @throws Error when a download timeout occurs or if the provided path is invalid.
    */
@@ -301,14 +354,39 @@ export class DappnodeRepository extends ApmRepository {
     path: _path,
     timeout,
     fileSize,
-    progress
+    progress,
+    filename
   }: {
     hash: string;
     path: string;
     timeout?: number;
     fileSize?: number;
     progress?: (n: number) => void;
+    filename?: string;
   }): Promise<void> {
+    const cidStr = this.sanitizeIpfsPath(hash);
+
+    // Try mirror first if available and we have a filename
+    if (this.mirrorProvider && filename) {
+      try {
+        const result = await this.mirrorProvider.fetchFile(cidStr, filename, {
+          onProgress: progress
+        });
+
+        if (result.status === "success") {
+          logs.info(`Downloaded ${filename} from mirror, writing to ${_path}`);
+          await fs.promises.writeFile(_path, result.bytes);
+          return; // Success - no need for IPFS fallback
+        }
+
+        logs.warn(`Mirror download failed: ${result.reason}, falling back to IPFS`);
+      } catch (error) {
+        const errMsg = error instanceof Error ? error.message : "unknown error";
+        logs.warn(`Mirror download error: ${errMsg}, falling back to IPFS`);
+      }
+    }
+
+    // Fallback to IPFS CAR download (existing implementation)
     const { carReader, root } = await this.getAndVerifyContentFromGateway(hash);
     const readable = await this.unpackCarReader(carReader, root);
 
@@ -373,6 +451,7 @@ export class DappnodeRepository extends ApmRepository {
 
   /**
    * Lists the contents of a directory pointed by the given hash.
+   * Tries mirror first (if available), then falls back to IPFS.
    * ipfs.dag.get => reutrns `Tsize`!
    *
    * TODO: research why the size is different, i.e for the hash QmWcJrobqhHF7GWpqEbxdv2cWCCXbACmq85Hh7aJ1eu8rn Tsize is 64461521 and size is 64446140
@@ -383,6 +462,11 @@ export class DappnodeRepository extends ApmRepository {
    */
   public async list(hash: string): Promise<IPFSEntry[]> {
     const cidStr = this.sanitizeIpfsPath(hash.toString());
+
+    // IMPORTANT: Always use IPFS for directory listings to get individual file CIDs
+    // Individual file CIDs are required for signature verification (serializeIpfsDirectory)
+    // Mirror is used for file downloads (writeFileToMemory/writeFileToFs) for speed
+    // This hybrid approach provides both security (signature verification) and speed (mirror downloads)
     const url = `${this.gatewayUrl}/ipfs/${cidStr}?format=dag-json`;
     const res = await fetch(url, {
       headers: { Accept: "application/vnd.ipld.dag-json" }
@@ -521,7 +605,8 @@ export class DappnodeRepository extends ApmRepository {
       return {
         hash: imageAsset.cid.toString(),
         size: imageAsset.size,
-        source // TODO: consdier adding different sources
+        source, // TODO: consdier adding different sources
+        filename: imageAsset.name // Add filename for mirror downloads
       };
     }
   }

--- a/packages/toolkit/test/repository/contentProvider.test.ts
+++ b/packages/toolkit/test/repository/contentProvider.test.ts
@@ -61,11 +61,11 @@ describe("HttpMirrorProvider", () => {
   const baseUrl = "https://test-mirror.example.com";
   const timeoutMs = 5000;
   const maxBytes = 1024 * 1024; // 1MB
-  let fetchCalls: { url: string; opts: any }[];
+  let fetchCalls: { url: string; opts: RequestInit }[];
 
-  function mockFetch(response: any, shouldReject = false) {
+  function mockFetch(response: unknown, shouldReject = false) {
     fetchCalls = [];
-    (globalThis as any).fetch = async (url: string, opts: any) => {
+    (globalThis as Record<string, unknown>).fetch = async (url: string, opts: RequestInit) => {
       fetchCalls.push({ url, opts });
       if (shouldReject) throw response;
       return response;
@@ -132,8 +132,8 @@ describe("HttpMirrorProvider", () => {
       try {
         await provider.list("QmTestCid");
         expect.fail("Should have thrown");
-      } catch (e: any) {
-        expect(e.message).to.include("Mirror list failed: 404 Not Found");
+      } catch (e: unknown) {
+        expect((e as Error).message).to.include("Mirror list failed: 404 Not Found");
       }
     });
 
@@ -143,8 +143,8 @@ describe("HttpMirrorProvider", () => {
       try {
         await provider.list("QmTestCid");
         expect.fail("Should have thrown");
-      } catch (e: any) {
-        expect(e.message).to.include("Network error");
+      } catch (e: unknown) {
+        expect((e as Error).message).to.include("Network error");
       }
     });
 
@@ -157,8 +157,8 @@ describe("HttpMirrorProvider", () => {
       try {
         await provider.list("QmTestCid");
         expect.fail("Should have thrown");
-      } catch (e: any) {
-        expect(e.message).to.include("Mirror list response is not an array");
+      } catch (e: unknown) {
+        expect((e as Error).message).to.include("Mirror list response is not an array");
       }
     });
   });

--- a/packages/toolkit/test/repository/contentProvider.test.ts
+++ b/packages/toolkit/test/repository/contentProvider.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { HttpMirrorProvider } from "../../src/repository/contentProvider/mirrorProvider.js";
+import { normalizeCid, roundProgress } from "../../src/repository/contentProvider/utils.js";
+
+describe("ContentProvider Utils", () => {
+  describe("normalizeCid", () => {
+    it("should remove /ipfs/ prefix", () => {
+      expect(normalizeCid("/ipfs/QmTest123")).toBe("QmTest123");
+    });
+
+    it("should remove ipfs/ prefix without leading slash", () => {
+      expect(normalizeCid("ipfs/QmTest123")).toBe("QmTest123");
+    });
+
+    it("should remove trailing slashes", () => {
+      expect(normalizeCid("QmTest123/")).toBe("QmTest123");
+      expect(normalizeCid("QmTest123///")).toBe("QmTest123");
+    });
+
+    it("should handle already normalized CID", () => {
+      expect(normalizeCid("QmTest123")).toBe("QmTest123");
+    });
+
+    it("should ignore subpaths", () => {
+      expect(normalizeCid("QmTest123/subpath/file.txt")).toBe("QmTest123");
+    });
+  });
+
+  describe("roundProgress", () => {
+    it("should calculate percentage correctly", () => {
+      expect(roundProgress(50, 100)).toBe(50);
+      expect(roundProgress(1, 4)).toBe(25);
+    });
+
+    it("should round to nearest percent by default", () => {
+      expect(roundProgress(33, 100)).toBe(33);
+      expect(roundProgress(33.4, 100)).toBe(33);
+      expect(roundProgress(33.6, 100)).toBe(34);
+    });
+
+    it("should respect custom resolution", () => {
+      expect(roundProgress(33, 100, 5)).toBe(35); // Round to nearest 5
+      expect(roundProgress(37, 100, 10)).toBe(40); // Round to nearest 10
+    });
+
+    it("should cap at 100%", () => {
+      expect(roundProgress(150, 100)).toBe(100);
+    });
+
+    it("should return 0 for zero total", () => {
+      expect(roundProgress(50, 0)).toBe(0);
+    });
+  });
+});
+
+describe("HttpMirrorProvider", () => {
+  let provider: HttpMirrorProvider;
+  const baseUrl = "https://test-mirror.example.com";
+  const timeoutMs = 5000;
+  const maxBytes = 1024 * 1024; // 1MB
+
+  beforeEach(() => {
+    provider = new HttpMirrorProvider(baseUrl, timeoutMs, maxBytes);
+    vi.clearAllMocks();
+  });
+
+  describe("list", () => {
+    it("should list directory contents successfully", async () => {
+      // Mock fetch to return directory listing (without individual file CIDs)
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => [
+          { name: "file1.txt", type: "file", size: 100, mtime: "2026-02-18T12:00:00Z" },
+          { name: "file2.txt", type: "file", size: 200, mtime: "2026-02-18T12:00:00Z" }
+        ]
+      });
+
+      const result = await provider.list("QmTestCid");
+
+      expect(result).toHaveLength(2);
+      expect(result[0].name).toBe("file1.txt");
+      expect(result[0].size).toBe(100);
+      expect(result[1].name).toBe("file2.txt");
+
+      // Verify correct URL was called
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${baseUrl}/QmTestCid/`,
+        expect.objectContaining({
+          headers: { Accept: "application/json" }
+        })
+      );
+    });
+
+    it("should normalize CID before making request", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => []
+      });
+
+      await provider.list("/ipfs/QmTestCid/");
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${baseUrl}/QmTestCid/`,
+        expect.anything()
+      );
+    });
+
+    it("should handle HTTP errors", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: "Not Found"
+      });
+
+      await expect(provider.list("QmTestCid")).rejects.toThrow("Mirror list failed: 404 Not Found");
+    });
+
+    it("should handle network errors", async () => {
+      global.fetch = vi.fn().mockRejectedValue(new Error("Network error"));
+
+      await expect(provider.list("QmTestCid")).rejects.toThrow("Network error");
+    });
+
+    it("should validate response is an array", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ invalid: "response" })
+      });
+
+      await expect(provider.list("QmTestCid")).rejects.toThrow("Mirror list response is not an array");
+    });
+  });
+
+  describe("fetchFile", () => {
+    it("should download file successfully", async () => {
+      const testContent = new Uint8Array([1, 2, 3, 4, 5]);
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        headers: new Map([["content-length", "5"]]),
+        arrayBuffer: async () => testContent.buffer
+      });
+
+      const result = await provider.fetchFile("QmTestCid", "test.txt");
+
+      expect(result.status).toBe("success");
+      if (result.status === "success") {
+        expect(result.bytes).toEqual(testContent);
+        expect(result.urlHost).toBe("test-mirror.example.com");
+      }
+
+      // Verify correct URL was called
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${baseUrl}/QmTestCid/test.txt`,
+        expect.objectContaining({
+          headers: { Accept: "application/octet-stream" }
+        })
+      );
+    });
+
+    it("should handle HTTP 404 errors gracefully", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: "Not Found"
+      });
+
+      const result = await provider.fetchFile("QmTestCid", "missing.txt");
+
+      expect(result.status).toBe("failed");
+      if (result.status === "failed") {
+        expect(result.reason).toBe("http_error_404");
+      }
+    });
+
+    it("should reject files exceeding max size", async () => {
+      const largeContent = new Uint8Array(maxBytes + 1);
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        headers: new Map([["content-length", String(maxBytes + 1)]]),
+        arrayBuffer: async () => largeContent.buffer
+      });
+
+      const result = await provider.fetchFile("QmTestCid", "large.bin");
+
+      expect(result.status).toBe("failed");
+      if (result.status === "failed") {
+        expect(result.reason).toContain("file_too_large");
+      }
+    });
+
+    it("should handle network errors gracefully", async () => {
+      global.fetch = vi.fn().mockRejectedValue(new Error("Connection refused"));
+
+      const result = await provider.fetchFile("QmTestCid", "test.txt");
+
+      expect(result.status).toBe("failed");
+      if (result.status === "failed") {
+        expect(result.reason).toBe("Connection refused");
+      }
+    });
+
+    it("should support progress callbacks", async () => {
+      const testContent = new Uint8Array(1000);
+      const progressCalls: number[] = [];
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        headers: new Map([["content-length", "1000"]]),
+        body: {
+          getReader: () => ({
+            read: vi
+              .fn()
+              .mockResolvedValueOnce({ done: false, value: new Uint8Array(500) })
+              .mockResolvedValueOnce({ done: false, value: new Uint8Array(500) })
+              .mockResolvedValueOnce({ done: true }),
+            releaseLock: vi.fn()
+          })
+        }
+      });
+
+      const result = await provider.fetchFile("QmTestCid", "test.txt", {
+        onProgress: (p) => progressCalls.push(p)
+      });
+
+      expect(result.status).toBe("success");
+      expect(progressCalls.length).toBeGreaterThan(0);
+      expect(progressCalls[progressCalls.length - 1]).toBe(100); // Should end at 100%
+    });
+  });
+
+  describe("fetchByCid", () => {
+    it("should fetch content by CID directly", async () => {
+      const testContent = new Uint8Array([1, 2, 3]);
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        headers: new Map([["content-length", "3"]]),
+        arrayBuffer: async () => testContent.buffer
+      });
+
+      const result = await provider.fetchByCid("QmTestCid");
+
+      expect(result.status).toBe("success");
+
+      // Verify correct URL was called (without filename)
+      expect(global.fetch).toHaveBeenCalledWith(`${baseUrl}/QmTestCid`, expect.anything());
+    });
+  });
+});

--- a/packages/toolkit/test/repository/contentProvider.test.ts
+++ b/packages/toolkit/test/repository/contentProvider.test.ts
@@ -1,54 +1,57 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { expect } from "chai";
 import { HttpMirrorProvider } from "../../src/repository/contentProvider/mirrorProvider.js";
 import { normalizeCid, roundProgress } from "../../src/repository/contentProvider/utils.js";
+
+// Helper to save and restore global.fetch
+let originalFetch: typeof globalThis.fetch;
 
 describe("ContentProvider Utils", () => {
   describe("normalizeCid", () => {
     it("should remove /ipfs/ prefix", () => {
-      expect(normalizeCid("/ipfs/QmTest123")).toBe("QmTest123");
+      expect(normalizeCid("/ipfs/QmTest123")).to.equal("QmTest123");
     });
 
     it("should remove ipfs/ prefix without leading slash", () => {
-      expect(normalizeCid("ipfs/QmTest123")).toBe("QmTest123");
+      expect(normalizeCid("ipfs/QmTest123")).to.equal("QmTest123");
     });
 
     it("should remove trailing slashes", () => {
-      expect(normalizeCid("QmTest123/")).toBe("QmTest123");
-      expect(normalizeCid("QmTest123///")).toBe("QmTest123");
+      expect(normalizeCid("QmTest123/")).to.equal("QmTest123");
+      expect(normalizeCid("QmTest123///")).to.equal("QmTest123");
     });
 
     it("should handle already normalized CID", () => {
-      expect(normalizeCid("QmTest123")).toBe("QmTest123");
+      expect(normalizeCid("QmTest123")).to.equal("QmTest123");
     });
 
     it("should ignore subpaths", () => {
-      expect(normalizeCid("QmTest123/subpath/file.txt")).toBe("QmTest123");
+      expect(normalizeCid("QmTest123/subpath/file.txt")).to.equal("QmTest123");
     });
   });
 
   describe("roundProgress", () => {
     it("should calculate percentage correctly", () => {
-      expect(roundProgress(50, 100)).toBe(50);
-      expect(roundProgress(1, 4)).toBe(25);
+      expect(roundProgress(50, 100)).to.equal(50);
+      expect(roundProgress(1, 4)).to.equal(25);
     });
 
     it("should round to nearest percent by default", () => {
-      expect(roundProgress(33, 100)).toBe(33);
-      expect(roundProgress(33.4, 100)).toBe(33);
-      expect(roundProgress(33.6, 100)).toBe(34);
+      expect(roundProgress(33, 100)).to.equal(33);
+      expect(roundProgress(33.4, 100)).to.equal(33);
+      expect(roundProgress(33.6, 100)).to.equal(34);
     });
 
     it("should respect custom resolution", () => {
-      expect(roundProgress(33, 100, 5)).toBe(35); // Round to nearest 5
-      expect(roundProgress(37, 100, 10)).toBe(40); // Round to nearest 10
+      expect(roundProgress(33, 100, 5)).to.equal(35); // Round to nearest 5
+      expect(roundProgress(37, 100, 10)).to.equal(40); // Round to nearest 10
     });
 
     it("should cap at 100%", () => {
-      expect(roundProgress(150, 100)).toBe(100);
+      expect(roundProgress(150, 100)).to.equal(100);
     });
 
     it("should return 0 for zero total", () => {
-      expect(roundProgress(50, 0)).toBe(0);
+      expect(roundProgress(50, 0)).to.equal(0);
     });
   });
 });
@@ -58,16 +61,37 @@ describe("HttpMirrorProvider", () => {
   const baseUrl = "https://test-mirror.example.com";
   const timeoutMs = 5000;
   const maxBytes = 1024 * 1024; // 1MB
+  let fetchCalls: { url: string; opts: any }[];
+
+  function mockFetch(response: any, shouldReject = false) {
+    fetchCalls = [];
+    (globalThis as any).fetch = async (url: string, opts: any) => {
+      fetchCalls.push({ url, opts });
+      if (shouldReject) throw response;
+      return response;
+    };
+  }
+
+  before(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  after(() => {
+    globalThis.fetch = originalFetch;
+  });
 
   beforeEach(() => {
     provider = new HttpMirrorProvider(baseUrl, timeoutMs, maxBytes);
-    vi.clearAllMocks();
+    fetchCalls = [];
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
   });
 
   describe("list", () => {
     it("should list directory contents successfully", async () => {
-      // Mock fetch to return directory listing (without individual file CIDs)
-      global.fetch = vi.fn().mockResolvedValue({
+      mockFetch({
         ok: true,
         json: async () => [
           { name: "file1.txt", type: "file", size: 100, mtime: "2026-02-18T12:00:00Z" },
@@ -77,64 +101,72 @@ describe("HttpMirrorProvider", () => {
 
       const result = await provider.list("QmTestCid");
 
-      expect(result).toHaveLength(2);
-      expect(result[0].name).toBe("file1.txt");
-      expect(result[0].size).toBe(100);
-      expect(result[1].name).toBe("file2.txt");
+      expect(result).to.have.lengthOf(2);
+      expect(result[0].name).to.equal("file1.txt");
+      expect(result[0].size).to.equal(100);
+      expect(result[1].name).to.equal("file2.txt");
 
       // Verify correct URL was called
-      expect(global.fetch).toHaveBeenCalledWith(
-        `${baseUrl}/QmTestCid/`,
-        expect.objectContaining({
-          headers: { Accept: "application/json" }
-        })
-      );
+      expect(fetchCalls).to.have.lengthOf(1);
+      expect(fetchCalls[0].url).to.equal(`${baseUrl}/QmTestCid/`);
     });
 
     it("should normalize CID before making request", async () => {
-      global.fetch = vi.fn().mockResolvedValue({
+      mockFetch({
         ok: true,
         json: async () => []
       });
 
       await provider.list("/ipfs/QmTestCid/");
 
-      expect(global.fetch).toHaveBeenCalledWith(
-        `${baseUrl}/QmTestCid/`,
-        expect.anything()
-      );
+      expect(fetchCalls[0].url).to.equal(`${baseUrl}/QmTestCid/`);
     });
 
     it("should handle HTTP errors", async () => {
-      global.fetch = vi.fn().mockResolvedValue({
+      mockFetch({
         ok: false,
         status: 404,
         statusText: "Not Found"
       });
 
-      await expect(provider.list("QmTestCid")).rejects.toThrow("Mirror list failed: 404 Not Found");
+      try {
+        await provider.list("QmTestCid");
+        expect.fail("Should have thrown");
+      } catch (e: any) {
+        expect(e.message).to.include("Mirror list failed: 404 Not Found");
+      }
     });
 
     it("should handle network errors", async () => {
-      global.fetch = vi.fn().mockRejectedValue(new Error("Network error"));
+      mockFetch(new Error("Network error"), true);
 
-      await expect(provider.list("QmTestCid")).rejects.toThrow("Network error");
+      try {
+        await provider.list("QmTestCid");
+        expect.fail("Should have thrown");
+      } catch (e: any) {
+        expect(e.message).to.include("Network error");
+      }
     });
 
     it("should validate response is an array", async () => {
-      global.fetch = vi.fn().mockResolvedValue({
+      mockFetch({
         ok: true,
         json: async () => ({ invalid: "response" })
       });
 
-      await expect(provider.list("QmTestCid")).rejects.toThrow("Mirror list response is not an array");
+      try {
+        await provider.list("QmTestCid");
+        expect.fail("Should have thrown");
+      } catch (e: any) {
+        expect(e.message).to.include("Mirror list response is not an array");
+      }
     });
   });
 
   describe("fetchFile", () => {
     it("should download file successfully", async () => {
       const testContent = new Uint8Array([1, 2, 3, 4, 5]);
-      global.fetch = vi.fn().mockResolvedValue({
+      mockFetch({
         ok: true,
         headers: new Map([["content-length", "5"]]),
         arrayBuffer: async () => testContent.buffer
@@ -142,23 +174,18 @@ describe("HttpMirrorProvider", () => {
 
       const result = await provider.fetchFile("QmTestCid", "test.txt");
 
-      expect(result.status).toBe("success");
+      expect(result.status).to.equal("success");
       if (result.status === "success") {
-        expect(result.bytes).toEqual(testContent);
-        expect(result.urlHost).toBe("test-mirror.example.com");
+        expect(new Uint8Array(result.bytes)).to.deep.equal(testContent);
+        expect(result.urlHost).to.equal("test-mirror.example.com");
       }
 
       // Verify correct URL was called
-      expect(global.fetch).toHaveBeenCalledWith(
-        `${baseUrl}/QmTestCid/test.txt`,
-        expect.objectContaining({
-          headers: { Accept: "application/octet-stream" }
-        })
-      );
+      expect(fetchCalls[0].url).to.equal(`${baseUrl}/QmTestCid/test.txt`);
     });
 
     it("should handle HTTP 404 errors gracefully", async () => {
-      global.fetch = vi.fn().mockResolvedValue({
+      mockFetch({
         ok: false,
         status: 404,
         statusText: "Not Found"
@@ -166,72 +193,73 @@ describe("HttpMirrorProvider", () => {
 
       const result = await provider.fetchFile("QmTestCid", "missing.txt");
 
-      expect(result.status).toBe("failed");
+      expect(result.status).to.equal("failed");
       if (result.status === "failed") {
-        expect(result.reason).toBe("http_error_404");
+        expect(result.reason).to.equal("http_error_404");
       }
     });
 
     it("should reject files exceeding max size", async () => {
-      const largeContent = new Uint8Array(maxBytes + 1);
-      global.fetch = vi.fn().mockResolvedValue({
+      mockFetch({
         ok: true,
         headers: new Map([["content-length", String(maxBytes + 1)]]),
-        arrayBuffer: async () => largeContent.buffer
+        arrayBuffer: async () => new Uint8Array(maxBytes + 1).buffer
       });
 
       const result = await provider.fetchFile("QmTestCid", "large.bin");
 
-      expect(result.status).toBe("failed");
+      expect(result.status).to.equal("failed");
       if (result.status === "failed") {
-        expect(result.reason).toContain("file_too_large");
+        expect(result.reason).to.include("file_too_large");
       }
     });
 
     it("should handle network errors gracefully", async () => {
-      global.fetch = vi.fn().mockRejectedValue(new Error("Connection refused"));
+      mockFetch(new Error("Connection refused"), true);
 
       const result = await provider.fetchFile("QmTestCid", "test.txt");
 
-      expect(result.status).toBe("failed");
+      expect(result.status).to.equal("failed");
       if (result.status === "failed") {
-        expect(result.reason).toBe("Connection refused");
+        expect(result.reason).to.equal("Connection refused");
       }
     });
 
     it("should support progress callbacks", async () => {
-      const testContent = new Uint8Array(1000);
       const progressCalls: number[] = [];
+      let readCallCount = 0;
 
-      global.fetch = vi.fn().mockResolvedValue({
+      mockFetch({
         ok: true,
         headers: new Map([["content-length", "1000"]]),
         body: {
           getReader: () => ({
-            read: vi
-              .fn()
-              .mockResolvedValueOnce({ done: false, value: new Uint8Array(500) })
-              .mockResolvedValueOnce({ done: false, value: new Uint8Array(500) })
-              .mockResolvedValueOnce({ done: true }),
-            releaseLock: vi.fn()
+            read: async () => {
+              readCallCount++;
+              if (readCallCount <= 2) {
+                return { done: false, value: new Uint8Array(500) };
+              }
+              return { done: true };
+            },
+            releaseLock: () => {}
           })
         }
       });
 
       const result = await provider.fetchFile("QmTestCid", "test.txt", {
-        onProgress: (p) => progressCalls.push(p)
+        onProgress: (p: number) => progressCalls.push(p)
       });
 
-      expect(result.status).toBe("success");
-      expect(progressCalls.length).toBeGreaterThan(0);
-      expect(progressCalls[progressCalls.length - 1]).toBe(100); // Should end at 100%
+      expect(result.status).to.equal("success");
+      expect(progressCalls.length).to.be.greaterThan(0);
+      expect(progressCalls[progressCalls.length - 1]).to.equal(100); // Should end at 100%
     });
   });
 
   describe("fetchByCid", () => {
     it("should fetch content by CID directly", async () => {
       const testContent = new Uint8Array([1, 2, 3]);
-      global.fetch = vi.fn().mockResolvedValue({
+      mockFetch({
         ok: true,
         headers: new Map([["content-length", "3"]]),
         arrayBuffer: async () => testContent.buffer
@@ -239,10 +267,10 @@ describe("HttpMirrorProvider", () => {
 
       const result = await provider.fetchByCid("QmTestCid");
 
-      expect(result.status).toBe("success");
+      expect(result.status).to.equal("success");
 
       // Verify correct URL was called (without filename)
-      expect(global.fetch).toHaveBeenCalledWith(`${baseUrl}/QmTestCid`, expect.anything());
+      expect(fetchCalls[0].url).to.equal(`${baseUrl}/QmTestCid`);
     });
   });
 });

--- a/packages/types/src/calls.ts
+++ b/packages/types/src/calls.ts
@@ -926,6 +926,7 @@ export interface DistributedFile {
   hash: string;
   source: DistributedFileSource;
   size: number;
+  filename?: string; // Used for mirror downloads to identify specific files within a CID directory
 }
 
 export interface IpfsRepository {

--- a/packages/types/src/pkg.ts
+++ b/packages/types/src/pkg.ts
@@ -2,6 +2,7 @@ import { Compose } from "./compose.js";
 import { Manifest, PrometheusTarget, GrafanaDashboard } from "./manifest.js";
 import { NotificationsConfig } from "./notifications.js";
 import { SetupWizard } from "./setupWizard.js";
+import { DistributedFile } from "./calls.js";
 
 /**
  * =========
@@ -177,15 +178,6 @@ export interface TrustedReleaseKey {
   dnpNameSuffix: string;
   /** `0x14791697260E4c9A71f18484C9f997B308e59325` */
   key: string;
-}
-
-export type DistributedFileSource = "ipfs" | "swarm";
-
-export interface DistributedFile {
-  hash: string;
-  source: DistributedFileSource;
-  size: number;
-  filename?: string; // Used for mirror downloads to identify specific files within a CID directory
 }
 
 /**

--- a/packages/types/src/pkg.ts
+++ b/packages/types/src/pkg.ts
@@ -179,12 +179,13 @@ export interface TrustedReleaseKey {
   key: string;
 }
 
-type DistributedFileSource = "ipfs" | "swarm";
+export type DistributedFileSource = "ipfs" | "swarm";
 
-interface DistributedFile {
+export interface DistributedFile {
   hash: string;
   source: DistributedFileSource;
   size: number;
+  filename?: string; // Used for mirror downloads to identify specific files within a CID directory
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1380,6 +1380,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@dappnode/toolkit@workspace:packages/toolkit"
   dependencies:
+    "@dappnode/logger": "workspace:^0.1.0"
     "@dappnode/types": "workspace:^0.1.0"
     "@ipld/car": "npm:^5.4.0"
     "@types/mocha": "npm:^10"


### PR DESCRIPTION
Adds a mirror content provider to list and download DNPs at https://packages.dappnode.net/

One issue pending related signature verification of `signature.json`:

---
The signature creation process is:

List the release directory → Gets each file **with its individual CID** (not available in mirror right now)
Serialize the directory → Creates a string like:

avatar.png zdj7WnZ4Yn4ev7T8qSACAjqnErfqfQsCPsfrHuJNKcaAp7PkJ
dappnode_package.json zdj7WbUmsj617EgJRysWqPpzJxriYfmBxBo1uhAv3kqq6k3VJ
docker-compose.yml zdj7Wf2pYesVyvSbcTEwWVd8TFtTjv588FET9L7qgkP47kRkf
Sign the string → Creates ECDSA signature of that exact string
Verification Process (must match exactly):

When verifying, getReleaseSignatureStatus() does:

List files → Get individual CIDs from IPFS
Serialize with serializeIpfsDirectory() → Must produce identical string
Verify signature → ethers.verifyMessage(signedData, signature)
Individual file CIDs are required for signature verification.

Right now the mirror approach takes the package CID for all files as a placeholder. Signature will always be wrong