### PR TITLE
Refactor pages to use PageContainer and PageHeader components

### DIFF
--- a/.github/instructions/admin-ui.instructions.md
+++ b/.github/instructions/admin-ui.instructions.md
@@ -166,29 +166,60 @@ When creating a new page:
 
 1. **Place it inside `src/pages-new/`** in the appropriate context folder.
 2. **Wrap it with `<NewPageLayout>`** (or `<div className="tw-base">` for custom layouts).
-3. **Use layout spacing tokens** (`tw:px-page-x`, `tw:py-page-y`, `tw:gap-section`, `tw:gap-card`, `tw:mt-header-gap`).
+3. **Use the page layout primitives** from `components/primitives/page` for consistent structure.
 4. **Add a route** in `src/App.tsx` under the "New UI routes" section.
 5. **Never modify legacy pages** in `src/pages/`.
+
+### Page Layout Primitives
+
+The project provides layout primitives in `src/components/primitives/page.tsx` that **must** be used for all page-level structure:
+
+| Component         | Purpose                                                   |
+| ----------------- | --------------------------------------------------------- |
+| `PageContainer`   | Outermost wrapper — applies `px-page-x`, `py-page-y`, `gap-section`, flexbox column layout. Replaces the repeated `<div className="tw:flex tw:flex-col tw:gap-section tw:px-page-x tw:py-page-y">` pattern. |
+| `PageHeader`      | Semantic `<header>` with optional `title` and `description` shorthand props. Also accepts `children` for composed content. |
+| `PageTitle`       | Wraps `TypographyH3` (`<h3>`, 2xl, semibold, tracking-tight) for consistent page headings. |
+| `PageDescription` | Wraps `TypographyMuted` with `mt-header-gap` spacing and `max-w-2xl`. |
+
+**Do not** duplicate the container/header pattern with raw HTML + utility classes — always use these primitives.
 
 ### Standard Page Structure
 
 ```tsx
-import { NewPageLayout } from "pages-new/layouts";
+import { PageContainer, PageHeader } from "components/primitives/page";
 
 export function MyPage() {
   return (
-    <NewPageLayout>
-      <div className="tw:flex tw:flex-col tw:gap-section tw:px-page-x tw:py-page-y">
-        <header>
-          <h1 className="tw:text-3xl tw:font-bold tw:tracking-tight tw:text-foreground">Title</h1>
-          <p className="tw:mt-header-gap tw:text-muted-foreground tw:max-w-2xl">Description</p>
-        </header>
-        {/* Page content */}
-      </div>
-    </NewPageLayout>
+    <PageContainer>
+      <PageHeader title="My Page" description="A short description of this page." />
+      {/* Page content */}
+    </PageContainer>
   );
 }
 ```
+
+### Composed Header (custom content)
+
+```tsx
+import { PageContainer, PageHeader, PageTitle, PageDescription } from "components/primitives/page";
+
+export function MyPage() {
+  return (
+    <PageContainer>
+      <PageHeader>
+        <PageTitle>My Page</PageTitle>
+        <PageDescription>Description with <strong>rich content</strong>.</PageDescription>
+        <Button>Custom action</Button>
+      </PageHeader>
+      {/* Page content */}
+    </PageContainer>
+  );
+}
+```
+
+### PageContainer with custom gap
+
+The detail page uses `<PageContainer className="tw:gap-6">` to override the default `gap-section` when tighter spacing is needed (e.g., for tab layouts).
 
 ## API Integration
 
@@ -232,7 +263,8 @@ The project provides typography components in `src/components/primitives/typogra
 - `TypographyH1` through `TypographyH4` — heading elements with consistent styling.
 - `TypographyMuted` — muted paragraph text for descriptions.
 - `TypographyInlineCode` — inline code snippets.
-- Use these instead of raw `<h1>`, `<p>` elements in new pages for consistent typography.
+
+**For page-level titles and descriptions**, prefer the page layout primitives (`PageTitle`, `PageDescription`) from `components/primitives/page` — they wrap `TypographyH3` and `TypographyMuted` respectively, adding consistent spacing tokens. Use the typography primitives directly for content-level headings within cards, sections, or prose.
 
 ## Coding Conventions
 

--- a/packages/admin-ui/src/components/primitives/page.tsx
+++ b/packages/admin-ui/src/components/primitives/page.tsx
@@ -1,0 +1,92 @@
+import * as React from "react";
+import { cn } from "lib/utils";
+import { TypographyH3, TypographyMuted } from "components/primitives/typography";
+
+/**
+ * Page-level container that applies the standard page padding and
+ * vertical rhythm. Use this as the outermost wrapper inside every
+ * route component rendered within `AiLayout`.
+ *
+ * ```tsx
+ * <PageContainer>
+ *   <PageHeader title="Packages" description="Manage your packages." />
+ *   <MyContent />
+ * </PageContainer>
+ * ```
+ */
+function PageContainer({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="page-container"
+      className={cn("tw:flex tw:flex-col tw:gap-section tw:px-page-x tw:py-page-y", className)}
+      {...props}
+    />
+  );
+}
+
+/**
+ * Standardised page header with a title and optional description.
+ *
+ * Renders a semantic `<header>` element containing:
+ * - A `<PageTitle>` (TypographyH3) for the page heading
+ * - An optional `<PageDescription>` (TypographyMuted) paragraph
+ *
+ * Supports both the shorthand props API and composition:
+ *
+ * ```tsx
+ * // Shorthand
+ * <PageHeader title="Store" description="Browse AI packages." />
+ *
+ * // Composed (for custom content)
+ * <PageHeader>
+ *   <PageTitle>Store</PageTitle>
+ *   <PageDescription>Browse AI packages.</PageDescription>
+ *   <Button>Custom action</Button>
+ * </PageHeader>
+ * ```
+ */
+function PageHeader({
+  className,
+  title,
+  description,
+  children,
+  ...props
+}: React.ComponentProps<"header"> & {
+  /** Shorthand: renders a `<PageTitle>` with this text. */
+  title?: React.ReactNode;
+  /** Shorthand: renders a `<PageDescription>` below the title. */
+  description?: React.ReactNode;
+}) {
+  return (
+    <header data-slot="page-header" className={cn("tw:flex tw:flex-col", className)} {...props}>
+      {title && <PageTitle>{title}</PageTitle>}
+      {description && <PageDescription>{description}</PageDescription>}
+      {children}
+    </header>
+  );
+}
+
+/**
+ * The main heading for a page — wraps `TypographyH3` to ensure
+ * consistent page-level heading style across all routes.
+ */
+function PageTitle({ className, ...props }: React.ComponentProps<"h3">) {
+  return <TypographyH3 data-slot="page-title" className={className} {...props} />;
+}
+
+/**
+ * A muted description paragraph that sits below `<PageTitle>`.
+ * Wraps `TypographyMuted` and adds the standard `header-gap`
+ * spacing token and max-width constraint.
+ */
+function PageDescription({ className, ...props }: React.ComponentProps<"p">) {
+  return (
+    <TypographyMuted
+      data-slot="page-description"
+      className={cn("tw:mt-header-gap tw:max-w-2xl", className)}
+      {...props}
+    />
+  );
+}
+
+export { PageContainer, PageHeader, PageTitle, PageDescription };

--- a/packages/admin-ui/src/pages-new/ai/OverviewPage.tsx
+++ b/packages/admin-ui/src/pages-new/ai/OverviewPage.tsx
@@ -14,6 +14,7 @@ import { toast } from "sonner";
 
 /* ── Existing primitives ─────────────────────────────────────────── */
 import { Button } from "components/primitives/button";
+import { PageContainer, PageHeader } from "components/primitives/page";
 import {
   Card,
   ClickableCard,
@@ -174,15 +175,12 @@ export function OverviewPage() {
 
   return (
     <TooltipProvider delayDuration={0}>
-      <div className="tw:flex tw:flex-col tw:gap-section tw:px-page-x tw:py-page-y tw:max-w-content-max">
+      <PageContainer className="tw:max-w-content-max">
         {/* Page header */}
-        <header>
-          <h1 className="tw:text-3xl tw:font-bold tw:tracking-tight tw:text-foreground">AI Overview</h1>
-          <p className="tw:mt-header-gap tw:text-muted-foreground tw:max-w-2xl">
-            Component showcase — every shadcn primitive rendered with all its variants. Use this page to verify
-            consistency across light and dark mode.
-          </p>
-        </header>
+        <PageHeader
+          title="AI Overview"
+          description="Component showcase — every shadcn primitive rendered with all its variants. Use this page to verify consistency across light and dark mode."
+        />
 
         <Separator />
 
@@ -925,7 +923,7 @@ export function OverviewPage() {
 
         {/* Bottom spacer */}
         <div className="tw:h-8" />
-      </div>
+      </PageContainer>
     </TooltipProvider>
   );
 }

--- a/packages/admin-ui/src/pages-new/ai/installer/InstallerPage.tsx
+++ b/packages/admin-ui/src/pages-new/ai/installer/InstallerPage.tsx
@@ -6,6 +6,7 @@ import { getProgressLogsByDnp } from "services/isInstallingLogs/selectors";
 import { Alert, AlertTitle, AlertDescription } from "components/primitives/alert";
 import { Skeleton } from "components/primitives/skeleton";
 import { Spinner } from "components/primitives/spinner";
+import { PageContainer } from "components/primitives/page";
 import { TriangleAlert } from "lucide-react";
 import { InstallerView } from "./InstallerView";
 
@@ -21,13 +22,13 @@ export function InstallerPage() {
 
   if (!id) {
     return (
-      <div className="tw:px-page-x tw:py-page-y">
+      <PageContainer>
         <Alert variant="destructive">
           <TriangleAlert className="tw:size-4" />
           <AlertTitle>Missing package ID</AlertTitle>
           <AlertDescription>No package ID was provided in the URL.</AlertDescription>
         </Alert>
-      </div>
+      </PageContainer>
     );
   }
 
@@ -38,19 +39,19 @@ export function InstallerPage() {
 
   if (error) {
     return (
-      <div className="tw:px-page-x tw:py-page-y">
+      <PageContainer>
         <Alert variant="destructive">
           <TriangleAlert className="tw:size-4" />
           <AlertTitle>Failed to load package</AlertTitle>
           <AlertDescription>{typeof error === "string" ? error : error.message}</AlertDescription>
         </Alert>
-      </div>
+      </PageContainer>
     );
   }
 
   if (!dnp) {
     return (
-      <div className="tw:flex tw:flex-col tw:items-center tw:justify-center tw:gap-6 tw:py-24 tw:px-page-x">
+      <PageContainer className="tw:items-center tw:justify-center tw:py-24">
         <Spinner className="tw:size-10 tw:text-primary" />
         <div className="tw:flex tw:flex-col tw:items-center tw:gap-2">
           <p className="tw:text-sm tw:font-medium tw:text-foreground">Loading package…</p>
@@ -59,7 +60,7 @@ export function InstallerPage() {
             <Skeleton className="tw:h-3 tw:w-3/4 tw:rounded-full" />
           </div>
         </div>
-      </div>
+      </PageContainer>
     );
   }
 

--- a/packages/admin-ui/src/pages-new/ai/installer/InstallerView.tsx
+++ b/packages/admin-ui/src/pages-new/ai/installer/InstallerView.tsx
@@ -29,6 +29,7 @@ import { AutoUpdatesDialog, shouldPromptAutoUpdates } from "./AutoUpdatesDialog"
 import { pathName as systemPathName, subPaths as systemSubPaths } from "pages/system/data";
 import { withLegacyBase } from "utils/path";
 import { packagesRelativePath } from "../packages/data";
+import { PageContainer } from "components/primitives/page";
 
 interface InstallerViewProps {
   dnp: RequestedDnp;
@@ -349,7 +350,7 @@ export function InstallerView({ dnp, progressLogs }: InstallerViewProps) {
   /* ── Render ───────────────────────────────────────────────────── */
 
   return (
-    <div className="tw:flex tw:flex-col tw:gap-section tw:px-page-x tw:py-page-y">
+    <PageContainer>
       {/* ── Blocking alerts ──────────────────────────────────────── */}
       {(requiresCoreUpdate || requiresDockerUpdate || packagesToBeUninstalled.length > 0) && (
         <div className="tw:flex tw:flex-col tw:gap-3">
@@ -442,6 +443,6 @@ export function InstallerView({ dnp, progressLogs }: InstallerViewProps) {
           }
         }}
       />
-    </div>
+    </PageContainer>
   );
 }

--- a/packages/admin-ui/src/pages-new/ai/nexus/NexusPage.tsx
+++ b/packages/admin-ui/src/pages-new/ai/nexus/NexusPage.tsx
@@ -1,25 +1,23 @@
 import * as React from "react";
-import { TypographyH1, TypographyMuted } from "components/primitives/typography";
+import { PageContainer, PageHeader, PageDescription } from "components/primitives/page";
 import { Button } from "components/primitives/button";
 import { nexusExternalUrl } from "./data";
 
 export function NexusPage() {
   return (
-    <div className="tw:flex tw:flex-col tw:gap-section tw:px-page-x tw:py-page-y">
-      <header>
-        <TypographyH1 className="tw:border-none tw:pb-0">Nexus</TypographyH1>
-        <TypographyMuted className="tw:mt-header-gap">
-          Dappnode Nexus is a privacy-first AI gateway that routes your prompts to the best cloud model while protecting
-          your data.
-        </TypographyMuted>
-        <TypographyMuted className="tw:mt-header-gap">
+    <PageContainer>
+      <PageHeader
+        title="Nexus"
+        description="Dappnode Nexus is a privacy-first AI gateway that routes your prompts to the best cloud model while protecting your data."
+      >
+        <PageDescription>
           To use it navigate directly to{" "}
           <Button variant="link" onClick={() => window.open(nexusExternalUrl, "_blank")} className="tw:px-0">
             Nexus Dashboard
           </Button>
           .
-        </TypographyMuted>
-      </header>
-    </div>
+        </PageDescription>
+      </PageHeader>
+    </PageContainer>
   );
 }

--- a/packages/admin-ui/src/pages-new/ai/packages/PackageDetailPage.tsx
+++ b/packages/admin-ui/src/pages-new/ai/packages/PackageDetailPage.tsx
@@ -7,7 +7,7 @@ import { InstalledPackageDetailData } from "@dappnode/types";
 import { Skeleton } from "components/primitives/skeleton";
 import { Alert, AlertTitle, AlertDescription } from "components/primitives/alert";
 import { Button } from "components/primitives/button";
-import { TypographyH3 } from "components/primitives/typography";
+import { PageContainer, PageTitle } from "components/primitives/page";
 import { ArrowLeft, TriangleAlert, ArrowUpCircle } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import defaultAvatar from "img/defaultAvatar.png";
@@ -81,11 +81,11 @@ export function PackageDetailPage() {
   /* ── Loading ──────────────────────────────────────────────────────── */
   if (!dnp && dnpRequest.isValidating) {
     return (
-      <div className="tw:flex tw:flex-col tw:gap-section tw:px-page-x tw:py-page-y">
+      <PageContainer>
         <Skeleton className="tw:h-8 tw:w-48" />
         <Skeleton className="tw:h-10 tw:w-full" />
         <Skeleton className="tw:h-96 tw:w-full tw:rounded-xl" />
-      </div>
+      </PageContainer>
     );
   }
 
@@ -93,7 +93,7 @@ export function PackageDetailPage() {
   if (!dnp) {
     const notFound = dnpRequest.error?.message?.includes("package not found");
     return (
-      <div className="tw:flex tw:flex-col tw:gap-section tw:px-page-x tw:py-page-y">
+      <PageContainer>
         <BackButton />
         <Alert variant="destructive">
           <TriangleAlert className="tw:size-4" />
@@ -104,14 +104,14 @@ export function PackageDetailPage() {
               : dnpRequest.error?.message || "Failed to load package."}
           </AlertDescription>
         </Alert>
-      </div>
+      </PageContainer>
     );
   }
 
   const availableTabs = tabDefs.filter((t) => t.available(dnp));
 
   return (
-    <div className="tw:flex tw:flex-col tw:gap-6 tw:px-page-x tw:py-page-y">
+    <PageContainer className="tw:gap-6">
       {/* Back + title */}
       <div className="tw:flex tw:flex-col tw:gap-3">
         <BackButton />
@@ -122,7 +122,7 @@ export function PackageDetailPage() {
             className="tw:size-10 tw:rounded-lg tw:bg-muted tw:object-cover"
           />
           <div>
-            <TypographyH3 className="tw:border-none tw:pb-0 tw:mb-0">{prettyDnpName(dnp.dnpName)}</TypographyH3>
+            <PageTitle>{prettyDnpName(dnp.dnpName)}</PageTitle>
             <span className="tw:text-sm tw:text-muted-foreground">v{dnp.version}</span>
           </div>
         </div>
@@ -178,7 +178,7 @@ export function PackageDetailPage() {
         {/* Default redirect to first available tab */}
         <Route path="*" element={<Navigate to={availableTabs[0]?.subPath || "info"} replace />} />
       </Routes>
-    </div>
+    </PageContainer>
   );
 }
 

--- a/packages/admin-ui/src/pages-new/ai/packages/PackagesPage.tsx
+++ b/packages/admin-ui/src/pages-new/ai/packages/PackagesPage.tsx
@@ -8,7 +8,7 @@ import { Badge } from "components/primitives/badge";
 import { Alert, AlertTitle, AlertDescription } from "components/primitives/alert";
 import { Empty, EmptyHeader, EmptyMedia, EmptyTitle, EmptyDescription } from "components/primitives/empty";
 import { Skeleton } from "components/primitives/skeleton";
-import { TypographyH3, TypographyMuted } from "components/primitives/typography";
+import { PageContainer, PageHeader } from "components/primitives/page";
 import { CircleCheck, CirclePause, CircleX, RefreshCw, TriangleAlert, PackageOpen } from "lucide-react";
 import { InstalledPackageDataApiReturn } from "@dappnode/types";
 import { parseContainerState, SimpleState } from "pages/packages/components/StateBadge/utils";
@@ -62,33 +62,42 @@ export function PackagesPage() {
 
   if (loading) {
     return (
-      <div className="tw:flex tw:flex-col tw:gap-section tw:px-page-x tw:py-page-y">
-        <PageHeader />
+      <PageContainer>
+        <PageHeader
+          title="Packages"
+          description="View and manage the AI packages installed on your Dappnode. Monitor the status, versions and updates."
+        />
         <div className="tw:grid tw:grid-cols-1 tw:sm:grid-cols-2 tw:lg:grid-cols-3 tw:gap-card">
           {Array.from({ length: 6 }).map((_, i) => (
             <Skeleton key={i} className="tw:h-36 tw:rounded-xl" />
           ))}
         </div>
-      </div>
+      </PageContainer>
     );
   }
 
   if (error) {
     return (
-      <div className="tw:flex tw:flex-col tw:gap-section tw:px-page-x tw:py-page-y">
-        <PageHeader />
+      <PageContainer>
+        <PageHeader
+          title="Packages"
+          description="View and manage the AI packages installed on your Dappnode. Monitor the status, versions and updates."
+        />
         <Alert variant="destructive">
           <TriangleAlert className="tw:size-4" />
           <AlertTitle>Failed to load packages</AlertTitle>
           <AlertDescription>{error.message}</AlertDescription>
         </Alert>
-      </div>
+      </PageContainer>
     );
   }
 
   return (
-    <div className="tw:flex tw:flex-col tw:gap-section tw:px-page-x tw:py-page-y">
-      <PageHeader />
+    <PageContainer>
+      <PageHeader
+        title="Packages"
+        description="View and manage the AI packages installed on your Dappnode. Monitor the status, versions and updates."
+      />
 
       {packages.length === 0 ? (
         <Empty className="tw:border tw:py-16">
@@ -141,17 +150,6 @@ export function PackagesPage() {
           })}
         </div>
       )}
-    </div>
-  );
-}
-
-function PageHeader() {
-  return (
-    <header>
-      <TypographyH3 className="tw:border-none tw:pb-0">Packages</TypographyH3>
-      <TypographyMuted className="tw:mt-header-gap">
-        View and manage the AI packages installed on your Dappnode. Monitor the status, versions and updates.
-      </TypographyMuted>
-    </header>
+    </PageContainer>
   );
 }

--- a/packages/admin-ui/src/pages-new/ai/store/StorePage.tsx
+++ b/packages/admin-ui/src/pages-new/ai/store/StorePage.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from "react-router-dom";
 import { DirectoryItemOk } from "@dappnode/types";
 import { getDnpDirectory, getDirectoryRequestStatus } from "services/dnpDirectory/selectors";
 import { fetchDnpDirectory } from "services/dnpDirectory/actions";
-import { TypographyH3, TypographyMuted } from "components/primitives/typography";
+import { PageContainer, PageHeader } from "components/primitives/page";
 import { Alert, AlertTitle, AlertDescription } from "components/primitives/alert";
 import { Empty, EmptyHeader, EmptyMedia, EmptyTitle, EmptyDescription } from "components/primitives/empty";
 import { PackageOpen, TriangleAlert } from "lucide-react";
@@ -50,14 +50,9 @@ export function StorePage() {
   }
 
   return (
-    <div className="tw:flex tw:flex-col tw:gap-section tw:px-page-x tw:py-page-y">
+    <PageContainer>
       {/* Page header */}
-      <header>
-        <TypographyH3 className="tw:border-none tw:pb-0">AI Store</TypographyH3>
-        <TypographyMuted className="tw:mt-header-gap tw:max-w-2xl">
-          Browse and install AI powered packages on your Dappnode.
-        </TypographyMuted>
-      </header>
+      <PageHeader title="AI Store" description="Browse and install AI powered packages on your Dappnode." />
 
       {/* Content area */}
       {requestStatus.loading && !directory.length ? (
@@ -83,6 +78,6 @@ export function StorePage() {
       ) : (
         <StoreGrid packages={aiPackages} onPackageClick={handlePackageClick} />
       )}
-    </div>
+    </PageContainer>
   );
 }


### PR DESCRIPTION
Replace div elements with PageContainer and PageHeader components across new pages for improved layout consistency and readability. This change enhances the structure of the pages by utilizing the new primitives.