### PR TITLE
gets avatars URL from mirror too

### DIFF
--- a/packages/dappmanager/src/calls/fetchDirectory.ts
+++ b/packages/dappmanager/src/calls/fetchDirectory.ts
@@ -45,7 +45,7 @@ export async function fetchDirectory(): Promise<DirectoryItem[]> {
           ...directoryItemBasic,
           status: "ok",
           description: getShortDescription(manifest),
-          avatarUrl: fileToGatewayUrl(avatarFile) || manifest.avatarUrl || "",
+          avatarUrl: fileToGatewayUrl(avatarFile),
           isInstalled: getIsInstalled(release, installedDnpList),
           isUpdated: getIsUpdated(release, installedDnpList),
           featuredStyle: manifest.style,

--- a/packages/dappmanager/src/calls/fetchDnpRequest.ts
+++ b/packages/dappmanager/src/calls/fetchDnpRequest.ts
@@ -95,7 +95,7 @@ export async function fetchDnpRequest({ id, version }: { id: string; version?: s
     semVersion: mainRelease.semVersion,
     reqVersion: mainRelease.reqVersion,
     origin: mainRelease.origin, // "/ipfs/Qm"
-    avatarUrl: fileToGatewayUrl(mainRelease.avatarFile) || mainRelease.manifest.avatarUrl || "",
+    avatarUrl: fileToGatewayUrl(mainRelease.avatarFile),
     // Setup
     setupWizard,
     // Additional data

--- a/packages/dappmanager/src/calls/fetchRegistry.ts
+++ b/packages/dappmanager/src/calls/fetchRegistry.ts
@@ -57,7 +57,7 @@ async function fetchRegistryIpfsData(registry: PublicRegistryEntry[]): Promise<D
           ...registryItemBasic,
           status: "ok",
           description: getShortDescription(manifest),
-          avatarUrl: fileToGatewayUrl(avatarFile) || manifest.avatarUrl || "",
+          avatarUrl: fileToGatewayUrl(avatarFile),
           isInstalled: getIsInstalled(release, dnpList),
           isUpdated: getIsUpdated(release, dnpList),
           featuredStyle: manifest.style,

--- a/packages/installer/src/dappnodeInstaller.ts
+++ b/packages/installer/src/dappnodeInstaller.ts
@@ -226,7 +226,7 @@ export class DappnodeInstaller extends DappnodeRepository {
           version: manifest.version,
           serviceName: service.serviceName,
           dependencies: sanitizeDependencies(metadata.dependencies || {}),
-          avatar: this.fileToMultiaddress(avatarFile) || manifest.avatarUrl,
+          avatar: this.fileToMultiaddress(avatarFile),
           chain: metadata.chain,
           origin,
           isCore,

--- a/packages/optimism/src/getOptimismConfig.ts
+++ b/packages/optimism/src/getOptimismConfig.ts
@@ -29,7 +29,7 @@ export async function getOptimismConfig(dappnodeInstaller: DappnodeInstaller): P
             return {
               status: "ok",
               dnpName: execClient,
-              avatarUrl: fileToGatewayUrl(pkgData.avatarFile) || pkgData.manifest.avatarUrl || "",
+              avatarUrl: fileToGatewayUrl(pkgData.avatarFile),
               isInstalled: getIsInstalled(pkgData, dnpList),
               isUpdated: getIsUpdated(pkgData, dnpList),
               isRunning: getIsRunning(pkgData, dnpList),
@@ -59,7 +59,7 @@ export async function getOptimismConfig(dappnodeInstaller: DappnodeInstaller): P
             resolve({
               status: "ok",
               dnpName: optimismNode,
-              avatarUrl: fileToGatewayUrl(pkgData.avatarFile) || pkgData.manifest.avatarUrl || "",
+              avatarUrl: fileToGatewayUrl(pkgData.avatarFile),
               isInstalled: getIsInstalled(pkgData, dnpList),
               isUpdated: getIsUpdated(pkgData, dnpList),
               isRunning,
@@ -89,7 +89,7 @@ export async function getOptimismConfig(dappnodeInstaller: DappnodeInstaller): P
             resolve({
               status: "ok",
               dnpName: optimismL2Geth,
-              avatarUrl: fileToGatewayUrl(pkgData.avatarFile) || pkgData.manifest.avatarUrl || "",
+              avatarUrl: fileToGatewayUrl(pkgData.avatarFile),
               isInstalled: getIsInstalled(pkgData, dnpList),
               isUpdated: getIsUpdated(pkgData, dnpList),
               isRunning,

--- a/packages/stakers/src/stakerComponent.ts
+++ b/packages/stakers/src/stakerComponent.ts
@@ -37,7 +37,7 @@ protected async getAll({
           return {
             status: "ok",
             dnpName,
-            avatarUrl: fileToGatewayUrl(pkgData.avatarFile) || pkgData.manifest.avatarUrl || "",
+            avatarUrl: fileToGatewayUrl(pkgData.avatarFile),
             isInstalled: getIsInstalled(pkgData, dnpList),
             isUpdated: getIsUpdated(pkgData, dnpList),
             isRunning: getIsRunning(pkgData, dnpList),

--- a/packages/toolkit/src/repository/repository.ts
+++ b/packages/toolkit/src/repository/repository.ts
@@ -220,15 +220,15 @@ export class DappnodeRepository extends ApmRepository {
       : true;
 
     // Avatar file hash is an individual file CID — only meaningful when listing came from IPFS.
-    // When using mirror listing, set avatarUrl directly in the manifest so it's available to the UI.
-    const avatarEntry = hasRealCids ? ipfsEntries.find((file: IPFSEntry) => releaseFiles.avatar.regex.test(file.name)) : undefined;
+    // When mirror is used, source is "mirror" so fileToGatewayUrl builds the HTTP mirror URL.
+    const avatarEntry = ipfsEntries.find((file: IPFSEntry) => releaseFiles.avatar.regex.test(file.name));
     const avatarFile: DistributedFile | undefined = avatarEntry
-      ? { hash: avatarEntry.cid.toString(), size: avatarEntry.size, source }
+      ? hasRealCids
+        // source is IPFS by default.
+        ? { hash: avatarEntry.cid.toString(), size: avatarEntry.size, source }   
+        // If fetched from mirror, source is mirror and we include filename and packageHash for mirror URL construction.
+        : { hash: avatarEntry.cid.toString(), size: avatarEntry.size, source: "mirror", filename: avatarEntry.name, packageHash: packageCidStr } 
       : undefined;
-
-    if (!hasRealCids && this.mirrorProvider) {
-      manifest.avatarUrl = this.mirrorProvider.getFileUrl(packageCidStr, "avatar.png");
-    }
 
     return {
       dnpName,

--- a/packages/types/src/calls.ts
+++ b/packages/types/src/calls.ts
@@ -921,15 +921,13 @@ export interface LocalIpResponse {
  * ====
  */
 
-export type DistributedFileSource = "ipfs" | "swarm";
+export type DistributedFileSource = "ipfs" | "swarm" | "mirror";
 export interface DistributedFile {
-  hash: string;
+  hash: string; // Individual file CID for "ipfs". Needed for fetching the file from IPFS.
   source: DistributedFileSource;
   size: number;
-  /** Filename within the package directory (used for mirror URL construction) */
-  filename?: string;
-  /** Package directory CID (used for mirror URL: /{packageHash}/{filename}) */
-  packageHash?: string;
+  filename?: string; // Required for "mirror": filename within the package dir (e.g. "avatar.png")
+  packageHash?: string; // Required for "mirror": package directory CID; mirror URL is {baseUrl}/{packageHash}/{filename}
 }
 
 export interface IpfsRepository {

--- a/packages/types/src/pkg.ts
+++ b/packages/types/src/pkg.ts
@@ -179,12 +179,14 @@ export interface TrustedReleaseKey {
   key: string;
 }
 
-type DistributedFileSource = "ipfs" | "swarm";
+type DistributedFileSource = "ipfs" | "swarm" | "mirror";
 
 interface DistributedFile {
-  hash: string;
+  hash: string; // Individual file CID for "ipfs". Needed for fetching the file from IPFS.
   source: DistributedFileSource;
   size: number;
+  filename?: string; // Required for "mirror": filename within the package dir (e.g. "avatar.png")
+  packageHash?: string; // Required for "mirror": package directory CID; mirror URL is {baseUrl}/{packageHash}/{filename}
 }
 
 /**

--- a/packages/utils/src/fileToGatewayUrl.ts
+++ b/packages/utils/src/fileToGatewayUrl.ts
@@ -15,6 +15,11 @@ export function fileToGatewayUrl(distributedFile?: DistributedFile): string {
   switch (distributedFile.source) {
     case "ipfs":
       return url.resolve(url.resolve(params.IPFS_REMOTE, params.IPFS_GATEWAY), normalizeHash(distributedFile.hash));
+    case "mirror": {
+      if (!distributedFile.filename || !distributedFile.packageHash) return "";
+      const base = params.CONTENT_MIRROR_BASE_URL.replace(/\/?$/, "");
+      return `${base}/${normalizeHash(distributedFile.packageHash)}/${distributedFile.filename}`;
+    }
     default:
       throw Error(`Source not supported: ${distributedFile.source}`);
   }


### PR DESCRIPTION
This pull request standardizes how avatar URLs are constructed and handled throughout the codebase. The main change is to always use the `fileToGatewayUrl` function for avatar files, removing fallback logic to manifest URLs. Additionally, support for a new `"mirror"` file source is introduced, enabling avatar files to be fetched from HTTP mirrors with proper URL construction. Type definitions are updated to reflect this new source and its required fields.

**Avatar URL handling improvements:**

* All avatar URL assignments now exclusively use `fileToGatewayUrl`, removing fallback to manifest URLs in functions such as `fetchDirectory`, `fetchDnpRequest`, `fetchRegistryIpfsData`, `getOptimismConfig`, and `getAll` in various files. [[1]](diffhunk://#diff-d188cab3a1f099f366fe9edf4c6a797b74c583410f716956f14b155c3b3700c4L48-R48) [[2]](diffhunk://#diff-064e7b605fb6f453e7ef8fb35430e60b85260cc065ee524fb4b32a61e7a989f4L98-R98) [[3]](diffhunk://#diff-1aeada61722ce0b3ae5574fb68d57d191c91a2184f7fbee4b66eca4b48c374c0L60-R60) [[4]](diffhunk://#diff-4a04084d92dae9970253aa764df4c8f7419b23a6d97a55acd076e45d10b444ebL32-R32) [[5]](diffhunk://#diff-4a04084d92dae9970253aa764df4c8f7419b23a6d97a55acd076e45d10b444ebL62-R62) [[6]](diffhunk://#diff-4a04084d92dae9970253aa764df4c8f7419b23a6d97a55acd076e45d10b444ebL92-R92) [[7]](diffhunk://#diff-ecef59d54ee6f253aec26af805eeff436f7899172b8e6fe4d4d097b605332b05L40-R40) [[8]](diffhunk://#diff-848b595d0a97c77ec3e80c27d9a8f5a67131037eac2b5ccaecfa3da19e3ba0acL229-R229)

* The repository logic is updated so that avatar file entries are always constructed, and mirror sources are handled explicitly, removing previous logic that set `manifest.avatarUrl` directly when using mirrors.

**Distributed file source enhancements:**

* The `DistributedFileSource` type now includes `"mirror"`, and the `DistributedFile` interface is updated to require `filename` and `packageHash` for mirror sources, with clarifying comments. [[1]](diffhunk://#diff-0fb0806d9dba3ce5c00e722af1f857a13d6b468fb264a8cc66dbecb0b88eb626L924-R930) [[2]](diffhunk://#diff-f8d2e5fecdb6f3096d04bc6cd38256d8d5a5961844f5c2d648e12b3caa32d67dL182-R189)

* The `fileToGatewayUrl` utility function is enhanced to generate proper URLs for mirror sources, using the base mirror URL, package hash, and filename, and returning an empty string if required fields are missing.