### PR TITLE
Proposed fix to file upload race condition

### DIFF
--- a/packages/dockerApi/src/api/copyFileTo.ts
+++ b/packages/dockerApi/src/api/copyFileTo.ts
@@ -8,7 +8,7 @@ import { shell } from "@dappnode/utils";
 const tempTransferDir = params.TEMP_TRANSFER_DIR;
 
 /**
- * Copy file to a DNP container:
+ * Copy file to a DNP container, starting it if necessary:
  *
  * @param containerName Name of a docker container
  * @param dataUri = "data:application/zip;base64,UEsDBBQAAAg..."
@@ -66,7 +66,7 @@ export async function copyFileToDockerContainer({
 
   dataUriToFile(dataUri, fromPath);
 
-  // docker cp works on containers in any state (created, running, stopped)
+  // Copy file from local file system to container
   await dockerCopyFileTo(containerName, fromPath, toPath);
 
   // Clean intermediate file

--- a/packages/dockerApi/src/api/copyFileTo.ts
+++ b/packages/dockerApi/src/api/copyFileTo.ts
@@ -4,13 +4,11 @@ import fs from "fs";
 import dataUriToBuffer from "data-uri-to-buffer";
 import { params } from "@dappnode/params";
 import { shell } from "@dappnode/utils";
-import { dockerContainerInspect, dockerContainerStart, dockerContainerStop } from "./container.js";
-import { logs } from "@dappnode/logger";
 
 const tempTransferDir = params.TEMP_TRANSFER_DIR;
 
 /**
- * Copy file to a DNP container, starting it if necessary:
+ * Copy file to a DNP container:
  *
  * @param containerName Name of a docker container
  * @param dataUri = "data:application/zip;base64,UEsDBBQAAAg..."
@@ -66,32 +64,13 @@ export async function copyFileToDockerContainer({
   // Remove existing file if it exists
   if (fs.existsSync(fromPath)) fs.rmSync(fromPath, { recursive: true, force: true });
 
-  /**
-   * Convert dataUri to local file
-   *
-   * In this conversion direction MIME types don't matter
-   * The extension is what decides the type and it's the user's
-   * responsability to specify it correctly on the UI. The code will
-   * not cause problems if the types are not setup corretly
-   */
   dataUriToFile(dataUri, fromPath);
 
-  // Container needs to be running to copy files
-  const containerInspect = await dockerContainerInspect(containerName);
-  const isInitiallyRunning = containerInspect.State.Running;
-
-  if (!isInitiallyRunning) await dockerContainerStart(containerName);
-
-  // Copy file from local file system to container
+  // docker cp works on containers in any state (created, running, stopped)
   await dockerCopyFileTo(containerName, fromPath, toPath);
 
   // Clean intermediate file
   if (fs.existsSync(fromPath)) fs.rmSync(fromPath, { recursive: true, force: true });
-
-  if (!isInitiallyRunning)
-    dockerContainerStop(containerName).catch((err) =>
-      logs.error(`Error stopping container ${containerName} after copying a file to it: ${err}`)
-    );
 }
 
 function dockerCopyFileTo(id: string, fromPath: string, toPath: string): Promise<string> {


### PR DESCRIPTION
## Context


This is a race condition for a fresh install of a DAppNode package, where if there is a file upload involved, the package will crash on the first run, as described in the issue below:

https://github.com/dappnode/DAppNodePackage-anchor-generic/issues/6

## Approach

Removed the start/stop logic. docker cp works on containers in any state (created, stopped, or running). The container no longer gets prematurely started before the file is ready.

## Test instructions

Tested on both Anchor and SSV packages, the crash-on-first-run when `import operator` mode is selected is no longer there, i.e., it successfully run on fresh setup.

Disclaimer: the solution is 100% generated by Claude code, I only tweak the comments a bit