### PR TITLE
Update Gnosis Beacon Explorer URL

### DIFF
--- a/packages/admin-ui/src/hooks/useNetworkStats.ts
+++ b/packages/admin-ui/src/hooks/useNetworkStats.ts
@@ -39,7 +39,7 @@ const networkFeatures: Record<DashboardSupportedNetwork, NetworkFeatures> = {
   [Network.Gnosis]: {
     hasValidators: true,
     logo: GnosisLogo,
-    beaconExplorer: { url: "https://beaconchain.gnosischain.com/", name: "Gnosis Beaconchain" }
+    beaconExplorer: { url: "https://beacon.gnosisscan.io/", name: "Beacon Gnosisscan" }
   },
   [Network.Lukso]: {
     hasValidators: true,


### PR DESCRIPTION
Update the URL for the Gnosis Beacon Explorer to point to Beacon Gnosisscan at the Stakers Dashboard