### PR TITLE
Fix handling of container ports for MacOS Docker API

### DIFF
--- a/packages/dockerApi/src/list/parseContainerInfo.ts
+++ b/packages/dockerApi/src/list/parseContainerInfo.ts
@@ -48,7 +48,7 @@ export function parseContainerInfo(container: ContainerInfo): PackageContainer {
     image: container.Image,
     ip: containerNetworks[params.DOCKER_PRIVATE_NETWORK_NAME]?.IPAddress,
     privateIp: containerNetworks[params.DOCKER_PRIVATE_NETWORK_NEW_NAME]?.IPAddress,
-    ports: ensureUniquePortsFromDockerApi(container.Ports, defaultPorts),
+    ports: container.Ports && ensureUniquePortsFromDockerApi(container.Ports, defaultPorts), // on MacOS docker API might return null for ports
     volumes: container.Mounts.map(
       ({ Name, Source, Destination }): VolumeMapping => ({
         host: Source, // "/var/lib/docker/volumes/nginxproxydnpdappnodeeth_vhost.d/_data",


### PR DESCRIPTION
## Context

This pull request addresses the issue of handling null values for container ports returned by the Docker API on MacOS. It ensures that the application can gracefully manage scenarios where the ports information is not available.

  ```
  ERROR  Error on updateSystemPackages TypeError: Cannot read properties of null (reading 'filter')
      at ensureUniquePortsFromDockerApi (file:///usr/src/app/packages/dockerApi/dist/utils.js:101:10)
      at parseContainerInfo (file:///usr/src/app/packages/dockerApi/dist/list/parseContainerInfo.js:41:16)
  ```

## Approach

The solution modifies the `parseContainerInfo` function to check for null values in the container ports before processing them, preventing potential errors and ensuring stability.

## Test instructions

1. Run the application on MacOS with Docker.
2. Create a container that returns null for ports.
3. Verify that the application handles the null value without crashing and that the rest of the container information is processed correctly.

