### PR TITLE
Add categories to container and package parsing

### DIFF
--- a/packages/dockerApi/src/list/parseContainerInfo.ts
+++ b/packages/dockerApi/src/list/parseContainerInfo.ts
@@ -34,7 +34,8 @@ export function parseContainerInfo(container: ContainerInfo): PackageContainer {
   }));
   // Declared here for reusability purposes
   const isDnp = Boolean(labels.dnpName) || containerName.includes(CONTAINER_NAME_PREFIX);
-  const isCore = typeof labels.isCore === "boolean" ? labels.isCore : containerName.includes(CONTAINER_CORE_NAME_PREFIX);
+  const isCore =
+    typeof labels.isCore === "boolean" ? labels.isCore : containerName.includes(CONTAINER_CORE_NAME_PREFIX);
 
   return {
     // Identification
@@ -72,6 +73,7 @@ export function parseContainerInfo(container: ContainerInfo): PackageContainer {
     avatarUrl: resolveAvatarUrl(labels.avatar, dnpName, isCore),
     origin: labels.origin,
     chain: labels.chain,
+    categories: labels.categories,
     canBeFullnode: allowedFullnodeDnpNames.includes(dnpName),
     isMain: labels.isMain,
     // Default settings on the original package version's docker-compose

--- a/packages/dockerApi/src/list/parseContainerInfo.ts
+++ b/packages/dockerApi/src/list/parseContainerInfo.ts
@@ -34,8 +34,7 @@ export function parseContainerInfo(container: ContainerInfo): PackageContainer {
   }));
   // Declared here for reusability purposes
   const isDnp = Boolean(labels.dnpName) || containerName.includes(CONTAINER_NAME_PREFIX);
-  const isCore =
-    typeof labels.isCore === "boolean" ? labels.isCore : containerName.includes(CONTAINER_CORE_NAME_PREFIX);
+  const isCore = typeof labels.isCore === "boolean" ? labels.isCore : containerName.includes(CONTAINER_CORE_NAME_PREFIX);
 
   return {
     // Identification

--- a/packages/dockerApi/src/list/parsePackageFromContainer.ts
+++ b/packages/dockerApi/src/list/parsePackageFromContainer.ts
@@ -20,6 +20,7 @@ export function groupPackagesFromContainers(containers: PackageContainer[]): Ins
           "avatarUrl",
           "origin",
           "chain",
+          "categories",
           "domainAlias",
           "canBeFullnode"
         ]),

--- a/packages/dockerCompose/src/labelsDb.ts
+++ b/packages/dockerCompose/src/labelsDb.ts
@@ -57,6 +57,7 @@ const labelParseFns: {
       return valueParsed as ChainDriver;
     return undefined;
   },
+  "dappnode.dnp.categories": (value) => parseJsonSafe<string[]>(value) || undefined,
   "dappnode.dnp.isCore": parseBool,
   "dappnode.dnp.isMain": parseBool,
   "dappnode.dnp.dockerTimeout": parseNumber,
@@ -79,6 +80,7 @@ const labelStringifyFns: {
     value && chainDriversTypes.includes(value as ChainDriverType)
       ? writeString(value as ChainDriverType)
       : writeJson(value as ChainDriverSpecs),
+  "dappnode.dnp.categories": writeJson,
   "dappnode.dnp.isCore": writeBool,
   "dappnode.dnp.isMain": writeBool,
   "dappnode.dnp.dockerTimeout": writeNumber,
@@ -120,6 +122,7 @@ export function readContainerLabels(labelsRaw: ContainerLabelsRaw): Partial<{
   avatar: string;
   origin: string;
   chain: ChainDriver;
+  categories: string[];
   isCore: boolean;
   isMain: boolean;
   dockerTimeout: number;
@@ -137,6 +140,7 @@ export function readContainerLabels(labelsRaw: ContainerLabelsRaw): Partial<{
     avatar: labelValues["dappnode.dnp.avatar"],
     origin: labelValues["dappnode.dnp.origin"],
     chain: labelValues["dappnode.dnp.chain"],
+    categories: labelValues["dappnode.dnp.categories"],
     isCore: labelValues["dappnode.dnp.isCore"],
     isMain: labelValues["dappnode.dnp.isMain"],
     dockerTimeout: labelValues["dappnode.dnp.dockerTimeout"],
@@ -153,6 +157,7 @@ export function writeMetadataToLabels({
   dependencies,
   avatar,
   chain,
+  categories,
   origin,
   isCore,
   isMain,
@@ -164,6 +169,7 @@ export function writeMetadataToLabels({
   dependencies?: Dependencies;
   avatar?: string;
   chain?: ChainDriver;
+  categories?: string[];
   origin?: string;
   isCore?: boolean;
   isMain?: boolean;
@@ -177,6 +183,7 @@ export function writeMetadataToLabels({
     "dappnode.dnp.avatar": avatar,
     "dappnode.dnp.origin": origin,
     "dappnode.dnp.chain": chain,
+    "dappnode.dnp.categories": categories,
     "dappnode.dnp.isCore": isCore,
     "dappnode.dnp.isMain": isMain,
     "dappnode.dnp.dockerTimeout": dockerTimeout

--- a/packages/dockerCompose/src/types.ts
+++ b/packages/dockerCompose/src/types.ts
@@ -18,6 +18,7 @@ export interface ContainerLabelTypes {
   "dappnode.dnp.avatar": string;
   "dappnode.dnp.origin": string;
   "dappnode.dnp.chain": ChainDriver;
+  "dappnode.dnp.categories": string[];
   "dappnode.dnp.isCore": boolean;
   "dappnode.dnp.isMain": boolean;
   "dappnode.dnp.dockerTimeout": number;

--- a/packages/dockerCompose/test/unit/labelDb.test.ts
+++ b/packages/dockerCompose/test/unit/labelDb.test.ts
@@ -13,6 +13,7 @@ describe("Parse and validate manifest labels to be used in the compose", () => {
       avatar: "avatar-url",
       origin: "origin-url",
       chain: "ethereum2-beacon-chain-prysm",
+      categories: undefined,
       isCore: true,
       isMain: true,
       dockerTimeout: 10,
@@ -54,6 +55,7 @@ describe("Parse and validate manifest labels to be used in the compose", () => {
       chain: {
         driver: "ethereum2-beacon-chain-prysm"
       },
+      categories: undefined,
       isCore: true,
       isMain: true,
       dockerTimeout: 10,
@@ -93,6 +95,7 @@ describe("Parse and validate manifest labels to be used in the compose", () => {
       avatar: "avatar-url",
       origin: "origin-url",
       chain: undefined,
+      categories: undefined,
       isCore: true,
       isMain: true,
       dockerTimeout: 10,

--- a/packages/installer/src/dappnodeInstaller.ts
+++ b/packages/installer/src/dappnodeInstaller.ts
@@ -49,11 +49,7 @@ export class DappnodeInstaller extends DappnodeRepository {
     super(
       ipfsUrl,
       provider,
-      {
-        baseUrl: params.CONTENT_MIRROR_BASE_URL,
-        timeoutMs: params.CONTENT_MIRROR_TIMEOUT_MS,
-        maxBytes: params.CONTENT_MIRROR_MAX_BYTES
-      },
+      { baseUrl: params.CONTENT_MIRROR_BASE_URL, timeoutMs: params.CONTENT_MIRROR_TIMEOUT_MS, maxBytes: params.CONTENT_MIRROR_MAX_BYTES },
       () => db.mirrorProviderEnabled.get()
     );
   }

--- a/packages/installer/src/dappnodeInstaller.ts
+++ b/packages/installer/src/dappnodeInstaller.ts
@@ -49,7 +49,11 @@ export class DappnodeInstaller extends DappnodeRepository {
     super(
       ipfsUrl,
       provider,
-      { baseUrl: params.CONTENT_MIRROR_BASE_URL, timeoutMs: params.CONTENT_MIRROR_TIMEOUT_MS, maxBytes: params.CONTENT_MIRROR_MAX_BYTES },
+      {
+        baseUrl: params.CONTENT_MIRROR_BASE_URL,
+        timeoutMs: params.CONTENT_MIRROR_TIMEOUT_MS,
+        maxBytes: params.CONTENT_MIRROR_MAX_BYTES
+      },
       () => db.mirrorProviderEnabled.get()
     );
   }
@@ -225,6 +229,7 @@ export class DappnodeInstaller extends DappnodeRepository {
           dependencies: sanitizeDependencies(metadata.dependencies || {}),
           avatar: this.fileToMultiaddress(avatarFile),
           chain: metadata.chain,
+          categories: metadata.categories,
           origin,
           isCore,
           isMain:

--- a/packages/types/src/calls.ts
+++ b/packages/types/src/calls.ts
@@ -523,6 +523,7 @@ export interface PackageContainer {
   avatarUrl: string;
   origin?: string;
   chain?: ChainDriver;
+  categories?: string[];
   domainAlias?: string[];
   canBeFullnode?: boolean;
   isMain?: boolean;
@@ -546,6 +547,7 @@ export type InstalledPackageData = Pick<
   | "avatarUrl"
   | "origin"
   | "chain"
+  | "categories"
   | "domainAlias"
   | "canBeFullnode"
 > & {


### PR DESCRIPTION
- [x] Add `categories` field to `PackageContainer` and `InstalledPackageData` types
- [x] Add `categories` label parsing/writing in `labelsDb.ts` and `types.ts`
- [x] Include `categories` in `parseContainerInfo` return and `groupPackagesFromContainers`
- [x] Pass `categories` from manifest metadata to labels in `dappnodeInstaller.ts`
- [x] Add test coverage for `categories` in label round-trip tests
- [x] Remove unrelated formatting changes per reviewer feedback

<!-- START COPILOT CODING AGENT TIPS -->
---

⚡ Quickly spin up Copilot coding agent tasks from anywhere on your macOS or Windows machine with [Raycast](https://gh.io/cca-raycast-docs).
