### PR TITLE
WIP no recreate and log compose changes

### DIFF
--- a/packages/dockerCompose/src/editor.ts
+++ b/packages/dockerCompose/src/editor.ts
@@ -303,8 +303,11 @@ export class ComposeEditor {
       if (typeof service.environment === "object" && !Array.isArray(service.environment))
         service.environment = stringifyEnvironment(service.environment);
 
-      // Remove hardcoded DNS
-      service.dns = undefined;
+      // Remove hardcoded DNS — use delete to fully remove the key from the object.
+      // Setting to undefined would leave the key present, causing yamlDump to serialize
+      // it as `dns: null`, which Docker Compose treats as a config change and triggers
+      // unnecessary container recreation.
+      delete service.dns;
 
       return {
         ...omitBy(service, (el) => isObject(el) && isEmpty(el)),

--- a/packages/dockerCompose/test/unit/network.test.ts
+++ b/packages/dockerCompose/test/unit/network.test.ts
@@ -55,8 +55,7 @@ describe("modules / compose / networks", () => {
             image,
             networks: {
               [networkName]: { aliases }
-            },
-            dns: undefined
+            }
           }
         },
         networks: {
@@ -71,8 +70,7 @@ describe("modules / compose / networks", () => {
         services: {
           "sample.dnp.dappnode.eth": {
             container_name,
-            image,
-            dns: undefined
+            image
           }
         },
         networks: {}

--- a/packages/stakers/src/stakerComponent.ts
+++ b/packages/stakers/src/stakerComponent.ts
@@ -6,6 +6,7 @@ import { InstalledPackageData, StakerItem, UserSettings, Network } from "@dappno
 import { getIsInstalled, getIsUpdated, getIsRunning, fileToGatewayUrl } from "@dappnode/utils";
 import { lt } from "semver";
 import { params } from "@dappnode/params";
+import fs from "fs";
 
 export class StakerComponent {
   protected dappnodeInstaller: DappnodeInstaller;
@@ -153,22 +154,37 @@ protected async getAll({
     dnpName: string;
     userSettings: UserSettings;
   }): Promise<void> {
+    let composeChanged = false;
+
     if (userSettings) {
       const composeEditor = new ComposeFileEditor(dnpName, false);
 
+      // Read the current compose YAML from disk before applying settings
+      const yamlBefore = fs.readFileSync(composeEditor.composePath, "utf8");
+
       composeEditor.applyUserSettings(userSettings, { dnpName });
-      // it must be called write after applying user settings otherwise the new settings will be lost and therefore the compose up will not have effect
       composeEditor.write();
+
+      // Compare the YAML after writing to detect actual changes
+      const yamlAfter = fs.readFileSync(composeEditor.composePath, "utf8");
+      composeChanged = yamlBefore !== yamlAfter;
+
+      if (composeChanged) {
+        logs.info(`Compose file changed for ${dnpName}, containers will be recreated`);
+      }
     }
 
-    // start all containers
+    // Ensure all containers are running.
+    // Use --no-recreate when the compose file hasn't changed to prevent
+    // unnecessary container recreation (which causes brief downtime).
+    // When the compose DID change (e.g. new backup beacon nodes), allow
+    // Docker Compose to recreate containers with the updated config.
     await dockerComposeUpPackage({
       composeArgs: { dnpName },
-      upAll: true
-      // dockerComposeUpOptions: { noRecreate: true }
+      upAll: true,
+      dockerComposeUpOptions: composeChanged ? undefined : { noRecreate: true }
     });
   }
-
   /**
    * Unset staker pkg:
    * - disconnects the staker pkg from the staker network


### PR DESCRIPTION
This pull request makes improvements to how Docker Compose files are managed and containers are recreated, focusing on preventing unnecessary container restarts and ensuring accurate detection of configuration changes. The main changes involve removing hardcoded DNS entries, updating test cases, and enhancing the logic for detecting and handling compose file modifications in the `StakerComponent`.

**Compose file management improvements:**

* Updated `ComposeEditor` to use `delete service.dns` instead of setting it to `undefined`, preventing `dns: null` from appearing in the YAML and avoiding unnecessary container recreation by Docker Compose.

**Test updates for DNS removal:**

* Modified unit tests in `network.test.ts` to remove references to `dns: undefined`, aligning tests with the updated compose file logic. [[1]](diffhunk://#diff-45f01d9d5d1176c95ab137d3f29947e24dcd855407cabc2227f3e09ffb7ccb2cL58-R58) [[2]](diffhunk://#diff-45f01d9d5d1176c95ab137d3f29947e24dcd855407cabc2227f3e09ffb7ccb2cL74-R73)

**StakerComponent enhancements:**

* Added logic in `StakerComponent` to read the compose YAML before and after applying user settings, detect actual changes, and only allow Docker Compose to recreate containers when the file has changed—otherwise, it uses `--no-recreate` to minimize downtime.
* Introduced `fs` import to support reading compose files for change detection.