### PR TITLE
Add tooltip for clients progress percentage

### DIFF
--- a/packages/admin-ui/src/pages/dashboard/components/NetworkCards.tsx
+++ b/packages/admin-ui/src/pages/dashboard/components/NetworkCards.tsx
@@ -238,7 +238,16 @@ const ClientSection = ({
             </div>
           </div>
         </div>
-        {showProgress && progress !== undefined && <ProgressBar animated now={progress} />}
+        {showProgress && progress !== undefined && (
+          <OverlayTrigger
+            overlay={
+              <Tooltip id={`${clientData.name}-${network}-progress-tooltip`}>Syncing progress: {progress}%</Tooltip>
+            }
+            placement="top"
+          >
+            <ProgressBar animated now={progress} />
+          </OverlayTrigger>
+        )}
       </div>
     );
   }


### PR DESCRIPTION
Add a tooltip to display the syncing progress percentage when hovering over the progress bar in the dashboard client cards.