### PR TITLE
add nimbus gnosis back

### DIFF
--- a/packages/admin-ui/src/__mock-backend__/stakerConfig.ts
+++ b/packages/admin-ui/src/__mock-backend__/stakerConfig.ts
@@ -1404,6 +1404,34 @@ export const stakerConfig: Pick<Routes, "stakerConfigGet" | "stakerConfigSet"> =
                   version: "0.1.0"
                 }
               }
+            },
+            {
+              status: "ok",
+              dnpName: "nimbus-gnosis.dnp.dappnode.eth",
+              isInstalled: true,
+              isRunning: true,
+              isUpdated: true,
+              isSelected: false,
+              avatarUrl: "",
+              data: {
+                dnpName: "package",
+                reqVersion: "0.1.3",
+                semVersion: "0.1.3",
+                imageFile: {
+                  hash: "QM..",
+                  source: "ipfs",
+                  size: 123
+                },
+                warnings: {},
+                signedSafe: true,
+
+                manifest: {
+                  name: "nimbus-gnosis.dnp.dappnode.eth",
+                  description: "Nimbus consensus client",
+                  shortDescription: "Nimbus consensus client",
+                  version: "0.1.3"
+                }
+              }
             }
           ],
           web3Signer: {

--- a/packages/stakers/src/consensus.ts
+++ b/packages/stakers/src/consensus.ts
@@ -53,7 +53,8 @@ export class Consensus extends StakerComponent {
     [Network.Gnosis]: [
       { dnpName: ConsensusClientGnosis.Lighthouse, minVersion: "0.1.5" },
       { dnpName: ConsensusClientGnosis.Teku, minVersion: "0.1.5" },
-      { dnpName: ConsensusClientGnosis.Lodestar, minVersion: "0.1.0" }
+      { dnpName: ConsensusClientGnosis.Lodestar, minVersion: "0.1.0" },
+      { dnpName: ConsensusClientGnosis.Nimbus, minVersion: "0.1.0" }
     ],
     [Network.Prater]: [
       { dnpName: ConsensusClientPrater.Prysm, minVersion: "1.0.15" },

--- a/packages/stakers/src/consensus.ts
+++ b/packages/stakers/src/consensus.ts
@@ -54,7 +54,7 @@ export class Consensus extends StakerComponent {
       { dnpName: ConsensusClientGnosis.Lighthouse, minVersion: "0.1.5" },
       { dnpName: ConsensusClientGnosis.Teku, minVersion: "0.1.5" },
       { dnpName: ConsensusClientGnosis.Lodestar, minVersion: "0.1.0" },
-      { dnpName: ConsensusClientGnosis.Nimbus, minVersion: "0.1.0" }
+      { dnpName: ConsensusClientGnosis.Nimbus, minVersion: "0.1.4" }
     ],
     [Network.Prater]: [
       { dnpName: ConsensusClientPrater.Prysm, minVersion: "1.0.15" },

--- a/packages/types/src/stakers.ts
+++ b/packages/types/src/stakers.ts
@@ -110,7 +110,8 @@ export enum MevBoostHoodi {
 export enum ConsensusClientGnosis {
   Lighthouse = "lighthouse-gnosis.dnp.dappnode.eth",
   Teku = "teku-gnosis.dnp.dappnode.eth",
-  Lodestar = "lodestar-gnosis.dnp.dappnode.eth"
+  Lodestar = "lodestar-gnosis.dnp.dappnode.eth",
+  Nimbus = "nimbus-gnosis.dnp.dappnode.eth"
 }
 export enum ExecutionClientGnosis {
   Nethermind = "nethermind-xdai.dnp.dappnode.eth",


### PR DESCRIPTION
This pull request adds support for the Nimbus consensus client on the Gnosis network. The changes update the relevant enums, configuration, and mock backend data to include Nimbus as a supported option.

Consensus client support:

* Added `Nimbus` to the `ConsensusClientGnosis` enum in `stakers.ts`, allowing it to be recognized as a valid consensus client for Gnosis.
* Updated the `Consensus` class in `consensus.ts` to include `Nimbus` with a minimum version of `0.1.0` for the Gnosis network.

Mock backend data:

* Added a mock entry for the `nimbus-gnosis.dnp.dappnode.eth` package in the `stakerConfig` mock backend, providing details such as version, status, and manifest information.