### PR TITLE
mirror download only

### DIFF
--- a/packages/installer/src/dappnodeInstaller.ts
+++ b/packages/installer/src/dappnodeInstaller.ts
@@ -46,7 +46,15 @@ export function getIpfsUrl(): string {
 
 export class DappnodeInstaller extends DappnodeRepository {
   constructor(ipfsUrl: string, provider: JsonRpcApiProvider) {
-    super(ipfsUrl, provider);
+    super(ipfsUrl, provider, {
+      mirror: params.CONTENT_MIRROR_BASE_URL
+        ? {
+            baseUrl: params.CONTENT_MIRROR_BASE_URL,
+            timeoutMs: params.CONTENT_MIRROR_TIMEOUT_MS,
+            maxBytes: params.CONTENT_MIRROR_MAX_BYTES
+          }
+        : undefined
+    });
   }
 
   private async updateProviders(): Promise<void> {

--- a/packages/installer/src/installer/downloadImages.ts
+++ b/packages/installer/src/installer/downloadImages.ts
@@ -68,13 +68,14 @@ export async function downloadImage(
   hash: string,
   path: string,
   fileSize: number,
-  progress: (n: number) => void
+  progress: (n: number) => void,
+  filename?: string
 ): Promise<void> {
   // TODO: Ensure file is available
 
   // Cat stream to file system
   // Make sure the path is correct and the parent folder exist or is created
-  await dappnodeInstaller.writeFileToFs({ hash, path, fileSize, progress });
+  await dappnodeInstaller.writeFileToFs({ hash, path, fileSize, progress, filename });
 }
 
 export async function getImage(
@@ -96,11 +97,11 @@ export async function getImage(
     logs.debug(`Image at ${path} is invalid: ${e}`);
   }
 
-  const { hash, size } = imageFile;
+  const { hash, size, filename } = imageFile;
 
   switch (imageFile.source) {
     case "ipfs":
-      await downloadImage(dappnodeInstaller, hash, path, size, progress);
+      await downloadImage(dappnodeInstaller, hash, path, size, progress, filename);
       break;
     default:
       throw Error(`Unsupported source ${imageFile.source}`);

--- a/packages/installer/src/installer/downloadImages.ts
+++ b/packages/installer/src/installer/downloadImages.ts
@@ -69,13 +69,14 @@ export async function downloadImage(
   path: string,
   fileSize: number,
   progress: (n: number) => void,
-  filename?: string
+  filename?: string,
+  packageHash?: string
 ): Promise<void> {
   // TODO: Ensure file is available
 
   // Cat stream to file system
   // Make sure the path is correct and the parent folder exist or is created
-  await dappnodeInstaller.writeFileToFs({ hash, path, fileSize, progress, filename });
+  await dappnodeInstaller.writeFileToFs({ hash, path, fileSize, progress, filename, packageHash });
 }
 
 export async function getImage(
@@ -97,11 +98,11 @@ export async function getImage(
     logs.debug(`Image at ${path} is invalid: ${e}`);
   }
 
-  const { hash, size, filename } = imageFile;
+  const { hash, size, filename, packageHash } = imageFile;
 
   switch (imageFile.source) {
     case "ipfs":
-      await downloadImage(dappnodeInstaller, hash, path, size, progress, filename);
+      await downloadImage(dappnodeInstaller, hash, path, size, progress, filename, packageHash);
       break;
     default:
       throw Error(`Unsupported source ${imageFile.source}`);

--- a/packages/params/src/params.ts
+++ b/packages/params/src/params.ts
@@ -171,7 +171,7 @@ export const params = {
 
   // Mirror provider parameters
   CONTENT_MIRROR_BASE_URL: process.env.CONTENT_MIRROR_BASE_URL || "https://packages.dappnode.net",
-  CONTENT_MIRROR_TIMEOUT_MS: parseInt(process.env.CONTENT_MIRROR_TIMEOUT_MS || "1800000", 10), // 30 minutes
+  CONTENT_MIRROR_TIMEOUT_MS: parseInt(process.env.CONTENT_MIRROR_TIMEOUT_MS || "3600000", 10), // 30 minutes
   CONTENT_MIRROR_MAX_BYTES: parseInt(process.env.CONTENT_MIRROR_MAX_BYTES || "10737418240", 10), // 10GB
 
   // Web3 parameters

--- a/packages/params/src/params.ts
+++ b/packages/params/src/params.ts
@@ -169,6 +169,11 @@ export const params = {
   IPFS_LOCAL: "http://ipfs.dappnode:8080",
   IPFS_REMOTE: "https://ipfs-gateway.dappnode.net",
 
+  // Mirror provider parameters
+  CONTENT_MIRROR_BASE_URL: process.env.CONTENT_MIRROR_BASE_URL || "https://packages.dappnode.net",
+  CONTENT_MIRROR_TIMEOUT_MS: parseInt(process.env.CONTENT_MIRROR_TIMEOUT_MS || "1800000", 10), // 30 minutes
+  CONTENT_MIRROR_MAX_BYTES: parseInt(process.env.CONTENT_MIRROR_MAX_BYTES || "10737418240", 10), // 10GB
+
   // Web3 parameters
   ETH_MAINNET_RPC_URL_REMOTE: process.env.ETH_MAINNET_RPC_URL_REMOTE || "https://web3.dappnode.net",
   ETH_MAINNET_CHECKPOINTSYNC_URL_REMOTE: "https://checkpoint-sync.dappnode.net",

--- a/packages/toolkit/src/repository/contentProvider/index.ts
+++ b/packages/toolkit/src/repository/contentProvider/index.ts
@@ -1,0 +1,3 @@
+export * from "./types.js";
+export * from "./mirrorProvider.js";
+export * from "./utils.js";

--- a/packages/toolkit/src/repository/contentProvider/mirrorProvider.ts
+++ b/packages/toolkit/src/repository/contentProvider/mirrorProvider.ts
@@ -1,0 +1,96 @@
+import { MirrorProvider, MirrorFetchResult, FetchOptions } from "./types.js";
+import { normalizeCid, roundProgress } from "./utils.js";
+
+/**
+ * HTTP mirror provider for downloading package files
+ */
+export class HttpMirrorProvider implements MirrorProvider {
+  private baseUrl: string;
+  private timeoutMs: number;
+  private maxBytes: number;
+
+  constructor(baseUrl: string, timeoutMs: number, maxBytes: number) {
+    this.baseUrl = baseUrl.replace(/\/?$/, "");
+    this.timeoutMs = timeoutMs;
+    this.maxBytes = maxBytes;
+  }
+
+  async fetchFile(cid: string, filename: string, options: FetchOptions = {}): Promise<MirrorFetchResult> {
+    const normalizedCid = normalizeCid(cid);
+    const url = `${this.baseUrl}/${normalizedCid}/${filename}`;
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    try {
+      const response = await fetch(url, { signal: controller.signal });
+
+      if (!response.ok) {
+        return { status: "failed", reason: `http_${response.status}` };
+      }
+
+      const contentLength = response.headers.get("content-length");
+      const totalBytes = contentLength ? parseInt(contentLength, 10) : 0;
+
+      if (totalBytes > this.maxBytes) {
+        return { status: "failed", reason: "file_too_large" };
+      }
+
+      const bytes = await this.readResponseWithProgress(response, totalBytes, options.onProgress);
+      return { status: "success", bytes };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "unknown_error";
+      return { status: "failed", reason: message };
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  private async readResponseWithProgress(
+    response: Response,
+    totalBytes: number,
+    onProgress?: (progress: number) => void
+  ): Promise<Uint8Array> {
+    if (!response.body) {
+      return new Uint8Array(await response.arrayBuffer());
+    }
+
+    const reader = response.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let receivedBytes = 0;
+    let lastReportedProgress = -1;
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        chunks.push(value);
+        receivedBytes += value.length;
+
+        if (onProgress && totalBytes > 0) {
+          const progress = roundProgress(receivedBytes, totalBytes, 5);
+          if (progress !== lastReportedProgress) {
+            onProgress(progress);
+            lastReportedProgress = progress;
+          }
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+
+    const result = new Uint8Array(receivedBytes);
+    let offset = 0;
+    for (const chunk of chunks) {
+      result.set(chunk, offset);
+      offset += chunk.length;
+    }
+
+    if (onProgress) {
+      onProgress(100);
+    }
+
+    return result;
+  }
+}

--- a/packages/toolkit/src/repository/contentProvider/mirrorProvider.ts
+++ b/packages/toolkit/src/repository/contentProvider/mirrorProvider.ts
@@ -1,5 +1,10 @@
-import { MirrorProvider, MirrorFetchResult, FetchOptions } from "./types.js";
+import fs from "fs";
+import stream from "stream";
+import util from "util";
+import { MirrorProvider, MirrorFetchResult, MirrorStreamResult, FetchOptions } from "./types.js";
 import { normalizeCid, roundProgress } from "./utils.js";
+
+const pipeline = util.promisify(stream.pipeline);
 
 /**
  * HTTP mirror provider for downloading package files
@@ -15,9 +20,17 @@ export class HttpMirrorProvider implements MirrorProvider {
     this.maxBytes = maxBytes;
   }
 
+  /**
+   * Build the mirror URL for a package file.
+   * @param cid - Package directory CID (not the individual file CID)
+   * @param filename - Filename within the package
+   */
+  private buildUrl(cid: string, filename: string): string {
+    return `${this.baseUrl}/${normalizeCid(cid)}/${filename}`;
+  }
+
   async fetchFile(cid: string, filename: string, options: FetchOptions = {}): Promise<MirrorFetchResult> {
-    const normalizedCid = normalizeCid(cid);
-    const url = `${this.baseUrl}/${normalizedCid}/${filename}`;
+    const url = this.buildUrl(cid, filename);
 
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs);
@@ -39,6 +52,76 @@ export class HttpMirrorProvider implements MirrorProvider {
       const bytes = await this.readResponseWithProgress(response, totalBytes, options.onProgress);
       return { status: "success", bytes };
     } catch (error) {
+      const message = error instanceof Error ? error.message : "unknown_error";
+      return { status: "failed", reason: message };
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  /**
+   * Stream a file directly to disk without buffering in RAM.
+   * Use this for large files (Docker images) to avoid OOM.
+   */
+  async fetchFileToPath(cid: string, filename: string, destPath: string, options: FetchOptions = {}): Promise<MirrorStreamResult> {
+    const url = this.buildUrl(cid, filename);
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    try {
+      const response = await fetch(url, { signal: controller.signal });
+
+      if (!response.ok) {
+        return { status: "failed", reason: `http_${response.status}` };
+      }
+
+      if (!response.body) {
+        return { status: "failed", reason: "no_response_body" };
+      }
+
+      const contentLength = response.headers.get("content-length");
+      const totalBytes = contentLength ? parseInt(contentLength, 10) : 0;
+
+      if (totalBytes > this.maxBytes) {
+        return { status: "failed", reason: "file_too_large" };
+      }
+
+      const fileStream = fs.createWriteStream(destPath);
+      // Convert Web ReadableStream to Node.js Readable
+      const nodeReadable = stream.Readable.fromWeb(response.body as Parameters<typeof stream.Readable.fromWeb>[0]);
+
+      if (options.onProgress && totalBytes > 0) {
+        let receivedBytes = 0;
+        let lastProgress = -1;
+        const { onProgress } = options;
+
+        const progressStream = new stream.Transform({
+          transform(chunk: Buffer, _encoding: string, callback: () => void) {
+            receivedBytes += chunk.length;
+            const progress = roundProgress(receivedBytes, totalBytes, 5);
+            if (progress !== lastProgress) {
+              onProgress(progress);
+              lastProgress = progress;
+            }
+            callback();
+            this.push(chunk);
+          }
+        });
+
+        await pipeline(nodeReadable, progressStream, fileStream);
+      } else {
+        await pipeline(nodeReadable, fileStream);
+      }
+
+      if (options.onProgress) options.onProgress(100);
+      return { status: "success" };
+    } catch (error) {
+      // Clean up partial file on error
+      try {
+        await fs.promises.unlink(destPath);
+      } catch {
+        // Ignore cleanup errors
+      }
       const message = error instanceof Error ? error.message : "unknown_error";
       return { status: "failed", reason: message };
     } finally {

--- a/packages/toolkit/src/repository/contentProvider/types.ts
+++ b/packages/toolkit/src/repository/contentProvider/types.ts
@@ -6,11 +6,18 @@ export type MirrorFetchResult =
   | { status: "success"; bytes: Uint8Array }
   | { status: "failed"; reason: string };
 
+export type MirrorStreamResult =
+  | { status: "success" }
+  | { status: "failed"; reason: string };
+
 export interface FetchOptions {
   signal?: AbortSignal;
   onProgress?: (progress: number) => void;
 }
 
 export interface MirrorProvider {
+  /** Fetch file into memory (for small files like manifests) */
   fetchFile(cid: string, filename: string, options?: FetchOptions): Promise<MirrorFetchResult>;
+  /** Stream file directly to disk (for large files like Docker images) */
+  fetchFileToPath(cid: string, filename: string, destPath: string, options?: FetchOptions): Promise<MirrorStreamResult>;
 }

--- a/packages/toolkit/src/repository/contentProvider/types.ts
+++ b/packages/toolkit/src/repository/contentProvider/types.ts
@@ -1,0 +1,16 @@
+/**
+ * Content provider types for mirror downloads
+ */
+
+export type MirrorFetchResult =
+  | { status: "success"; bytes: Uint8Array }
+  | { status: "failed"; reason: string };
+
+export interface FetchOptions {
+  signal?: AbortSignal;
+  onProgress?: (progress: number) => void;
+}
+
+export interface MirrorProvider {
+  fetchFile(cid: string, filename: string, options?: FetchOptions): Promise<MirrorFetchResult>;
+}

--- a/packages/toolkit/src/repository/contentProvider/utils.ts
+++ b/packages/toolkit/src/repository/contentProvider/utils.ts
@@ -1,0 +1,30 @@
+/**
+ * Utility functions for content provider operations
+ */
+
+/**
+ * Normalize a CID by removing IPFS prefixes and slashes
+ */
+export function normalizeCid(cid: string): string {
+  let normalized = cid.split("ipfs/")[1] || cid;
+
+  while (normalized.endsWith("/")) {
+    normalized = normalized.slice(0, -1);
+  }
+
+  while (normalized.startsWith("/")) {
+    normalized = normalized.slice(1);
+  }
+
+  return normalized.split("/")[0];
+}
+
+/**
+ * Round progress percentage to avoid excessive callbacks
+ */
+export function roundProgress(current: number, total: number, resolution = 1): number {
+  if (total === 0) return 0;
+  const percentage = (current / total) * 100;
+  const rounded = resolution * Math.round(percentage / resolution);
+  return Math.min(rounded, 100);
+}

--- a/packages/toolkit/src/repository/repository.ts
+++ b/packages/toolkit/src/repository/repository.ts
@@ -170,19 +170,20 @@ export class DappnodeRepository extends ApmRepository {
     const ipfsEntries = await this.list(contentUri);
 
     // get manifest
-    const manifest = await this.getPkgAsset<Manifest>(releaseFilesToDownload.manifest, ipfsEntries);
+    const manifest = await this.getPkgAsset<Manifest>(releaseFilesToDownload.manifest, ipfsEntries, contentUri);
     // Ensure its a directory release
     if (!manifest) throw Error(`Invalid pkg release ${contentUri}, manifest not found`);
     const dnpName = manifest.name;
     const isCore = manifest.type === "dncore";
 
     // get compose
-    const compose = await this.getPkgAsset<Compose>(releaseFilesToDownload.compose, ipfsEntries);
+    const compose = await this.getPkgAsset<Compose>(releaseFilesToDownload.compose, ipfsEntries, contentUri);
     if (!compose) throw Error(`Invalid pkg release ${contentUri}, compose not found`);
 
     const signature: ReleaseSignature | undefined = await this.getPkgAsset<ReleaseSignature>(
       releaseFilesToDownload.signature,
-      ipfsEntries
+      ipfsEntries,
+      contentUri
     );
 
     const signatureStatus: ReleaseSignatureStatus = signature
@@ -213,10 +214,10 @@ export class DappnodeRepository extends ApmRepository {
       semVersion: manifest.version,
       isCore,
       origin,
-      imageFile: this.getImageByArch(manifest, ipfsEntries, os),
+      imageFile: this.getImageByArch(manifest, ipfsEntries, os, contentUri),
       avatarFile,
       manifest,
-      setupWizard: await this.getPkgAsset(releaseFilesToDownload.setupWizard, ipfsEntries),
+      setupWizard: await this.getPkgAsset(releaseFilesToDownload.setupWizard, ipfsEntries, contentUri),
       compose,
       signature,
       signatureStatus,
@@ -226,11 +227,11 @@ export class DappnodeRepository extends ApmRepository {
         coreFromForeignRegistry: isCore && !dnpName.endsWith(dappnodeRegistry),
         requestNameMismatch: isEnsDomain(dnpNameOrHash) && dnpNameOrHash !== dnpName
       },
-      disclaimer: await this.getPkgAsset(releaseFilesToDownload.disclaimer, ipfsEntries),
-      gettingStarted: await this.getPkgAsset(releaseFilesToDownload.gettingStarted, ipfsEntries),
-      prometheusTargets: await this.getPkgAsset(releaseFilesToDownload.prometheusTargets, ipfsEntries),
-      grafanaDashboards: await this.getPkgAsset(releaseFilesToDownload.grafanaDashboards, ipfsEntries),
-      notifications: await this.getPkgAsset(releaseFilesToDownload.notifications, ipfsEntries)
+      disclaimer: await this.getPkgAsset(releaseFilesToDownload.disclaimer, ipfsEntries, contentUri),
+      gettingStarted: await this.getPkgAsset(releaseFilesToDownload.gettingStarted, ipfsEntries, contentUri),
+      prometheusTargets: await this.getPkgAsset(releaseFilesToDownload.prometheusTargets, ipfsEntries, contentUri),
+      grafanaDashboards: await this.getPkgAsset(releaseFilesToDownload.grafanaDashboards, ipfsEntries, contentUri),
+      notifications: await this.getPkgAsset(releaseFilesToDownload.notifications, ipfsEntries, contentUri)
     };
   }
 
@@ -243,7 +244,7 @@ export class DappnodeRepository extends ApmRepository {
    * @throws - If the file is required and not found.
    * @returns - The release package for the request or undefined if not found.
    */
-  public async getPkgAsset<T>(fileConfig: FileConfig, ipfsEntries: IPFSEntry[]): Promise<T | undefined> {
+  public async getPkgAsset<T>(fileConfig: FileConfig, ipfsEntries: IPFSEntry[], packageHash?: string): Promise<T | undefined> {
     const { regex, required, multiple } = fileConfig;
     // We filter the entries (files) so that we only consider the ones that match the regex.
     // for example, all grafana dashboards must pass /.*grafana-dashboard.json$/ regex
@@ -258,7 +259,7 @@ export class DappnodeRepository extends ApmRepository {
     // Process matched entries. If multiple files are allowed, and more than one file matches, we parse all of them.
     const { maxSize: maxLength, format } = fileConfig;
     const contents = await Promise.all(
-      matchingEntries.map((entry) => this.writeFileToMemory(entry.cid.toString(), maxLength, entry.name))
+      matchingEntries.map((entry) => this.writeFileToMemory(entry.cid.toString(), maxLength, entry.name, packageHash))
     );
 
     // If multiple files are allowed, we return an array of parsed assets.
@@ -278,13 +279,16 @@ export class DappnodeRepository extends ApmRepository {
    * @see catString
    * @see catCarReaderToMemory
    */
-  public async writeFileToMemory(hash: string, maxLength?: number, filename?: string): Promise<string> {
+  public async writeFileToMemory(hash: string, maxLength?: number, filename?: string, packageHash?: string): Promise<string> {
     const cidStr = this.sanitizeIpfsPath(hash.toString());
 
-    // Try mirror first if available and we have a filename
-    if (this.mirrorProvider && filename) {
+    // Try mirror first if available and we have a filename.
+    // Use packageHash (directory CID) for the mirror URL — the mirror serves files
+    // at /{packageCID}/{filename}, not /{fileCID}/{filename}.
+    if (this.mirrorProvider && filename && packageHash) {
+      const mirrorCid = this.sanitizeIpfsPath(packageHash);
       try {
-        const result = await this.mirrorProvider.fetchFile(cidStr, filename, {});
+        const result = await this.mirrorProvider.fetchFile(mirrorCid, filename, {});
 
         if (result.status === "success") {
           if (maxLength && result.bytes.length >= maxLength) {
@@ -303,7 +307,7 @@ export class DappnodeRepository extends ApmRepository {
 
     // Fallback to IPFS
     const chunks: Uint8Array[] = [];
-    const { carReader, root } = await this.getAndVerifyContentFromGateway(hash);
+    const { carReader, root } = await this.getAndVerifyContentFromGateway(cidStr);
     const content = await this.unpackCarReader(carReader, root);
     for await (const chunk of content) chunks.push(chunk);
 
@@ -347,7 +351,8 @@ export class DappnodeRepository extends ApmRepository {
     timeout,
     fileSize,
     progress,
-    filename
+    filename,
+    packageHash
   }: {
     hash: string;
     path: string;
@@ -355,19 +360,22 @@ export class DappnodeRepository extends ApmRepository {
     fileSize?: number;
     progress?: (n: number) => void;
     filename?: string;
+    packageHash?: string;
   }): Promise<void> {
     const cidStr = this.sanitizeIpfsPath(hash.toString());
 
-    // Try mirror first if available and we have a filename
-    if (this.mirrorProvider && filename) {
+    // Try mirror first if available.
+    // Use packageHash (directory CID) for the URL — mirror serves /{packageCID}/{filename}.
+    // Stream directly to disk to avoid loading the entire image into RAM.
+    if (this.mirrorProvider && filename && packageHash) {
+      const mirrorCid = this.sanitizeIpfsPath(packageHash);
       try {
-        const result = await this.mirrorProvider.fetchFile(cidStr, filename, {
+        const result = await this.mirrorProvider.fetchFileToPath(mirrorCid, filename, _path, {
           onProgress: progress
         });
 
         if (result.status === "success") {
-          await fs.promises.writeFile(_path, result.bytes);
-          return; // Success - no need for IPFS fallback
+          return; // Streamed to disk — no IPFS fallback needed
         }
 
         // Mirror failed, fallback to IPFS (no logging)
@@ -377,7 +385,7 @@ export class DappnodeRepository extends ApmRepository {
     }
 
     // Fallback to IPFS
-    const { carReader, root } = await this.getAndVerifyContentFromGateway(hash);
+    const { carReader, root } = await this.getAndVerifyContentFromGateway(cidStr);
     const readable = await this.unpackCarReader(carReader, root);
 
     return new Promise((resolve, reject) => {
@@ -553,7 +561,7 @@ export class DappnodeRepository extends ApmRepository {
    * @param nodeArch - The architecture of the node.
    * @returns The distributed file object of the image.
    */
-  private getImageByArch(manifest: Manifest, files: IPFSEntry[], nodeArch: NodeJS.Architecture): DistributedFile {
+  private getImageByArch(manifest: Manifest, files: IPFSEntry[], nodeArch: NodeJS.Architecture, packageHash?: string): DistributedFile {
     let arch: Architecture;
     switch (nodeArch) {
       case "arm":
@@ -590,7 +598,8 @@ export class DappnodeRepository extends ApmRepository {
         hash: imageAsset.cid.toString(),
         size: imageAsset.size,
         source, // TODO: consdier adding different sources
-        filename: imageAsset.name
+        filename: imageAsset.name,
+        packageHash
       };
     }
   }

--- a/packages/toolkit/src/repository/repository.ts
+++ b/packages/toolkit/src/repository/repository.ts
@@ -29,8 +29,17 @@ import { getReleaseSignatureStatus, serializeIpfsDirectory } from "./releaseSign
 import { isEnsDomain } from "../isEnsDomain.js";
 import { dappnodeRegistry } from "./params.js";
 import { JsonRpcApiProvider } from "ethers";
+import { MirrorProvider, HttpMirrorProvider } from "./contentProvider/index.js";
 
 const source = "ipfs" as const;
+
+export interface DappnodeRepositoryOptions {
+  mirror?: {
+    baseUrl: string;
+    timeoutMs: number;
+    maxBytes: number;
+  };
+}
 
 /**
  * The DappnodeRepository class extends ApmRepository class to provide methods to interact with the IPFS network.
@@ -41,15 +50,26 @@ const source = "ipfs" as const;
 export class DappnodeRepository extends ApmRepository {
   protected gatewayUrl: string;
   protected localIpfsUrl = "http://ipfs.dappnode:5001";
+  private mirrorProvider?: MirrorProvider;
 
   /**
    * Constructs an instance of DappnodeRepository
    * @param ipfsUrl - The URL of the IPFS network node.
    * @param ethUrl - The URL of the Ethereum node to connect to.
+   * @param options - Optional configuration including mirror provider.
    */
-  constructor(ipfsUrl: string, provider: JsonRpcApiProvider) {
+  constructor(ipfsUrl: string, provider: JsonRpcApiProvider, options?: DappnodeRepositoryOptions) {
     super(provider);
     this.gatewayUrl = ipfsUrl.replace(/\/?$/, ""); // e.g. "https://gateway.pinata.cloud"
+
+    // Initialize mirror provider if configured
+    if (options?.mirror) {
+      this.mirrorProvider = new HttpMirrorProvider(
+        options.mirror.baseUrl,
+        options.mirror.timeoutMs,
+        options.mirror.maxBytes
+      );
+    }
   }
 
   /**
@@ -238,7 +258,7 @@ export class DappnodeRepository extends ApmRepository {
     // Process matched entries. If multiple files are allowed, and more than one file matches, we parse all of them.
     const { maxSize: maxLength, format } = fileConfig;
     const contents = await Promise.all(
-      matchingEntries.map((entry) => this.writeFileToMemory(entry.cid.toString(), maxLength))
+      matchingEntries.map((entry) => this.writeFileToMemory(entry.cid.toString(), maxLength, entry.name))
     );
 
     // If multiple files are allowed, we return an array of parsed assets.
@@ -252,12 +272,36 @@ export class DappnodeRepository extends ApmRepository {
    *
    * @param hash - The content identifier (CID) of the file to download.
    * @param maxLength - The maximum length of the file in bytes. If the downloaded file exceeds this length, an error is thrown.
+   * @param filename - Optional filename for mirror downloads.
    * @returns The downloaded file content as a UTF8 string.
    * @throws Error when the maximum size is exceeded.
    * @see catString
    * @see catCarReaderToMemory
    */
-  public async writeFileToMemory(hash: string, maxLength?: number): Promise<string> {
+  public async writeFileToMemory(hash: string, maxLength?: number, filename?: string): Promise<string> {
+    const cidStr = this.sanitizeIpfsPath(hash.toString());
+
+    // Try mirror first if available and we have a filename
+    if (this.mirrorProvider && filename) {
+      try {
+        const result = await this.mirrorProvider.fetchFile(cidStr, filename, {});
+
+        if (result.status === "success") {
+          if (maxLength && result.bytes.length >= maxLength) {
+            throw Error(`Maximum size ${maxLength} bytes exceeded`);
+          }
+
+          const decoder = new TextDecoder("utf-8");
+          return decoder.decode(result.bytes);
+        }
+
+        // Mirror failed, fallback to IPFS (no logging)
+      } catch (error) {
+        // Mirror error, fallback to IPFS (no logging)
+      }
+    }
+
+    // Fallback to IPFS
     const chunks: Uint8Array[] = [];
     const { carReader, root } = await this.getAndVerifyContentFromGateway(hash);
     const content = await this.unpackCarReader(carReader, root);
@@ -293,6 +337,7 @@ export class DappnodeRepository extends ApmRepository {
    * @param args.timeout - The maximum time to wait for the download in milliseconds.
    * @param args.fileSize - The expected size of the file in bytes.
    * @param args.progress - An optional function to call with the download progress.
+   * @param args.filename - Optional filename for mirror downloads.
    * @returns A promise that resolves when the file has been written.
    * @throws Error when a download timeout occurs or if the provided path is invalid.
    */
@@ -301,14 +346,37 @@ export class DappnodeRepository extends ApmRepository {
     path: _path,
     timeout,
     fileSize,
-    progress
+    progress,
+    filename
   }: {
     hash: string;
     path: string;
     timeout?: number;
     fileSize?: number;
     progress?: (n: number) => void;
+    filename?: string;
   }): Promise<void> {
+    const cidStr = this.sanitizeIpfsPath(hash.toString());
+
+    // Try mirror first if available and we have a filename
+    if (this.mirrorProvider && filename) {
+      try {
+        const result = await this.mirrorProvider.fetchFile(cidStr, filename, {
+          onProgress: progress
+        });
+
+        if (result.status === "success") {
+          await fs.promises.writeFile(_path, result.bytes);
+          return; // Success - no need for IPFS fallback
+        }
+
+        // Mirror failed, fallback to IPFS (no logging)
+      } catch (error) {
+        // Mirror error, fallback to IPFS (no logging)
+      }
+    }
+
+    // Fallback to IPFS
     const { carReader, root } = await this.getAndVerifyContentFromGateway(hash);
     const readable = await this.unpackCarReader(carReader, root);
 
@@ -521,7 +589,8 @@ export class DappnodeRepository extends ApmRepository {
       return {
         hash: imageAsset.cid.toString(),
         size: imageAsset.size,
-        source // TODO: consdier adding different sources
+        source, // TODO: consdier adding different sources
+        filename: imageAsset.name
       };
     }
   }

--- a/packages/types/src/calls.ts
+++ b/packages/types/src/calls.ts
@@ -927,6 +927,7 @@ export interface DistributedFile {
   source: DistributedFileSource;
   size: number;
   filename?: string;
+  packageHash?: string; // Parent directory CID, used for mirror URL construction
 }
 
 export interface IpfsRepository {

--- a/packages/types/src/calls.ts
+++ b/packages/types/src/calls.ts
@@ -926,6 +926,7 @@ export interface DistributedFile {
   hash: string;
   source: DistributedFileSource;
   size: number;
+  filename?: string;
 }
 
 export interface IpfsRepository {


### PR DESCRIPTION
This pull request introduces support for downloading package files from an HTTP mirror as a fallback or alternative to IPFS, improving reliability and speed of content delivery. It adds a new mirror provider abstraction, updates configuration to support mirror parameters, and extends the repository and installer logic to utilize mirrors when available. The most significant changes are grouped as follows:

**Mirror Provider Implementation and Integration:**

* Introduced a new `HttpMirrorProvider` class that implements the `MirrorProvider` interface for downloading files from a configured HTTP mirror, with support for timeouts, file size limits, and progress reporting (`mirrorProvider.ts`, `types.ts`, `utils.ts`). [[1]](diffhunk://#diff-cf0a0a123f43e9ea501662b821f1da66a468ca1a35d748a108bad5085f500a12R1-R96) [[2]](diffhunk://#diff-c7c680561de3527aa46a3133b3e929378a3555a92f5cfe8f6bdfcb45bc8bf7faR1-R16) [[3]](diffhunk://#diff-da348be0f006a4d5c865947f1ea51a9fc4e6f200c03be183eb392475aae5db36R1-R30)
* Updated `DappnodeRepository` to accept mirror configuration and use the mirror provider for reading and writing files, falling back to IPFS if the mirror is unavailable or fails (`repository.ts`). [[1]](diffhunk://#diff-a9af413fa8fb0cef0f59b100e5a27234ccd0ac3aeb42f787e05483e0192df364R32-R43) [[2]](diffhunk://#diff-a9af413fa8fb0cef0f59b100e5a27234ccd0ac3aeb42f787e05483e0192df364R53-R72) [[3]](diffhunk://#diff-a9af413fa8fb0cef0f59b100e5a27234ccd0ac3aeb42f787e05483e0192df364R275-R304) [[4]](diffhunk://#diff-a9af413fa8fb0cef0f59b100e5a27234ccd0ac3aeb42f787e05483e0192df364R340) [[5]](diffhunk://#diff-a9af413fa8fb0cef0f59b100e5a27234ccd0ac3aeb42f787e05483e0192df364L304-R379)

**Configuration and Parameters:**

* Added new environment-based parameters for mirror base URL, timeout, and maximum file size in `params.ts`, and passed these to the repository and installer (`params.ts`, `dappnodeInstaller.ts`). [[1]](diffhunk://#diff-536979f21bc68038174bb419fc0b4bc0681e2880b7d52dee6bfb0d8097cde0c7R172-R176) [[2]](diffhunk://#diff-848b595d0a97c77ec3e80c27d9a8f5a67131037eac2b5ccaecfa3da19e3ba0acL49-R57)

**Installer and Download Logic Updates:**

* Modified image download and retrieval functions to support and propagate the optional `filename` parameter, enabling mirror-based downloads (`downloadImages.ts`). [[1]](diffhunk://#diff-511c14bfca3bad57082d179a63d4c5fdefd5ec5f76ff5ac188bb7fe450fcf70aL71-R78) [[2]](diffhunk://#diff-511c14bfca3bad57082d179a63d4c5fdefd5ec5f76ff5ac188bb7fe450fcf70aL99-R104)
* Updated asset and distributed file types to include an optional `filename` field, ensuring compatibility with mirror downloads (`calls.ts`, `repository.ts`). [[1]](diffhunk://#diff-0fb0806d9dba3ce5c00e722af1f857a13d6b468fb264a8cc66dbecb0b88eb626R929) [[2]](diffhunk://#diff-a9af413fa8fb0cef0f59b100e5a27234ccd0ac3aeb42f787e05483e0192df364L524-R593)

**Exports and Utility Improvements:**

* Added exports for new mirror provider modules and utility functions to the content provider index (`index.ts`).

These changes collectively enable the system to fetch files from a reliable HTTP mirror when possible, with seamless fallback to IPFS, improving robustness and configurability.