### PR TITLE
feat: Nexus chat in the DAppNode UI + MCP server

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -29,6 +29,7 @@ services:
       - ETH_MAINNET_RPC_URL_REMOTE=
       - IPFS_HOST=
       - DISABLE_UPNP=
+      - NEXUS_API_KEY=
     networks:
       dncore_network:
         aliases:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       - ALWAYS_DAPPGETBASIC=
       - SKIP_COMPOSE_VALIDATION=
       - TEST=
+      - NEXUS_API_KEY=
     networks:
       dncore_network:
         aliases:

--- a/packages/admin-ui/package.json
+++ b/packages/admin-ui/package.json
@@ -61,6 +61,7 @@
     "react-toastify": "^4.1.0",
     "redux": "^4.0.0",
     "redux-thunk": "^2.3.0",
+    "remark-gfm": "^3.0.1",
     "sass": "^1.49.7",
     "semver": "^7.3.8",
     "shadcn": "^4.0.8",

--- a/packages/admin-ui/src/App.tsx
+++ b/packages/admin-ui/src/App.tsx
@@ -21,6 +21,7 @@ import { NoConnectionPage } from "./pages-new/home/NoConnectionPage";
 import { AiLayout } from "./pages-new/ai/AiLayout";
 import { HomeLayout } from "./pages-new/home/HomeLayout";
 import { StakingLayout } from "./pages-new/staking/StakingLayout";
+import { FloatingChatLauncher } from "./pages-new/ai/nexus/chat/FloatingChatLauncher";
 // Layouts
 import { LegacyStakingLayout } from "./layouts/LegacyStakingLayout";
 // Types
@@ -128,6 +129,11 @@ function MainApp({ username }: { username: string }) {
             }
           />
         </FaroRoutes>
+
+        {/* App-wide chat launcher — sits outside the route tree so it
+            persists across navigations. Hides itself on /ai/nexus where the
+            full-page chat already lives. */}
+        <FloatingChatLauncher />
       </div>
     </AppContext.Provider>
   );

--- a/packages/admin-ui/src/components/primitives/empty.tsx
+++ b/packages/admin-ui/src/components/primitives/empty.tsx
@@ -20,7 +20,7 @@ function EmptyHeader({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="empty-header"
-      className={cn("tw:flex tw:max-w-sm tw:flex-col tw:items-center tw:gap-2", className)}
+      className={cn("tw:flex tw:max-w-sm tw:flex-col tw:items-center tw:gap-2 tw:text-center", className)}
       {...props}
     />
   )
@@ -84,7 +84,7 @@ function EmptyContent({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="empty-content"
       className={cn(
-        "tw:flex tw:w-full tw:max-w-sm tw:min-w-0 tw:flex-col tw:items-center tw:gap-2.5 tw:text-sm tw:text-balance",
+        "tw:flex tw:w-full tw:max-w-sm tw:min-w-0 tw:flex-col tw:items-center tw:gap-2.5 tw:text-sm tw:text-center tw:text-balance",
         className
       )}
       {...props}

--- a/packages/admin-ui/src/pages-new/ai/nexus/NexusPage.tsx
+++ b/packages/admin-ui/src/pages-new/ai/nexus/NexusPage.tsx
@@ -1,183 +1,63 @@
 import * as React from "react";
-import { PageContainer } from "components/primitives/page";
-import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "components/primitives/card";
+import { ExternalLink } from "lucide-react";
+import { PageContainer, PageHeader, PageTitle, PageDescription } from "components/primitives/page";
 import { Button } from "components/primitives/button";
-import { Badge } from "components/primitives/badge";
-import { Separator } from "components/primitives/separator";
-import { TypographyH4, TypographyInlineCode, TypographyMuted } from "components/primitives/typography";
-import {
-  ShieldCheck,
-  Wallet,
-  Plug,
-  BarChart3,
-  ExternalLink,
-  Sparkles,
-  UserPlus,
-  CreditCard,
-  KeyRound
-} from "lucide-react";
-import { nexusExternalUrl, nexusLandingPageUrl } from "./data";
+import { TypographyMuted } from "components/primitives/typography";
+import { ChatPanel } from "./chat/ChatPanel";
+import { nexusExternalUrl } from "./data";
 
-/* ── Feature data ───────────────────────────────────────────────────── */
-
-const features = [
-  {
-    icon: ShieldCheck,
-    title: "Private AI Models",
-    description: "All models through one unified API. Switch between private and standard models instantly."
-  },
-  {
-    icon: Wallet,
-    title: "Flexible Pricing",
-    description: "Select between prepaid credits or monthly subscriptions based on your needs."
-  },
-  {
-    icon: Plug,
-    title: "Easy Integration",
-    description: "Manage your API key to integrate the models with your preferred AI agents."
-  },
-  {
-    icon: BarChart3,
-    title: "Real-Time Usage",
-    description: "Monitor how many tokens you're spending, on which models, over time."
-  }
-];
-
-/* ── Getting-started steps ──────────────────────────────────────────── */
-
-const steps = [
-  {
-    icon: UserPlus,
-    title: "Create your account",
-    description: "Sign up at Nexus to start running AI models privately."
-  },
-  {
-    icon: CreditCard,
-    title: "Buy credits or subscribe",
-    description: "Get 5 € in free credits and test the power of private AI models."
-  },
-  {
-    icon: KeyRound,
-    title: "Create your API key",
-    description: "Use your API key to set up models in your favourite AI agent."
-  }
-];
-
-/* ── Page component ─────────────────────────────────────────────────── */
-
+/**
+ * Nexus chat — a small free playground that lives on this DAppNode.
+ *
+ * The dappmanager backend holds the Nexus API key and proxies every
+ * request, so the key never reaches the browser. A locally-tracked
+ * quota gates the "Open Nexus" CTA. Once Nexus exposes an anonymous
+ * signup endpoint we'll auto-provision instead of relying on an
+ * env-configured key.
+ */
 export function NexusPage() {
   return (
-    <PageContainer className="tw:items-center">
-      {/* ── Hero ──────────────────────────────────────────────────── */}
-      <section className="tw:flex tw:flex-col tw:items-center tw:text-center tw:max-w-2xl tw:gap-5">
-        <Badge variant="secondary" className="tw:gap-1.5">
-          <Sparkles className="tw:size-3" />
-          Built into every Dappnode AI product
-        </Badge>
-
-        <h2 className="tw:text-3xl tw:sm:text-4xl tw:font-extrabold tw:tracking-tight tw:text-foreground tw:text-balance">
-          The gateway for AI builders{" "}
-          <span className="tw:bg-gradient-to-r tw:from-dn-blue tw:via-dn-cyan tw:to-dn-purple tw:bg-clip-text tw:text-transparent">
-            who value privacy
+    <PageContainer>
+      <PageHeader>
+        <PageTitle>
+          <span className="tw:inline-flex tw:items-baseline tw:gap-2">
+            Nexus chat
+            <span className="tw:font-mono tw:text-xs tw:font-normal tw:tracking-tight tw:text-muted-foreground">
+              · powered by your DAppNode
+            </span>
           </span>
-        </h2>
+        </PageTitle>
+        <PageDescription>
+          A private model, reached through this node's Nexus gateway. Free for the first few
+          messages — then{" "}
+          <a
+            href={nexusExternalUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="tw:text-primary tw:underline tw:underline-offset-2"
+          >
+            open Nexus
+          </a>{" "}
+          for the full experience.
+        </PageDescription>
+      </PageHeader>
 
-        <TypographyMuted className="tw:text-base tw:sm:text-lg tw:max-w-xl tw:leading-relaxed">
-          Access top AI models through a single OpenAI-compatible API endpoint — filtered by privacy, speed, and
-          reasoning level.
+      <ChatPanel />
+
+      <footer className="tw:flex tw:flex-wrap tw:items-center tw:justify-between tw:gap-3 tw:pt-2">
+        <TypographyMuted className="tw:text-[12px]">
+          Your prompts leave this DAppNode through the Nexus gateway. Nexus is built by DAppNode.
         </TypographyMuted>
-
-        <div className="tw:flex tw:flex-wrap tw:items-center tw:justify-center tw:gap-3 tw:pt-2">
-          <Button size="lg" onClick={() => window.open(nexusLandingPageUrl, "_blank")}>
-            Learn more
-            <ExternalLink className="tw:size-4" />
-          </Button>
-          <Button size="lg" variant="outline" onClick={() => window.open(nexusExternalUrl, "_blank")}>
-            Open Dashboard
-            <ExternalLink className="tw:size-4" />
-          </Button>
-        </div>
-      </section>
-
-      <Separator />
-
-      {/* ── Integration callout ───────────────────────────────────── */}
-      <Card className="tw:w-full tw:max-w-content-max tw:bg-primary/5 tw:ring-primary/20">
-        <CardContent className="tw:flex tw:flex-col tw:sm:flex-row tw:items-start tw:sm:items-center tw:gap-4">
-          <div className="tw:flex tw:items-center tw:justify-center tw:size-10 tw:shrink-0 tw:rounded-lg tw:bg-primary/10 tw:text-primary">
-            <Plug className="tw:size-5" />
-          </div>
-          <div className="tw:flex-1 tw:space-y-1">
-            <TypographyH4>Nexus is integrated into every AI product in Dappnode</TypographyH4>
-            <TypographyMuted>
-              If a direct integration isn't available, you can always connect via the API endpoint:{" "}
-              <TypographyInlineCode>nexus.dappnode.com/v1</TypographyInlineCode>
-            </TypographyMuted>
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* ── Features grid ─────────────────────────────────────────── */}
-      <section className="tw:flex tw:flex-col tw:items-center tw:gap-section tw:w-full tw:max-w-content-max">
-        <header className="tw:text-center">
-          <TypographyH4>Key Benefits</TypographyH4>
-          <TypographyMuted className="tw:mt-header-gap">
-            Dappnode Nexus provides a curated selection of AI models to run in a few clicks.
-          </TypographyMuted>
-        </header>
-
-        <div className="tw:grid tw:grid-cols-1 tw:sm:grid-cols-2 tw:gap-card tw:w-full">
-          {features.map((f) => (
-            <Card key={f.title}>
-              <CardHeader>
-                <div className="tw:flex tw:items-center tw:gap-3">
-                  <div className="tw:flex tw:items-center tw:justify-center tw:size-9 tw:rounded-lg tw:bg-primary/10 tw:text-primary">
-                    <f.icon className="tw:size-4.5" />
-                  </div>
-                  <CardTitle>{f.title}</CardTitle>
-                </div>
-              </CardHeader>
-              <CardContent>
-                <CardDescription className="tw:text-sm tw:leading-relaxed">{f.description}</CardDescription>
-              </CardContent>
-            </Card>
-          ))}
-        </div>
-      </section>
-
-      <Separator />
-
-      {/* ── Getting started ───────────────────────────────────────── */}
-      <section className="tw:flex tw:flex-col tw:items-center tw:gap-section tw:w-full tw:max-w-content-max">
-        <header className="tw:text-center">
-          <TypographyH4>How to Get Started</TypographyH4>
-          <TypographyMuted className="tw:mt-header-gap">Three simple steps to start using Nexus.</TypographyMuted>
-        </header>
-
-        <div className="tw:grid tw:grid-cols-1 tw:md:grid-cols-3 tw:gap-card tw:w-full">
-          {steps.map((s, i) => (
-            <Card key={s.title} className="tw:items-center tw:text-center">
-              <CardHeader className="tw:flex tw:w-full tw:items-center tw:justify-center tw:gap-3">
-                <div className="tw:flex tw:items-center tw:justify-center tw:size-10 tw:rounded-full tw:bg-primary/10 tw:text-primary tw:ring-1 tw:ring-primary/20 tw:mb-1">
-                  <span className="tw:text-sm tw:font-bold">{i + 1}</span>
-                </div>
-                <CardTitle>{s.title}</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <CardDescription className="tw:leading-relaxed">{s.description}</CardDescription>
-              </CardContent>
-            </Card>
-          ))}
-        </div>
-
-        {/* Bottom CTA */}
-        <div className="tw:flex tw:flex-wrap tw:items-center tw:justify-center tw:gap-3">
-          <Button onClick={() => window.open(nexusExternalUrl, "_blank")}>
-            Create your account
-            <ExternalLink className="tw:size-4" />
-          </Button>
-        </div>
-      </section>
+        <Button
+          variant="link"
+          size="sm"
+          onClick={() => window.open(nexusExternalUrl, "_blank")}
+          className="tw:px-0"
+        >
+          About Nexus
+          <ExternalLink />
+        </Button>
+      </footer>
     </PageContainer>
   );
 }

--- a/packages/admin-ui/src/pages-new/ai/nexus/chat/ChatPanel.tsx
+++ b/packages/admin-ui/src/pages-new/ai/nexus/chat/ChatPanel.tsx
@@ -58,6 +58,7 @@ const SUGGESTIONS = [
 interface PendingConfirmation {
   id: string;
   tool: string;
+  displayName: string;
   args: unknown;
 }
 
@@ -207,7 +208,12 @@ export function ChatPanel({ variant = "page", getPageContext, onRequestClose }: 
             return next;
           });
         } else if (event.type === "confirm_required") {
-          setPendingConfirm({ id: event.id, tool: event.tool, args: event.args });
+          setPendingConfirm({
+            id: event.id,
+            tool: event.tool,
+            displayName: event.displayName,
+            args: event.args
+          });
         } else if (event.type === "confirm_resolved") {
           // Server-side resolution arrived (e.g. via another tab, or the
           // user clicked Approve/Deny — either way we can clear the dialog).
@@ -792,10 +798,15 @@ function ConfirmationCard({
         </div>
 
         <div className="tw:mt-3 tw:overflow-hidden tw:rounded-lg tw:border tw:border-border tw:bg-background">
-          <div className="tw:flex tw:items-center tw:justify-between tw:gap-2 tw:border-b tw:border-border tw:px-3 tw:py-1.5">
-            <code className="tw:font-mono tw:text-[12px] tw:font-semibold tw:text-foreground">
-              {confirmation.tool}
-            </code>
+          <div className="tw:flex tw:items-center tw:justify-between tw:gap-2 tw:border-b tw:border-border tw:px-3 tw:py-2">
+            <div className="tw:min-w-0 tw:flex tw:flex-col">
+              <span className="tw:truncate tw:text-[13px] tw:font-semibold tw:text-foreground">
+                {confirmation.displayName}
+              </span>
+              <code className="tw:truncate tw:font-mono tw:text-[10.5px] tw:text-muted-foreground">
+                {confirmation.tool}
+              </code>
+            </div>
             <span className="tw:font-mono tw:text-[10.5px] tw:uppercase tw:tracking-wide tw:text-muted-foreground">
               mutating
             </span>

--- a/packages/admin-ui/src/pages-new/ai/nexus/chat/ChatPanel.tsx
+++ b/packages/admin-ui/src/pages-new/ai/nexus/chat/ChatPanel.tsx
@@ -35,12 +35,14 @@ import {
   ChatPageContext,
   NexusModel,
   NexusStatus,
+  clearNexusApiKey,
   deleteConversation,
   getNexusStatus,
   listChatHistory,
   listNexusModels,
   loadConversation,
   saveConversation,
+  setNexusApiKey,
   smoothStream,
   streamChat,
   submitChatConfirmation
@@ -94,6 +96,7 @@ export function ChatPanel({ variant = "page", getPageContext, onRequestClose }: 
   const [pendingConfirm, setPendingConfirm] = useState<PendingConfirmation | null>(null);
   const [conversationId, setConversationId] = useState<string | null>(null);
   const [historyList, setHistoryList] = useState<ChatHistorySummary[]>([]);
+  const [keyEditorOpen, setKeyEditorOpen] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
   // Mirror of `messages` so the post-stream save can read the final state
   // without races with React's state batching.
@@ -105,6 +108,28 @@ export function ChatPanel({ variant = "page", getPageContext, onRequestClose }: 
   // unchanged state (e.g. immediately after loading a conversation).
   const lastSavedRef = useRef<string>("");
 
+  // Loads the chat-capable models for a configured DAppNode and selects an
+  // initial model: last-used (if still available) → env default (if listed) →
+  // first listed. Shared by the mount effect and the post-key-save flow.
+  const loadModels = useCallback(async (s: NexusStatus) => {
+    setModelsError(null);
+    try {
+      const list = await listNexusModels();
+      setModels(list);
+      const remembered = readRememberedModel();
+      setSelectedModel((prev) => {
+        // Keep the current pick if it's still offered; otherwise fall back to
+        // last-used → env default → first listed.
+        const preferred = [prev, remembered, s.defaultModel].find(
+          (id) => id && list.some((m) => m.id === id)
+        );
+        return preferred || list[0]?.id || "";
+      });
+    } catch (err) {
+      setModelsError((err as Error).message);
+    }
+  }, []);
+
   // Fetch status + models on mount.
   useEffect(() => {
     let cancelled = false;
@@ -112,21 +137,7 @@ export function ChatPanel({ variant = "page", getPageContext, onRequestClose }: 
       .then(async (s) => {
         if (cancelled) return;
         setStatus(s);
-        if (!s.configured) return;
-        try {
-          const list = await listNexusModels();
-          if (cancelled) return;
-          setModels(list);
-          // Choose the initial model: last-used (if still available) →
-          // env default (if listed) → first listed.
-          const remembered = readRememberedModel();
-          const preferred = [remembered, s.defaultModel].find(
-            (id) => id && list.some((m) => m.id === id)
-          );
-          setSelectedModel(preferred || list[0]?.id || "");
-        } catch (err) {
-          if (!cancelled) setModelsError((err as Error).message);
-        }
+        if (s.configured) await loadModels(s);
       })
       .catch((err: Error) => {
         if (!cancelled) setStatusError(err.message);
@@ -134,7 +145,23 @@ export function ChatPanel({ variant = "page", getPageContext, onRequestClose }: 
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [loadModels]);
+
+  // Applies a status returned after the user sets/clears the key in-app, then
+  // (re)loads the model list so the picker reflects the new credential.
+  const applyStatus = useCallback(
+    async (s: NexusStatus) => {
+      setStatusError(null);
+      setStatus(s);
+      if (s.configured) {
+        await loadModels(s);
+      } else {
+        setModels([]);
+        setSelectedModel("");
+      }
+    },
+    [loadModels]
+  );
 
   // Persist last-used model so the next visit lands on the same choice.
   useEffect(() => {
@@ -337,10 +364,27 @@ export function ChatPanel({ variant = "page", getPageContext, onRequestClose }: 
         onNewChat={startNewChat}
         onOpenConversation={openHistoryConversation}
         onDeleteConversation={removeHistoryConversation}
+        onManageKey={() => setKeyEditorOpen((v) => !v)}
         onRequestClose={onRequestClose}
       />
 
       <div className="tw:relative tw:flex tw:flex-1 tw:flex-col tw:min-h-0">
+        {keyEditorOpen && (
+          <ApiKeyEditor
+            status={status}
+            onClose={() => setKeyEditorOpen(false)}
+            onSave={async (key) => {
+              const next = await setNexusApiKey(key);
+              await applyStatus(next);
+              setKeyEditorOpen(false);
+            }}
+            onClear={async () => {
+              const next = await clearNexusApiKey();
+              await applyStatus(next);
+              setKeyEditorOpen(false);
+            }}
+          />
+        )}
         {messages.length === 0 ? (
           <EmptyState
             configured={status.configured}
@@ -358,7 +402,7 @@ export function ChatPanel({ variant = "page", getPageContext, onRequestClose }: 
       </div>
 
       {!status.configured ? (
-        <NotConfigured />
+        <NotConfigured onConfigure={() => setKeyEditorOpen(true)} />
       ) : (
         <Composer
           draft={draft}
@@ -422,6 +466,7 @@ function Header({
   onNewChat,
   onOpenConversation,
   onDeleteConversation,
+  onManageKey,
   onRequestClose
 }: {
   status: NexusStatus;
@@ -434,6 +479,7 @@ function Header({
   onNewChat: () => void;
   onOpenConversation: (id: string) => void;
   onDeleteConversation: (id: string) => void;
+  onManageKey: () => void;
   onRequestClose?: () => void;
 }) {
   return (
@@ -476,6 +522,15 @@ function Header({
           onOpen={onOpenConversation}
           onDelete={onDeleteConversation}
         />
+        <Button
+          size="icon-xs"
+          variant="ghost"
+          onClick={onManageKey}
+          title={status.configured ? "Manage API key" : "Set API key"}
+          aria-label={status.configured ? "Manage API key" : "Set API key"}
+        >
+          <KeyRound />
+        </Button>
         {onRequestClose && (
           <Button
             size="icon-xs"
@@ -942,7 +997,7 @@ function Composer({
 
 /* ── CTAs ──────────────────────────────────────────────────────────── */
 
-function NotConfigured() {
+function NotConfigured({ onConfigure }: { onConfigure: () => void }) {
   return (
     <div className="tw:shrink-0 tw:border-t tw:border-border tw:bg-muted/40 tw:px-5 tw:py-5">
       <div className="tw:mx-auto tw:flex tw:max-w-xl tw:flex-col tw:items-start tw:gap-2">
@@ -951,14 +1006,158 @@ function NotConfigured() {
           Nexus chat is not configured on this DAppNode
         </div>
         <TypographyMuted className="tw:text-[12.5px]">
-          Set <code className="tw:rounded tw:bg-muted tw:px-1 tw:py-0.5 tw:font-mono">NEXUS_API_KEY</code>{" "}
-          on the dappmanager container and restart. The Nexus user portal is where you generate the
-          key.
+          Paste a Nexus API key to get started — generate one in the Nexus user portal. You can also
+          set <code className="tw:rounded tw:bg-muted tw:px-1 tw:py-0.5 tw:font-mono">NEXUS_API_KEY</code>{" "}
+          on the dappmanager container instead.
         </TypographyMuted>
-        <Button variant="outline" size="sm" onClick={() => window.open(nexusExternalUrl, "_blank")}>
-          Open Nexus
-          <ExternalLink />
+        <div className="tw:flex tw:flex-wrap tw:items-center tw:gap-2">
+          <Button size="sm" onClick={onConfigure}>
+            <KeyRound />
+            Add API key
+          </Button>
+          <Button variant="outline" size="sm" onClick={() => window.open(nexusExternalUrl, "_blank")}>
+            Open Nexus
+            <ExternalLink />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ── API-key editor ────────────────────────────────────────────────── */
+
+/**
+ * Inline overlay for setting, replacing or clearing the Nexus API key without
+ * leaving the chat. Validation happens server-side (the key is probed against
+ * the gateway before it's persisted), so a bad key surfaces as an error here.
+ */
+function ApiKeyEditor({
+  status,
+  onSave,
+  onClear,
+  onClose
+}: {
+  status: NexusStatus;
+  onSave: (key: string) => Promise<void>;
+  onClear: () => Promise<void>;
+  onClose: () => void;
+}) {
+  const [value, setValue] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = async () => {
+    const key = value.trim();
+    if (!key || busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await onSave(key);
+    } catch (err) {
+      setError((err as Error).message || "Failed to save the API key");
+      setBusy(false);
+    }
+  };
+
+  const clear = async () => {
+    if (busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await onClear();
+    } catch (err) {
+      setError((err as Error).message || "Failed to clear the API key");
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="tw:absolute tw:inset-0 tw:z-10 tw:flex tw:items-start tw:justify-center tw:overflow-y-auto tw:bg-background/80 tw:backdrop-blur-sm tw:p-6">
+      {/* Card + spacing follow the project's Dialog primitive: no leading icon,
+          title/description stacked at the left edge, close button top-right, a
+          full-bleed muted footer bar. */}
+      <div className="tw:relative tw:w-full tw:max-w-md tw:overflow-hidden tw:rounded-xl tw:border tw:border-border tw:bg-card tw:shadow-lg">
+        <Button
+          size="icon-sm"
+          variant="ghost"
+          onClick={onClose}
+          aria-label="Close"
+          disabled={busy}
+          className="tw:absolute tw:top-2 tw:right-2"
+        >
+          <X />
         </Button>
+
+        <div className="tw:flex tw:flex-col tw:gap-4 tw:p-4">
+          <div className="tw:flex tw:flex-col tw:gap-1 tw:pr-8">
+            <div className="tw:text-base tw:font-medium tw:leading-none tw:text-foreground">
+              {status.configured ? "Update Nexus API key" : "Set Nexus API key"}
+            </div>
+            <TypographyMuted className="tw:text-[12.5px]">
+              The key is stored on this DAppNode and used to talk to Nexus. Generate one in the Nexus
+              user portal.
+            </TypographyMuted>
+          </div>
+
+          {status.keySource === "env" && (
+            <TypographyMuted className="tw:text-[12px]">
+              A key is currently provided via the{" "}
+              <code className="tw:rounded tw:bg-muted tw:px-1 tw:py-0.5 tw:font-mono">NEXUS_API_KEY</code>{" "}
+              env var. Saving a key here overrides it.
+            </TypographyMuted>
+          )}
+
+          {/*
+            Input surface mirrors the Composer's: the visible frame lives on the
+            wrapper (auto width, so it can't overflow the card) and the inner
+            field is borderless with no horizontal padding.
+          */}
+          <div className="tw:flex tw:items-center tw:rounded-lg tw:border tw:border-input tw:bg-transparent tw:px-3 tw:py-1.5 tw:transition-colors tw:focus-within:border-ring tw:focus-within:ring-3 tw:focus-within:ring-ring/50 tw:dark:bg-input/30">
+            <input
+              type="password"
+              value={value}
+              autoFocus
+              autoComplete="off"
+              placeholder="sk-…"
+              disabled={busy}
+              onChange={(e) => setValue(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  submit();
+                }
+              }}
+              className="tw:min-w-0 tw:flex-1 tw:appearance-none tw:border-0 tw:bg-transparent tw:py-1 tw:font-mono tw:text-[13px] tw:text-foreground tw:shadow-none tw:outline-none tw:ring-0 tw:placeholder:text-muted-foreground tw:focus:outline-none tw:focus:ring-0 tw:disabled:opacity-50"
+            />
+          </div>
+
+          {error && (
+            <Alert variant="destructive" className="tw:py-2 tw:text-[12.5px]">
+              <AlertTitle className="tw:text-[12.5px]">{error}</AlertTitle>
+            </Alert>
+          )}
+        </div>
+
+        <div className="tw:flex tw:items-center tw:justify-between tw:gap-2 tw:border-t tw:border-border tw:bg-muted/40 tw:px-4 tw:py-3">
+          <div>
+            {status.keySource === "db" && (
+              <Button variant="ghost" size="sm" onClick={clear} disabled={busy}>
+                <Trash2 />
+                Remove key
+              </Button>
+            )}
+          </div>
+          <div className="tw:flex tw:items-center tw:gap-2">
+            <Button variant="outline" size="sm" onClick={onClose} disabled={busy}>
+              Cancel
+            </Button>
+            <Button size="sm" onClick={submit} disabled={busy || !value.trim()}>
+              {busy && <Spinner className="tw:size-3.5" />}
+              {status.configured ? "Save" : "Save & connect"}
+            </Button>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/packages/admin-ui/src/pages-new/ai/nexus/chat/ChatPanel.tsx
+++ b/packages/admin-ui/src/pages-new/ai/nexus/chat/ChatPanel.tsx
@@ -1,0 +1,954 @@
+import * as React from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  ArrowUp,
+  ExternalLink,
+  History,
+  MessageSquarePlus,
+  Sparkles,
+  Square,
+  KeyRound,
+  ShieldAlert,
+  Trash2,
+  X
+} from "lucide-react";
+import { Button } from "components/primitives/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger
+} from "components/primitives/dropdown-menu";
+import { TypographyMuted } from "components/primitives/typography";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "components/primitives/select";
+import { Alert, AlertTitle } from "components/primitives/alert";
+import { Spinner } from "components/primitives/spinner";
+import { cn } from "lib/utils";
+import { nexusExternalUrl } from "../data";
+import { Markdown } from "./Markdown";
+import {
+  ChatError,
+  ChatHistorySummary,
+  ChatMessage,
+  ChatPageContext,
+  NexusModel,
+  NexusStatus,
+  deleteConversation,
+  getNexusStatus,
+  listChatHistory,
+  listNexusModels,
+  loadConversation,
+  saveConversation,
+  smoothStream,
+  streamChat,
+  submitChatConfirmation
+} from "./api";
+
+const SELECTED_MODEL_STORAGE_KEY = "nexus-chat-selected-model";
+
+const SUGGESTIONS = [
+  "List the packages installed on this DAppNode and explain what each does",
+  "Suggest packages I should install for solo Ethereum staking",
+  "Explain MEV-Boost in the DAppNode context",
+  "How do I back up and restore a package?"
+];
+
+interface PendingConfirmation {
+  id: string;
+  tool: string;
+  args: unknown;
+}
+
+/**
+ * `page` (default) renders the panel sized for the dedicated /ai/nexus route.
+ * `floating` lets the parent (e.g. the bottom-right launcher) control the
+ * outer dimensions, drops the outer ring and lets the close button render in
+ * the header.
+ */
+export type ChatPanelVariant = "page" | "floating";
+
+export interface ChatPanelProps {
+  variant?: ChatPanelVariant;
+  /**
+   * Sampled lazily on each send — pass a function so the panel always
+   * reads the current URL when the user actually hits Enter, even if they
+   * navigated while the chat was open.
+   */
+  getPageContext?: () => ChatPageContext | undefined;
+  onRequestClose?: () => void;
+}
+
+export function ChatPanel({ variant = "page", getPageContext, onRequestClose }: ChatPanelProps = {}) {
+  const [status, setStatus] = useState<NexusStatus | null>(null);
+  const [statusError, setStatusError] = useState<string | null>(null);
+  const [models, setModels] = useState<NexusModel[]>([]);
+  const [modelsError, setModelsError] = useState<string | null>(null);
+  const [selectedModel, setSelectedModel] = useState<string>("");
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [isRunning, setIsRunning] = useState(false);
+  const [draft, setDraft] = useState("");
+  const [streamError, setStreamError] = useState<string | null>(null);
+  const [pendingConfirm, setPendingConfirm] = useState<PendingConfirmation | null>(null);
+  const [conversationId, setConversationId] = useState<string | null>(null);
+  const [historyList, setHistoryList] = useState<ChatHistorySummary[]>([]);
+  const abortRef = useRef<AbortController | null>(null);
+  // Mirror of `messages` so the post-stream save can read the final state
+  // without races with React's state batching.
+  const messagesRef = useRef<ChatMessage[]>([]);
+  useEffect(() => {
+    messagesRef.current = messages;
+  }, [messages]);
+  // Signature of the most recently saved conversation — used to skip saving
+  // unchanged state (e.g. immediately after loading a conversation).
+  const lastSavedRef = useRef<string>("");
+
+  // Fetch status + models on mount.
+  useEffect(() => {
+    let cancelled = false;
+    getNexusStatus()
+      .then(async (s) => {
+        if (cancelled) return;
+        setStatus(s);
+        if (!s.configured) return;
+        try {
+          const list = await listNexusModels();
+          if (cancelled) return;
+          setModels(list);
+          // Choose the initial model: last-used (if still available) →
+          // env default (if listed) → first listed.
+          const remembered = readRememberedModel();
+          const preferred = [remembered, s.defaultModel].find(
+            (id) => id && list.some((m) => m.id === id)
+          );
+          setSelectedModel(preferred || list[0]?.id || "");
+        } catch (err) {
+          if (!cancelled) setModelsError((err as Error).message);
+        }
+      })
+      .catch((err: Error) => {
+        if (!cancelled) setStatusError(err.message);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Persist last-used model so the next visit lands on the same choice.
+  useEffect(() => {
+    if (selectedModel) writeRememberedModel(selectedModel);
+  }, [selectedModel]);
+
+  const refreshHistory = useCallback(async () => {
+    try {
+      const list = await listChatHistory();
+      setHistoryList(list);
+    } catch {
+      /* non-fatal */
+    }
+  }, []);
+
+  // Load the history list on mount so the dropdown is populated immediately.
+  useEffect(() => {
+    refreshHistory();
+  }, [refreshHistory]);
+
+  // Auto-save the conversation server-side once a turn has settled (i.e.
+  // we're no longer streaming) and the messages have actually changed since
+  // the last save — so loading an existing conversation doesn't trigger a
+  // pointless write.
+  useEffect(() => {
+    if (isRunning || !conversationId || messages.length < 2) return;
+    const signature = JSON.stringify(messages);
+    if (signature === lastSavedRef.current) return;
+    lastSavedRef.current = signature;
+    saveConversation(conversationId, messages)
+      .then(() => refreshHistory())
+      .catch(() => {
+        /* ignore — will retry on the next settled turn */
+      });
+  }, [isRunning, conversationId, messages, refreshHistory]);
+
+  const send = async (text: string) => {
+    if (!text.trim() || isRunning || !status?.configured || !selectedModel) return;
+
+    // Lazily assign a conversation id on the first message of a fresh chat.
+    if (!conversationId) {
+      const id = (typeof crypto !== "undefined" && crypto.randomUUID)
+        ? crypto.randomUUID()
+        : `chat-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+      setConversationId(id);
+    }
+
+    const userMsg: ChatMessage = { role: "user", content: text.trim() };
+    const placeholder: ChatMessage = { role: "assistant", content: "" };
+    const history = [...messages, userMsg];
+    setMessages([...history, placeholder]);
+    setDraft("");
+    setStreamError(null);
+    setIsRunning(true);
+    const ac = new AbortController();
+    abortRef.current = ac;
+
+    try {
+      const source = streamChat({
+        model: selectedModel,
+        messages: history,
+        signal: ac.signal,
+        pageContext: getPageContext?.()
+      });
+      for await (const event of smoothStream(source, ac.signal)) {
+        if (event.type === "content") {
+          setMessages((prev) => {
+            const next = prev.slice();
+            const last = next[next.length - 1];
+            next[next.length - 1] = { ...last, content: last.content + event.delta };
+            return next;
+          });
+        } else if (event.type === "confirm_required") {
+          setPendingConfirm({ id: event.id, tool: event.tool, args: event.args });
+        } else if (event.type === "confirm_resolved") {
+          // Server-side resolution arrived (e.g. via another tab, or the
+          // user clicked Approve/Deny — either way we can clear the dialog).
+          setPendingConfirm((current) => (current?.id === event.id ? null : current));
+        }
+      }
+    } catch (err) {
+      if ((err as Error)?.name === "AbortError") {
+        // user-initiated cancel — keep partial text
+      } else if (err instanceof ChatError) {
+        setStreamError(err.message);
+        if (err.status) setStatus(err.status);
+        // drop the placeholder if nothing came through
+        setMessages((prev) => (prev[prev.length - 1]?.content ? prev : prev.slice(0, -1)));
+      } else {
+        setStreamError((err as Error).message || "Unknown error");
+        setMessages((prev) => (prev[prev.length - 1]?.content ? prev : prev.slice(0, -1)));
+      }
+    } finally {
+      setIsRunning(false);
+      abortRef.current = null;
+      setPendingConfirm(null);
+    }
+  };
+
+  const cancel = () => abortRef.current?.abort();
+
+  const respondToConfirmation = async (
+    confirmation: PendingConfirmation,
+    decision: "approve" | "deny"
+  ) => {
+    // Optimistically dismiss; the server will also emit `confirm_resolved`.
+    setPendingConfirm(null);
+    try {
+      await submitChatConfirmation(confirmation.id, decision);
+    } catch (err) {
+      // If the POST fails the server-side 5min timeout will catch it.
+      setStreamError((err as Error).message);
+    }
+  };
+
+  const startNewChat = () => {
+    if (isRunning) abortRef.current?.abort();
+    if (messages.length === 0 && !conversationId) return;
+    setMessages([]);
+    setConversationId(null);
+    setDraft("");
+    setStreamError(null);
+    setPendingConfirm(null);
+    lastSavedRef.current = "";
+  };
+
+  const openHistoryConversation = async (id: string) => {
+    if (id === conversationId) return;
+    if (isRunning) abortRef.current?.abort();
+    setStreamError(null);
+    setPendingConfirm(null);
+    try {
+      const conv = await loadConversation(id);
+      // Drop any zero-text placeholders that might have slipped through.
+      const restored = conv.messages.filter((m) => m.content || m.role === "user");
+      setMessages(restored);
+      setConversationId(id);
+      lastSavedRef.current = JSON.stringify(restored);
+    } catch (err) {
+      setStreamError((err as Error).message);
+    }
+  };
+
+  const removeHistoryConversation = async (id: string) => {
+    try {
+      await deleteConversation(id);
+      setHistoryList((prev) => prev.filter((h) => h.id !== id));
+      if (id === conversationId) {
+        setMessages([]);
+        setConversationId(null);
+        lastSavedRef.current = "";
+      }
+    } catch (err) {
+      setStreamError((err as Error).message);
+    }
+  };
+
+  // Loading state
+  if (!status && !statusError) {
+    return (
+      <Panel variant={variant}>
+        <div className="tw:flex tw:flex-1 tw:flex-col tw:items-center tw:justify-center tw:gap-3 tw:p-12">
+          <Spinner className="tw:size-5 tw:text-muted-foreground" />
+          <TypographyMuted className="tw:text-sm">Connecting to Nexus…</TypographyMuted>
+        </div>
+      </Panel>
+    );
+  }
+
+  if (statusError) {
+    return (
+      <Panel variant={variant}>
+        <div className="tw:flex tw:flex-1 tw:items-center tw:justify-center tw:p-12 tw:text-center">
+          <div>
+            <div className="tw:text-sm tw:font-medium tw:text-foreground">Couldn't reach DAppNode</div>
+            <TypographyMuted className="tw:mt-1 tw:text-xs">{statusError}</TypographyMuted>
+          </div>
+        </div>
+      </Panel>
+    );
+  }
+
+  if (!status) return null;
+
+  return (
+    <Panel variant={variant}>
+      <Header
+        status={status}
+        models={models}
+        selectedModel={selectedModel}
+        onSelectModel={setSelectedModel}
+        modelsError={modelsError}
+        historyList={historyList}
+        activeConversationId={conversationId}
+        onNewChat={startNewChat}
+        onOpenConversation={openHistoryConversation}
+        onDeleteConversation={removeHistoryConversation}
+        onRequestClose={onRequestClose}
+      />
+
+      <div className="tw:relative tw:flex tw:flex-1 tw:flex-col tw:min-h-0">
+        {messages.length === 0 ? (
+          <EmptyState
+            configured={status.configured}
+            onPick={(prompt) => send(prompt)}
+            disabled={!status.configured || !selectedModel}
+          />
+        ) : (
+          <Thread
+            messages={messages}
+            isRunning={isRunning}
+            pendingConfirm={pendingConfirm}
+            onConfirmation={respondToConfirmation}
+          />
+        )}
+      </div>
+
+      {!status.configured ? (
+        <NotConfigured />
+      ) : (
+        <Composer
+          draft={draft}
+          onDraftChange={setDraft}
+          onSend={() => send(draft)}
+          onCancel={cancel}
+          isRunning={isRunning}
+          error={streamError}
+          disabled={!selectedModel}
+        />
+      )}
+    </Panel>
+  );
+}
+
+function readRememberedModel(): string {
+  try {
+    return localStorage.getItem(SELECTED_MODEL_STORAGE_KEY) || "";
+  } catch {
+    return "";
+  }
+}
+
+function writeRememberedModel(id: string): void {
+  try {
+    localStorage.setItem(SELECTED_MODEL_STORAGE_KEY, id);
+  } catch {
+    /* private mode — non-fatal */
+  }
+}
+
+/* ── Layout shell ──────────────────────────────────────────────────── */
+
+function Panel({
+  variant,
+  children
+}: {
+  variant: ChatPanelVariant;
+  children: React.ReactNode;
+}) {
+  // Both variants render onto `bg-card` with `text-card-foreground` to match
+  // the project's Card primitive. In floating mode the launcher provides the
+  // outer ring/shadow/size; in page mode the panel owns those.
+  const className =
+    variant === "floating"
+      ? "tw:flex tw:h-full tw:w-full tw:flex-col tw:overflow-hidden tw:bg-card tw:text-card-foreground"
+      : "tw:flex tw:h-[calc(100svh-9rem)] tw:min-h-[540px] tw:w-full tw:flex-col tw:overflow-hidden tw:rounded-xl tw:bg-card tw:text-card-foreground tw:ring-1 tw:ring-foreground/10";
+  return <div className={className}>{children}</div>;
+}
+
+/* ── Header ────────────────────────────────────────────────────────── */
+
+function Header({
+  status,
+  models,
+  selectedModel,
+  onSelectModel,
+  modelsError,
+  historyList,
+  activeConversationId,
+  onNewChat,
+  onOpenConversation,
+  onDeleteConversation,
+  onRequestClose
+}: {
+  status: NexusStatus;
+  models: NexusModel[];
+  selectedModel: string;
+  onSelectModel: (id: string) => void;
+  modelsError: string | null;
+  historyList: ChatHistorySummary[];
+  activeConversationId: string | null;
+  onNewChat: () => void;
+  onOpenConversation: (id: string) => void;
+  onDeleteConversation: (id: string) => void;
+  onRequestClose?: () => void;
+}) {
+  return (
+    <header className="tw:relative tw:flex tw:shrink-0 tw:items-center tw:gap-3 tw:border-b tw:border-border tw:px-5 tw:py-3">
+      <div className="tw:flex tw:size-8 tw:shrink-0 tw:items-center tw:justify-center tw:rounded-lg tw:bg-primary/10 tw:text-primary">
+        <Sparkles className="tw:size-4" />
+      </div>
+      <div className="tw:flex tw:min-w-0 tw:flex-1 tw:flex-col">
+        <div className="tw:flex tw:items-center tw:gap-2">
+          <span className="tw:text-sm tw:font-semibold tw:text-foreground">Nexus chat</span>
+          {status.configured && (
+            <span
+              className="tw:size-1.5 tw:rounded-full tw:bg-emerald-500"
+              aria-label="online"
+            />
+          )}
+        </div>
+        <ModelPicker
+          configured={status.configured}
+          models={models}
+          selectedModel={selectedModel}
+          onSelectModel={onSelectModel}
+          error={modelsError}
+          fallback={status.defaultModel}
+        />
+      </div>
+      <div className="tw:flex tw:items-center tw:gap-1.5">
+        <Button
+          size="icon-xs"
+          variant="ghost"
+          onClick={onNewChat}
+          title="New chat"
+          aria-label="New chat"
+        >
+          <MessageSquarePlus />
+        </Button>
+        <HistoryMenu
+          history={historyList}
+          activeId={activeConversationId}
+          onOpen={onOpenConversation}
+          onDelete={onDeleteConversation}
+        />
+        {onRequestClose && (
+          <Button
+            size="icon-xs"
+            variant="ghost"
+            onClick={onRequestClose}
+            title="Close chat"
+            aria-label="Close chat"
+          >
+            <X />
+          </Button>
+        )}
+      </div>
+    </header>
+  );
+}
+
+function HistoryMenu({
+  history,
+  activeId,
+  onOpen,
+  onDelete
+}: {
+  history: ChatHistorySummary[];
+  activeId: string | null;
+  onOpen: (id: string) => void;
+  onDelete: (id: string) => void;
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          size="icon-xs"
+          variant="ghost"
+          aria-label="Past conversations"
+          title="Past conversations"
+        >
+          <History />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="tw:w-72">
+        <DropdownMenuLabel className="tw:flex tw:items-center tw:justify-between">
+          <span>Past conversations</span>
+          <span className="tw:font-mono tw:text-[10.5px] tw:text-muted-foreground">
+            {history.length}
+          </span>
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {history.length === 0 ? (
+          <div className="tw:px-2 tw:py-2 tw:text-[12px] tw:text-muted-foreground">
+            No saved chats yet.
+          </div>
+        ) : (
+          history.map((h) => (
+            <DropdownMenuItem
+              key={h.id}
+              onSelect={(e) => {
+                e.preventDefault();
+                onOpen(h.id);
+              }}
+              className={cn(
+                "tw:flex tw:items-start tw:gap-2",
+                h.id === activeId && "tw:bg-muted"
+              )}
+            >
+              <div className="tw:min-w-0 tw:flex-1">
+                <div className="tw:truncate tw:text-[12.5px] tw:text-foreground">
+                  {h.title}
+                </div>
+                <div className="tw:mt-0.5 tw:font-mono tw:text-[10.5px] tw:text-muted-foreground">
+                  {formatRelative(h.updatedAt)} · {h.messageCount} msg
+                </div>
+              </div>
+              <Button
+                size="icon-xs"
+                variant="ghost"
+                aria-label="Delete conversation"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDelete(h.id);
+                }}
+                className="tw:size-6 tw:text-muted-foreground hover:tw:bg-destructive/10 hover:tw:text-destructive"
+              >
+                <Trash2 className="tw:size-3.5" />
+              </Button>
+            </DropdownMenuItem>
+          ))
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function formatRelative(ts: number): string {
+  const diff = Date.now() - ts;
+  if (diff < 60_000) return "just now";
+  const minutes = Math.floor(diff / 60_000);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  return new Date(ts).toLocaleDateString();
+}
+
+function ModelPicker({
+  configured,
+  models,
+  selectedModel,
+  onSelectModel,
+  error,
+  fallback
+}: {
+  configured: boolean;
+  models: NexusModel[];
+  selectedModel: string;
+  onSelectModel: (id: string) => void;
+  error: string | null;
+  fallback: string;
+}) {
+  const sorted = useMemo(() => sortModels(models), [models]);
+
+  if (!configured) {
+    return (
+      <div className="tw:mt-0.5 tw:truncate tw:font-mono tw:text-[10.5px] tw:text-muted-foreground">
+        not configured
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="tw:mt-0.5 tw:truncate tw:font-mono tw:text-[10.5px] tw:text-destructive">
+        {error}
+      </div>
+    );
+  }
+
+  if (sorted.length === 0) {
+    return (
+      <div className="tw:mt-0.5 tw:truncate tw:font-mono tw:text-[10.5px] tw:text-muted-foreground">
+        {selectedModel || fallback || "loading models…"}
+      </div>
+    );
+  }
+
+  const currentModel = sorted.find((m) => m.id === selectedModel);
+  const currentLabel = currentModel
+    ? `${currentModel.id}${currentModel.kind === "router" ? "  ·  router" : ""}`
+    : selectedModel || fallback || "(none)";
+
+  return (
+    <Select value={selectedModel} onValueChange={onSelectModel}>
+      <SelectTrigger
+        size="sm"
+        aria-label="Choose model"
+        className="tw:mt-0.5 tw:inline-flex tw:max-w-full tw:h-auto tw:border-0 tw:bg-transparent tw:font-mono tw:text-[10.5px] tw:text-muted-foreground tw:p-0 tw:gap-0.5 tw:hover:text-foreground tw:shadow-none tw:hover:bg-transparent tw:dark:bg-transparent tw:dark:hover:bg-transparent tw:[&_svg:last-child]:size-3"
+      >
+        <span className="tw:truncate">{currentLabel}</span>
+        <SelectValue asChild>
+          <span />
+        </SelectValue>
+      </SelectTrigger>
+      <SelectContent align="start" className="tw:font-mono tw:text-xs">
+        {sorted.map((m) => (
+          <SelectItem key={m.id} value={m.id}>
+            {m.id}
+            {m.kind === "router" ? "  ·  router" : ""}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
+function sortModels(models: NexusModel[]): NexusModel[] {
+  return [...models].sort((a, b) => {
+    const aRank = a.kind === "router" ? 0 : 1;
+    const bRank = b.kind === "router" ? 0 : 1;
+    if (aRank !== bRank) return aRank - bRank;
+    return a.id.localeCompare(b.id);
+  });
+}
+
+/* ── Empty state ───────────────────────────────────────────────────── */
+
+function EmptyState({
+  configured,
+  onPick,
+  disabled
+}: {
+  configured: boolean;
+  onPick: (prompt: string) => void;
+  disabled: boolean;
+}) {
+  return (
+    <div className="tw:flex tw:flex-1 tw:flex-col tw:items-center tw:justify-center tw:gap-4 tw:px-6 tw:py-6 tw:text-center">
+      <div className="tw:flex tw:size-12 tw:items-center tw:justify-center tw:rounded-2xl tw:bg-primary/10 tw:text-primary tw:ring-1 tw:ring-primary/20">
+        <Sparkles className="tw:size-5" />
+      </div>
+      <div className="tw:flex tw:max-w-md tw:flex-col tw:items-center tw:gap-2">
+        <h3 className="tw:text-2xl tw:font-semibold tw:tracking-tight tw:text-foreground">
+          Talk to a private model
+        </h3>
+        <p className="tw:text-sm tw:text-muted-foreground">
+          {configured
+            ? "Talks to Nexus through this DAppNode, with the official docs and your installed-package list as context. Pick a prompt or just start typing."
+            : "Nexus chat hasn't been configured on this DAppNode yet."}
+        </p>
+      </div>
+      {configured && (
+        <div className="tw:grid tw:w-full tw:max-w-md tw:gap-2 tw:sm:grid-cols-2">
+          {SUGGESTIONS.map((prompt) => (
+            <Button
+              key={prompt}
+              variant="outline"
+              size="sm"
+              disabled={disabled}
+              onClick={() => onPick(prompt)}
+              className="tw:h-auto tw:whitespace-normal tw:justify-start tw:py-3 tw:text-left tw:text-[13px] tw:leading-snug tw:font-normal tw:disabled:opacity-50"
+            >
+              {prompt}
+            </Button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ── Messages ──────────────────────────────────────────────────────── */
+
+function Thread({
+  messages,
+  isRunning,
+  pendingConfirm,
+  onConfirmation
+}: {
+  messages: ChatMessage[];
+  isRunning: boolean;
+  pendingConfirm: PendingConfirmation | null;
+  onConfirmation: (confirmation: PendingConfirmation, decision: "approve" | "deny") => void;
+}) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const stickRef = useRef(true);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const onScroll = () => {
+      stickRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
+    };
+    el.addEventListener("scroll", onScroll, { passive: true });
+    return () => el.removeEventListener("scroll", onScroll);
+  }, []);
+
+  useEffect(() => {
+    if (!stickRef.current) return;
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+  }, [messages, pendingConfirm]);
+
+  return (
+    <div ref={scrollRef} className="tw:flex tw:flex-1 tw:flex-col tw:gap-6 tw:overflow-y-auto tw:px-6 tw:py-6">
+      {messages.map((msg, idx) => {
+        const isLast = idx === messages.length - 1;
+        return msg.role === "user" ? (
+          <UserBubble key={idx} text={msg.content} />
+        ) : (
+          <AssistantBubble
+            key={idx}
+            text={msg.content}
+            isRunning={isRunning && isLast && !pendingConfirm}
+          />
+        );
+      })}
+      {pendingConfirm && (
+        <ConfirmationCard
+          confirmation={pendingConfirm}
+          onDecision={(decision) => onConfirmation(pendingConfirm, decision)}
+        />
+      )}
+    </div>
+  );
+}
+
+function ConfirmationCard({
+  confirmation,
+  onDecision
+}: {
+  confirmation: PendingConfirmation;
+  onDecision: (decision: "approve" | "deny") => void;
+}) {
+  const formattedArgs = useMemo(() => {
+    if (!confirmation.args || typeof confirmation.args !== "object") {
+      return JSON.stringify(confirmation.args ?? {});
+    }
+    return JSON.stringify(confirmation.args, null, 2);
+  }, [confirmation.args]);
+
+  return (
+    <div className="tw:flex tw:gap-3">
+      <span
+        aria-hidden
+        className="tw:mt-1.5 tw:h-full tw:w-0.5 tw:shrink-0 tw:rounded-full tw:bg-gradient-to-b tw:from-amber-500/80 tw:via-amber-500/40 tw:to-amber-500/0"
+      />
+      <div className="tw:min-w-0 tw:flex-1 tw:rounded-xl tw:border tw:border-amber-500/30 tw:bg-amber-500/5 tw:p-4">
+        <div className="tw:flex tw:items-start tw:gap-2.5">
+          <div className="tw:flex tw:size-8 tw:shrink-0 tw:items-center tw:justify-center tw:rounded-lg tw:bg-amber-500/15 tw:text-amber-600 tw:dark:text-amber-300">
+            <ShieldAlert className="tw:size-4" />
+          </div>
+          <div className="tw:flex-1">
+            <div className="tw:text-sm tw:font-semibold tw:text-foreground">
+              Confirm tool call
+            </div>
+            <TypographyMuted className="tw:mt-0.5 tw:text-[12.5px]">
+              The assistant wants to run a tool that changes state on this DAppNode.
+            </TypographyMuted>
+          </div>
+        </div>
+
+        <div className="tw:mt-3 tw:overflow-hidden tw:rounded-lg tw:border tw:border-border tw:bg-background">
+          <div className="tw:flex tw:items-center tw:justify-between tw:gap-2 tw:border-b tw:border-border tw:px-3 tw:py-1.5">
+            <code className="tw:font-mono tw:text-[12px] tw:font-semibold tw:text-foreground">
+              {confirmation.tool}
+            </code>
+            <span className="tw:font-mono tw:text-[10.5px] tw:uppercase tw:tracking-wide tw:text-muted-foreground">
+              mutating
+            </span>
+          </div>
+          <pre className="tw:max-h-48 tw:overflow-auto tw:px-3 tw:py-2 tw:font-mono tw:text-[12px] tw:text-foreground">
+            {formattedArgs}
+          </pre>
+        </div>
+
+        <div className="tw:mt-3 tw:flex tw:items-center tw:justify-end tw:gap-2">
+          <Button variant="outline" size="sm" onClick={() => onDecision("deny")}>
+            Deny
+          </Button>
+          <Button size="sm" onClick={() => onDecision("approve")}>
+            Approve & run
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function UserBubble({ text }: { text: string }) {
+  return (
+    <div className="tw:flex tw:justify-end">
+      <div className="tw:max-w-[85%] tw:whitespace-pre-wrap tw:rounded-2xl tw:rounded-tr-md tw:bg-muted tw:px-4 tw:py-2.5 tw:text-[14px] tw:text-foreground">
+        {text}
+      </div>
+    </div>
+  );
+}
+
+function AssistantBubble({ text, isRunning }: { text: string; isRunning: boolean }) {
+  const showTyping = isRunning && !text;
+  return (
+    <div className="tw:flex tw:gap-3">
+      <span
+        aria-hidden
+        className="tw:mt-1.5 tw:h-full tw:w-0.5 tw:shrink-0 tw:rounded-full tw:bg-gradient-to-b tw:from-primary/70 tw:via-primary/40 tw:to-primary/0"
+      />
+      <div className="tw:min-w-0 tw:flex-1 tw:pb-1 tw:text-[14px] tw:leading-relaxed tw:text-foreground">
+        {showTyping ? <TypingDots /> : <Markdown content={text} />}
+      </div>
+    </div>
+  );
+}
+
+function TypingDots() {
+  return (
+    <div className="tw:flex tw:items-center tw:gap-1.5 tw:py-1" aria-label="Assistant is typing">
+      {[0, 1, 2].map((i) => (
+        <span
+          key={i}
+          className="tw:inline-block tw:size-1.5 tw:rounded-full tw:bg-muted-foreground tw:animate-pulse"
+          style={{ animationDelay: `${i * 0.18}s`, animationDuration: "1.1s" }}
+        />
+      ))}
+    </div>
+  );
+}
+
+/* ── Composer ──────────────────────────────────────────────────────── */
+
+function Composer({
+  draft,
+  onDraftChange,
+  onSend,
+  onCancel,
+  isRunning,
+  error,
+  disabled
+}: {
+  draft: string;
+  onDraftChange: (v: string) => void;
+  onSend: () => void;
+  onCancel: () => void;
+  isRunning: boolean;
+  error: string | null;
+  disabled?: boolean;
+}) {
+  const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      onSend();
+    }
+  };
+
+  return (
+    <div className="tw:shrink-0 tw:border-t tw:border-border tw:bg-background/40 tw:px-4 tw:py-3">
+      {error && (
+        <Alert variant="destructive" className="tw:mb-2 tw:py-2 tw:text-[12.5px]">
+          <AlertTitle className="tw:text-[12.5px]">{error}</AlertTitle>
+        </Alert>
+      )}
+      {/*
+        Composer surface: matches the project's Input primitive idiom
+        (border-input, focus ring via --ring). The textarea explicitly drops
+        its own browser-default border (`border-0`) and outline so only the
+        outer wrapper renders the visible frame.
+      */}
+      <div className="tw:flex tw:items-end tw:gap-2 tw:rounded-lg tw:border tw:border-input tw:bg-transparent tw:px-3 tw:py-1.5 tw:transition-colors tw:focus-within:border-ring tw:focus-within:ring-3 tw:focus-within:ring-ring/50 tw:dark:bg-input/30">
+        <textarea
+          value={draft}
+          onChange={(e) => onDraftChange(e.target.value)}
+          onKeyDown={onKeyDown}
+          rows={1}
+          placeholder="Send a message…"
+          autoFocus
+          style={{ fieldSizing: "content" } as React.CSSProperties}
+          className="tw:max-h-44 tw:flex-1 tw:resize-none tw:appearance-none tw:border-0 tw:bg-transparent tw:py-1.5 tw:text-[14px] tw:leading-relaxed tw:text-foreground tw:shadow-none tw:outline-none tw:ring-0 tw:focus:outline-none tw:focus:ring-0 tw:placeholder:text-muted-foreground"
+        />
+        {isRunning ? (
+          <Button size="icon-sm" variant="outline" onClick={onCancel} aria-label="Stop generating">
+            <Square className="tw:fill-current" />
+          </Button>
+        ) : (
+          <Button
+            size="icon-sm"
+            onClick={onSend}
+            disabled={disabled || !draft.trim()}
+            aria-label="Send message"
+          >
+            <ArrowUp />
+          </Button>
+        )}
+      </div>
+      <p className="tw:mt-1.5 tw:text-center tw:text-[10.5px] tw:text-muted-foreground">
+        Enter to send · Shift+Enter for newline
+      </p>
+    </div>
+  );
+}
+
+/* ── CTAs ──────────────────────────────────────────────────────────── */
+
+function NotConfigured() {
+  return (
+    <div className="tw:shrink-0 tw:border-t tw:border-border tw:bg-muted/40 tw:px-5 tw:py-5">
+      <div className="tw:mx-auto tw:flex tw:max-w-xl tw:flex-col tw:items-start tw:gap-2">
+        <div className="tw:flex tw:items-center tw:gap-2 tw:text-[13px] tw:font-medium tw:text-foreground">
+          <KeyRound className="tw:size-4 tw:text-muted-foreground" />
+          Nexus chat is not configured on this DAppNode
+        </div>
+        <TypographyMuted className="tw:text-[12.5px]">
+          Set <code className="tw:rounded tw:bg-muted tw:px-1 tw:py-0.5 tw:font-mono">NEXUS_API_KEY</code>{" "}
+          on the dappmanager container and restart. The Nexus user portal is where you generate the
+          key.
+        </TypographyMuted>
+        <Button variant="outline" size="sm" onClick={() => window.open(nexusExternalUrl, "_blank")}>
+          Open Nexus
+          <ExternalLink />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/admin-ui/src/pages-new/ai/nexus/chat/FloatingChatLauncher.tsx
+++ b/packages/admin-ui/src/pages-new/ai/nexus/chat/FloatingChatLauncher.tsx
@@ -1,0 +1,140 @@
+import * as React from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useLocation } from "react-router-dom";
+import { MessageSquare, Sparkles } from "lucide-react";
+import { cn } from "lib/utils";
+import { ChatPageContext } from "./api";
+import { ChatPanel } from "./ChatPanel";
+
+/**
+ * App-wide chat launcher. Renders a bubble in the bottom-right corner; clicking
+ * it slides out a Nexus chat panel anchored to the same corner. The chat
+ * receives the current URL on every send so the model can answer "what is this
+ * page?" without an extra round-trip.
+ *
+ * Lifecycle:
+ *  - The panel is lazily mounted on the first open, then kept in the tree
+ *    (just hidden) so an in-progress stream / draft survives close + reopen.
+ *  - Hidden entirely on /ai/nexus, where the full-page chat already lives.
+ */
+
+const HIDE_ON_PATH_PREFIXES = ["/ai/nexus"];
+
+export function FloatingChatLauncher() {
+  const location = useLocation();
+  const [isOpen, setIsOpen] = useState(false);
+  const [hasEverOpened, setHasEverOpened] = useState(false);
+
+  const hideEntirely = HIDE_ON_PATH_PREFIXES.some((prefix) =>
+    location.pathname.startsWith(prefix)
+  );
+
+  const open = useCallback(() => {
+    setIsOpen(true);
+    setHasEverOpened(true);
+  }, []);
+  const close = useCallback(() => setIsOpen(false), []);
+
+  // Esc to close — only attached while open.
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") close();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [isOpen, close]);
+
+  // Stable ref to the current location so the ChatPanel can read it lazily
+  // at send-time (the user may have navigated since the panel was opened).
+  const locationRef = useRef(location);
+  useEffect(() => {
+    locationRef.current = location;
+  }, [location]);
+
+  const getPageContext = useCallback((): ChatPageContext | undefined => {
+    const loc = locationRef.current;
+    return {
+      path: loc.pathname,
+      ...(loc.search ? { search: loc.search } : {}),
+      ...(loc.hash ? { hash: loc.hash } : {}),
+      title: typeof document !== "undefined" ? document.title || undefined : undefined
+    };
+  }, []);
+
+  // Wrap the close handler so it's referentially stable for the chat panel.
+  const onRequestClose = useMemo(() => () => close(), [close]);
+
+  if (hideEntirely) return null;
+
+  return (
+    <>
+      {/* Backdrop tap-out — on small screens the panel takes most of the viewport,
+          so tapping the dimmed area is the natural close gesture. */}
+      {isOpen && (
+        <button
+          type="button"
+          aria-label="Close chat"
+          onClick={close}
+          className="tw:fixed tw:inset-0 tw:z-40 tw:cursor-default tw:bg-foreground/0 tw:sm:hidden"
+        />
+      )}
+
+      {/* Bubble launcher */}
+      <button
+        type="button"
+        onClick={isOpen ? close : open}
+        aria-label={isOpen ? "Close Nexus chat" : "Open Nexus chat"}
+        aria-expanded={isOpen}
+        className={cn(
+          "tw:fixed tw:bottom-5 tw:right-5 tw:z-50 tw:sm:bottom-6 tw:sm:right-6",
+          "tw:flex tw:size-14 tw:items-center tw:justify-center tw:rounded-2xl tw:border-0",
+          "tw:bg-[color-mix(in_oklab,var(--primary)_15%,var(--card))] tw:text-primary tw:shadow-md tw:shadow-primary/15",
+          "tw:transition-all tw:duration-200 tw:outline-none tw:select-none",
+          "tw:hover:bg-primary tw:hover:text-primary-foreground tw:hover:shadow-lg tw:hover:shadow-primary/40 tw:hover:-translate-y-0.5 tw:active:translate-y-0",
+          "tw:focus-visible:ring-3 tw:focus-visible:ring-ring/50",
+          "tw:disabled:pointer-events-none tw:disabled:opacity-50",
+          "tw:[&_svg]:pointer-events-none tw:[&_svg]:shrink-0"
+        )}
+      >
+        {isOpen ? (
+          <MessageSquare className="tw:size-6" aria-hidden />
+        ) : (
+          <Sparkles className="tw:size-6" aria-hidden />
+        )}
+      </button>
+
+      {/* Panel — keeps mounted after first open so streams + drafts survive close */}
+      {hasEverOpened && (
+        <div
+          role="dialog"
+          aria-modal="false"
+          aria-label="Nexus chat"
+          className={cn(
+            // Position
+            "tw:fixed tw:z-50",
+            // Mobile: nearly fullscreen, gutter to leave the bubble tappable
+            "tw:inset-3 tw:bottom-24",
+            // ≥sm: anchored card in the bottom-right corner — bigger surface
+            // so the conversation actually has room to breathe.
+            "tw:sm:inset-auto tw:sm:bottom-24 tw:sm:right-6 tw:sm:w-[500px] tw:sm:max-w-[calc(100vw-3rem)]",
+            // Height clamp so it can never overflow the viewport
+            "tw:sm:h-[min(760px,calc(100svh-7rem))]",
+            // Surface — matches the project's Card idiom (rounded-xl, ring on
+            // foreground/10) but with a heavier shadow since this floats.
+            "tw:overflow-hidden tw:rounded-xl tw:bg-card tw:text-card-foreground tw:shadow-2xl tw:shadow-foreground/15 tw:ring-1 tw:ring-foreground/10",
+            // Open/close transition (display-toggle, so no enter anim — just keep it crisp)
+            "tw:origin-bottom-right tw:transition-opacity tw:duration-150",
+            isOpen ? "tw:opacity-100" : "tw:pointer-events-none tw:hidden tw:opacity-0"
+          )}
+        >
+          <ChatPanel
+            variant="floating"
+            getPageContext={getPageContext}
+            onRequestClose={onRequestClose}
+          />
+        </div>
+      )}
+    </>
+  );
+}

--- a/packages/admin-ui/src/pages-new/ai/nexus/chat/Markdown.tsx
+++ b/packages/admin-ui/src/pages-new/ai/nexus/chat/Markdown.tsx
@@ -1,0 +1,115 @@
+import * as React from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { cn } from "lib/utils";
+import { Separator } from "components/primitives/separator";
+
+interface MarkdownProps {
+  content: string;
+  className?: string;
+}
+
+/**
+ * Renders chat assistant text as GitHub-flavoured Markdown styled with the
+ * DAppNode design tokens. GFM gives us tables, strikethrough, and task
+ * lists — without it the model's tables collapse into one paragraph.
+ */
+function MarkdownBase({ content, className }: MarkdownProps) {
+  return (
+    <div className={cn("tw:space-y-3", className)}>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={{
+          p: ({ children }) => (
+            <p className="tw:leading-relaxed tw:text-foreground">{children}</p>
+          ),
+          h1: ({ children }) => (
+            <h3 className="tw:mt-4 tw:text-base tw:font-semibold tw:text-foreground">{children}</h3>
+          ),
+          h2: ({ children }) => (
+            <h4 className="tw:mt-4 tw:text-[15px] tw:font-semibold tw:text-foreground">{children}</h4>
+          ),
+          h3: ({ children }) => (
+            <h5 className="tw:mt-3 tw:text-sm tw:font-semibold tw:text-foreground">{children}</h5>
+          ),
+          h4: ({ children }) => (
+            <h6 className="tw:mt-3 tw:text-sm tw:font-medium tw:text-foreground">{children}</h6>
+          ),
+          ul: ({ children }) => (
+            <ul className="tw:ml-5 tw:list-disc tw:space-y-1 marker:tw:text-muted-foreground">
+              {children}
+            </ul>
+          ),
+          ol: ({ children }) => (
+            <ol className="tw:ml-5 tw:list-decimal tw:space-y-1 marker:tw:text-muted-foreground">
+              {children}
+            </ol>
+          ),
+          li: ({ children }) => <li className="tw:leading-relaxed">{children}</li>,
+          a: ({ children, href }) => (
+            <a
+              href={href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="tw:text-primary tw:underline tw:underline-offset-2 tw:hover:opacity-80"
+            >
+              {children}
+            </a>
+          ),
+          strong: ({ children }) => (
+            <strong className="tw:font-semibold tw:text-foreground">{children}</strong>
+          ),
+          em: ({ children }) => <em className="tw:italic">{children}</em>,
+          blockquote: ({ children }) => (
+            <blockquote className="tw:border-l-2 tw:border-border tw:pl-3 tw:text-muted-foreground tw:italic">
+              {children}
+            </blockquote>
+          ),
+          hr: () => <Separator />,
+          del: ({ children }) => <del className="tw:text-muted-foreground">{children}</del>,
+          code: ({ inline, children }: React.PropsWithChildren<{ inline?: boolean }>) =>
+            inline ? (
+              <code className="tw:rounded tw:bg-muted tw:px-1.5 tw:py-0.5 tw:font-mono tw:text-[0.85em]">
+                {children}
+              </code>
+            ) : (
+              <code className="tw:block tw:font-mono tw:text-[0.85em] tw:leading-relaxed">
+                {children}
+              </code>
+            ),
+          pre: ({ children }) => (
+            <pre className="tw:overflow-x-auto tw:rounded-lg tw:border tw:border-border tw:bg-muted/60 tw:p-3">
+              {children}
+            </pre>
+          ),
+          // GFM tables — wrap in a horizontal scroll container so wide
+          // tables don't blow out the chat width.
+          table: ({ children }) => (
+            <div className="tw:my-3 tw:overflow-x-auto tw:rounded-lg tw:border tw:border-border">
+              <table className="tw:w-full tw:border-collapse tw:text-[12.5px]">{children}</table>
+            </div>
+          ),
+          thead: ({ children }) => (
+            <thead className="tw:bg-muted/60 tw:text-[11.5px] tw:font-mono tw:uppercase tw:tracking-wide tw:text-muted-foreground">
+              {children}
+            </thead>
+          ),
+          tbody: ({ children }) => <tbody>{children}</tbody>,
+          tr: ({ children }) => (
+            <tr className="tw:border-b tw:border-border last:tw:border-b-0">{children}</tr>
+          ),
+          th: ({ children }) => (
+            <th className="tw:px-3 tw:py-2 tw:text-left tw:font-semibold">{children}</th>
+          ),
+          td: ({ children }) => (
+            <td className="tw:px-3 tw:py-2 tw:align-top tw:text-foreground">{children}</td>
+          )
+        }}
+      >
+        {content}
+      </ReactMarkdown>
+    </div>
+  );
+}
+
+export const Markdown = React.memo(MarkdownBase);

--- a/packages/admin-ui/src/pages-new/ai/nexus/chat/api.ts
+++ b/packages/admin-ui/src/pages-new/ai/nexus/chat/api.ts
@@ -174,13 +174,14 @@ export interface StreamChatOptions {
  */
 export type StreamEvent =
   | { type: "content"; delta: string }
-  | { type: "confirm_required"; id: string; tool: string; args: unknown }
+  | { type: "confirm_required"; id: string; tool: string; displayName: string; args: unknown }
   | { type: "confirm_resolved"; id: string; decision: "approve" | "deny"; reason?: string };
 
 interface DappmanagerEvent {
   type?: string;
   id?: string;
   tool?: string;
+  displayName?: string;
   args?: unknown;
   decision?: "approve" | "deny";
   reason?: string;
@@ -258,7 +259,13 @@ export async function* streamChat(options: StreamChatOptions): AsyncGenerator<St
     if (chunk.dappmanager) {
       const ev = chunk.dappmanager;
       if (ev.type === "confirm_required" && typeof ev.id === "string" && typeof ev.tool === "string") {
-        yield { type: "confirm_required", id: ev.id, tool: ev.tool, args: ev.args };
+        yield {
+          type: "confirm_required",
+          id: ev.id,
+          tool: ev.tool,
+          displayName: typeof ev.displayName === "string" && ev.displayName ? ev.displayName : ev.tool,
+          args: ev.args
+        };
       } else if (ev.type === "confirm_resolved" && typeof ev.id === "string" && (ev.decision === "approve" || ev.decision === "deny")) {
         yield { type: "confirm_resolved", id: ev.id, decision: ev.decision, reason: ev.reason };
       }

--- a/packages/admin-ui/src/pages-new/ai/nexus/chat/api.ts
+++ b/packages/admin-ui/src/pages-new/ai/nexus/chat/api.ts
@@ -1,0 +1,327 @@
+/**
+ * Browser-side client for the DAppNode-hosted Nexus chat proxy.
+ *
+ * The dappmanager backend holds the Nexus API key and proxies every request,
+ * so this module just talks to same-origin endpoints.
+ */
+
+export type ChatRole = "user" | "assistant";
+
+export interface ChatMessage {
+  role: ChatRole;
+  content: string;
+}
+
+export interface NexusStatus {
+  configured: boolean;
+  gatewayUrl: string;
+  defaultModel: string;
+}
+
+const STATUS_URL = "/nexus/status";
+const MODELS_URL = "/nexus/models";
+const CHAT_URL = "/nexus/chat/completions";
+const CONFIRM_URL = "/nexus/chat/confirm";
+const HISTORY_URL = "/nexus/chat/history";
+
+export interface NexusModel {
+  id: string;
+  display_name?: string;
+  description?: string;
+  kind?: string;
+  context_size?: number;
+  max_output_tokens?: number;
+  input_price_per_1m_tokens_cents?: number;
+  output_price_per_1m_tokens_cents?: number;
+}
+
+async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, { credentials: "include", ...init });
+  if (!res.ok) {
+    let detail = "";
+    try {
+      const body = (await res.json()) as { error?: { message?: string } };
+      detail = body?.error?.message ?? "";
+    } catch {
+      /* ignore */
+    }
+    throw new Error(detail || `${res.status} ${res.statusText}`);
+  }
+  return (await res.json()) as T;
+}
+
+export function getNexusStatus(): Promise<NexusStatus> {
+  return fetchJson<NexusStatus>(STATUS_URL);
+}
+
+export async function listNexusModels(): Promise<NexusModel[]> {
+  const res = await fetchJson<{ data?: NexusModel[] }>(MODELS_URL);
+  return Array.isArray(res.data) ? res.data : [];
+}
+
+/** Approve / deny a pending tool-call surfaced on the SSE stream. */
+export function submitChatConfirmation(
+  id: string,
+  decision: "approve" | "deny",
+  reason?: string
+): Promise<{ ok: boolean }> {
+  return fetchJson<{ ok: boolean }>(CONFIRM_URL, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ id, decision, reason })
+  });
+}
+
+/* ------------------------------------------------------------------ *
+ * Chat history
+ * ------------------------------------------------------------------ */
+
+export interface ChatHistorySummary {
+  id: string;
+  title: string;
+  messageCount: number;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface StoredConversation extends ChatHistorySummary {
+  messages: ChatMessage[];
+}
+
+export async function listChatHistory(): Promise<ChatHistorySummary[]> {
+  const res = await fetchJson<{ data?: ChatHistorySummary[] }>(HISTORY_URL);
+  return Array.isArray(res.data) ? res.data : [];
+}
+
+export function loadConversation(id: string): Promise<StoredConversation> {
+  return fetchJson<StoredConversation>(`${HISTORY_URL}/${encodeURIComponent(id)}`);
+}
+
+export function saveConversation(
+  id: string,
+  messages: ChatMessage[],
+  title?: string
+): Promise<StoredConversation> {
+  return fetchJson<StoredConversation>(`${HISTORY_URL}/${encodeURIComponent(id)}`, {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ messages, title })
+  });
+}
+
+export async function deleteConversation(id: string): Promise<void> {
+  const res = await fetch(`${HISTORY_URL}/${encodeURIComponent(id)}`, {
+    method: "DELETE",
+    credentials: "include"
+  });
+  if (!res.ok && res.status !== 204) {
+    throw new Error(`Failed to delete conversation: ${res.status}`);
+  }
+}
+
+/* ------------------------------------------------------------------ *
+ * Chat completion (SSE)
+ * ------------------------------------------------------------------ */
+
+interface OpenAIDelta {
+  choices?: { delta?: { content?: string }; finish_reason?: string | null }[];
+  error?: { message?: string; type?: string };
+}
+
+interface ChatErrorBody {
+  error?: { code?: string; message?: string };
+  status?: NexusStatus;
+}
+
+/** Raised when the gateway refuses the request before any tokens arrive. */
+export class ChatError extends Error {
+  code: string;
+  status?: NexusStatus;
+  constructor(message: string, code: string, status?: NexusStatus) {
+    super(message);
+    this.name = "ChatError";
+    this.code = code;
+    this.status = status;
+  }
+}
+
+/**
+ * Tells the server which page of the admin UI the user is looking at when
+ * they send the message. Travels alongside the OpenAI body and is appended
+ * to the system prompt by the proxy so the model can resolve vague queries
+ * ("what is this page?", "what does this do?") without a round-trip.
+ */
+export interface ChatPageContext {
+  path: string;
+  search?: string;
+  hash?: string;
+  title?: string;
+}
+
+export interface StreamChatOptions {
+  model: string;
+  messages: ChatMessage[];
+  temperature?: number;
+  maxTokens?: number;
+  signal?: AbortSignal;
+  pageContext?: ChatPageContext;
+}
+
+/**
+ * What `streamChat` yields. Text deltas (`type: "content"`) are paced by
+ * `smoothStream`; control events (`confirm_required` / `confirm_resolved`)
+ * pass through immediately so the UI can react without typing-delay.
+ */
+export type StreamEvent =
+  | { type: "content"; delta: string }
+  | { type: "confirm_required"; id: string; tool: string; args: unknown }
+  | { type: "confirm_resolved"; id: string; decision: "approve" | "deny"; reason?: string };
+
+interface DappmanagerEvent {
+  type?: string;
+  id?: string;
+  tool?: string;
+  args?: unknown;
+  decision?: "approve" | "deny";
+  reason?: string;
+}
+
+/**
+ * Splits an SSE `text/event-stream` body into the inner `data:` payloads.
+ * `:` comment lines are skipped and the `[DONE]` terminator is filtered out.
+ */
+async function* readSSE(stream: ReadableStream<Uint8Array>): AsyncGenerator<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true }).replace(/\r\n/g, "\n");
+      let sep: number;
+      while ((sep = buffer.indexOf("\n\n")) !== -1) {
+        const event = buffer.slice(0, sep);
+        buffer = buffer.slice(sep + 2);
+        for (const line of event.split("\n")) {
+          if (!line.startsWith("data:")) continue;
+          const payload = line.slice(5).trim();
+          if (payload && payload !== "[DONE]") yield payload;
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+/** Calls the dappmanager proxy and yields typed stream events. */
+export async function* streamChat(options: StreamChatOptions): AsyncGenerator<StreamEvent> {
+  const res = await fetch(CHAT_URL, {
+    method: "POST",
+    credentials: "include",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      model: options.model,
+      messages: options.messages,
+      stream: true,
+      ...(options.temperature !== undefined ? { temperature: options.temperature } : {}),
+      ...(options.maxTokens !== undefined ? { max_tokens: options.maxTokens } : {}),
+      ...(options.pageContext ? { dappmanager_page: options.pageContext } : {})
+    }),
+    signal: options.signal
+  });
+
+  if (!res.ok) {
+    let parsed: ChatErrorBody | undefined;
+    try {
+      parsed = (await res.json()) as ChatErrorBody;
+    } catch {
+      /* ignore */
+    }
+    const code = parsed?.error?.code ?? `http_${res.status}`;
+    const message = parsed?.error?.message ?? `Request failed (${res.status})`;
+    throw new ChatError(message, code, parsed?.status);
+  }
+
+  if (!res.body) throw new ChatError("Empty response body", "no_body");
+
+  for await (const payload of readSSE(res.body)) {
+    let chunk: OpenAIDelta & { dappmanager?: DappmanagerEvent };
+    try {
+      chunk = JSON.parse(payload) as OpenAIDelta & { dappmanager?: DappmanagerEvent };
+    } catch {
+      continue;
+    }
+
+    // Out-of-band dappmanager events ride alongside OpenAI chunks.
+    if (chunk.dappmanager) {
+      const ev = chunk.dappmanager;
+      if (ev.type === "confirm_required" && typeof ev.id === "string" && typeof ev.tool === "string") {
+        yield { type: "confirm_required", id: ev.id, tool: ev.tool, args: ev.args };
+      } else if (ev.type === "confirm_resolved" && typeof ev.id === "string" && (ev.decision === "approve" || ev.decision === "deny")) {
+        yield { type: "confirm_resolved", id: ev.id, decision: ev.decision, reason: ev.reason };
+      }
+      continue;
+    }
+
+    if (chunk.error) throw new ChatError(chunk.error.message ?? "stream error", "stream_error");
+    const delta = chunk.choices?.[0]?.delta?.content;
+    if (delta) yield { type: "content", delta };
+  }
+}
+
+/* ------------------------------------------------------------------ *
+ * Smooth streaming — re-paces bursty network deltas into a steady,
+ * letter-level reveal. Drains proportionally so it catches up fast when
+ * far behind and eases to a single-character finish at the end.
+ * ------------------------------------------------------------------ */
+
+const FRAME_MS = 16;
+
+export async function* smoothStream(
+  source: AsyncGenerator<StreamEvent>,
+  signal?: AbortSignal
+): AsyncGenerator<StreamEvent> {
+  let pending = "";
+  let finished = false;
+  let failure: unknown = null;
+  const sidecar: StreamEvent[] = [];
+
+  const pump = (async () => {
+    try {
+      for await (const event of source) {
+        if (event.type === "content") pending += event.delta;
+        else sidecar.push(event);
+      }
+    } catch (err) {
+      failure = err;
+    } finally {
+      finished = true;
+    }
+  })();
+
+  const nextFrame = () => new Promise<void>((resolve) => setTimeout(resolve, FRAME_MS));
+
+  try {
+    while (!signal?.aborted) {
+      // Non-content events fire immediately — they're UI signals, not text.
+      while (sidecar.length > 0) yield sidecar.shift()!;
+
+      if (pending.length > 0) {
+        const take = Math.max(1, Math.ceil(pending.length / 10));
+        yield { type: "content", delta: pending.slice(0, take) };
+        pending = pending.slice(take);
+        await nextFrame();
+        continue;
+      }
+      if (finished) break;
+      await nextFrame();
+    }
+    while (sidecar.length > 0) yield sidecar.shift()!;
+  } finally {
+    await pump;
+  }
+
+  if (failure) throw failure;
+}

--- a/packages/admin-ui/src/pages-new/ai/nexus/chat/api.ts
+++ b/packages/admin-ui/src/pages-new/ai/nexus/chat/api.ts
@@ -16,9 +16,12 @@ export interface NexusStatus {
   configured: boolean;
   gatewayUrl: string;
   defaultModel: string;
+  /** Where the active key comes from: set in-app, from env, or unset. */
+  keySource: "db" | "env" | "none";
 }
 
 const STATUS_URL = "/nexus/status";
+const CONFIG_URL = "/nexus/config";
 const MODELS_URL = "/nexus/models";
 const CHAT_URL = "/nexus/chat/completions";
 const CONFIRM_URL = "/nexus/chat/confirm";
@@ -52,6 +55,23 @@ async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
 
 export function getNexusStatus(): Promise<NexusStatus> {
   return fetchJson<NexusStatus>(STATUS_URL);
+}
+
+/**
+ * Saves a Nexus API key on this DAppNode. The backend validates the key
+ * against the gateway before persisting, so a bad key rejects with an error.
+ */
+export function setNexusApiKey(apiKey: string): Promise<NexusStatus> {
+  return fetchJson<NexusStatus>(CONFIG_URL, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ apiKey })
+  });
+}
+
+/** Clears the in-app Nexus API key (falls back to the env var if set). */
+export function clearNexusApiKey(): Promise<NexusStatus> {
+  return fetchJson<NexusStatus>(CONFIG_URL, { method: "DELETE" });
 }
 
 export async function listNexusModels(): Promise<NexusModel[]> {

--- a/packages/dappmanager/package.json
+++ b/packages/dappmanager/package.json
@@ -40,6 +40,7 @@
     "@dappnode/types": "workspace:^0.1.0",
     "@dappnode/upnpc": "workspace:^0.1.0",
     "@dappnode/utils": "workspace:^0.1.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@types/async-retry": "^1.4.2",
     "@types/bcryptjs": "^2.4.2",
     "@types/compression": "^1.7.0",
@@ -76,7 +77,9 @@
     "prom-client": "^14.1.0",
     "semver": "^7.3.8",
     "socket.io": "^4.5.1",
-    "systeminformation": "^5.21.24"
+    "systeminformation": "^5.21.24",
+    "zod": "^3.25.0",
+    "zod-to-json-schema": "^3.25.1"
   },
   "devDependencies": {
     "@types/mocha": "^10",

--- a/packages/dappmanager/src/api/routes/nexus.ts
+++ b/packages/dappmanager/src/api/routes/nexus.ts
@@ -1,0 +1,799 @@
+import type { Request, Response as ExpressResponse } from "express";
+import * as db from "@dappnode/db";
+import { listPackages } from "@dappnode/dockerapi";
+import { logs } from "@dappnode/logger";
+import type { InstalledPackageData, PackageContainer } from "@dappnode/types";
+import { wrapHandler } from "../utils.js";
+import { dappnodeTools, dappnodeToolList } from "../../mcp/tools.js";
+import { dispatchTool, getOpenAITools } from "../../mcp/dispatch.js";
+import { createPendingConfirmation, resolveConfirmation } from "../../mcp/confirmation.js";
+import { startDocsWarmup } from "../../mcp/docs.js";
+
+/**
+ * Nexus chat proxy — talks to a Nexus gateway with a Nexus API key held
+ * server-side, so the secret never reaches the browser.
+ *
+ * The DAppNode admin configures a single Nexus API key via env
+ * (`NEXUS_API_KEY`). When Nexus gains an anonymous-signup endpoint, the
+ * env-key path is replaced with auto-provisioning.
+ */
+
+const DEFAULT_GATEWAY_URL = "https://nexus-api.dappnode.com/v1";
+const DEFAULT_MODEL = "openai/gpt-4o-mini";
+const LLMS_TXT_URL = "https://docs.dappnode.io/llms.txt";
+const LLMS_TXT_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const LLMS_TXT_MAX_BYTES = 60_000; // safety cap; all listed gateway models have ≥128K context
+const PACKAGE_LIST_TTL_MS = 60_000; // 60 seconds — listPackages() hits Docker
+
+function getGatewayUrl(): string {
+  const raw = process.env.NEXUS_GATEWAY_URL || DEFAULT_GATEWAY_URL;
+  return raw.replace(/\/+$/, "");
+}
+
+function getApiKey(): string {
+  return process.env.NEXUS_API_KEY || "";
+}
+
+function getDefaultModel(): string {
+  return process.env.NEXUS_DEFAULT_MODEL || DEFAULT_MODEL;
+}
+
+interface NexusStatus {
+  configured: boolean;
+  gatewayUrl: string;
+  defaultModel: string;
+}
+
+/* ──────────────────────────────────────────────────────────────────── *
+ * Dappnode context — injected as a system message on every chat call.
+ * ──────────────────────────────────────────────────────────────────── */
+
+let llmsCache: { fetchedAt: number; content: string } | null = null;
+let llmsInflight: Promise<string> | null = null;
+
+/**
+ * Strips Docusaurus's raw-markdown `.md` extension from any docs.dappnode.io
+ * URL inside an llms.txt body, so the catalogue the model sees uses the same
+ * URLs a human would visit. The raw `.md` form is purely an implementation
+ * detail for the docs-fetch tool.
+ */
+function stripMdFromDocsUrls(body: string): string {
+  return body.replace(
+    /(https:\/\/docs\.dappnode\.io\/[^\s)]+?)\.md(?=[\s)])/g,
+    "$1"
+  );
+}
+
+/** Fetches docs.dappnode.io/llms.txt with a 24h in-memory cache. */
+async function fetchLlmsContext(): Promise<string> {
+  const now = Date.now();
+  if (llmsCache && now - llmsCache.fetchedAt < LLMS_TXT_TTL_MS) {
+    return llmsCache.content;
+  }
+  if (llmsInflight) return llmsInflight;
+
+  llmsInflight = (async () => {
+    try {
+      const r = await fetch(LLMS_TXT_URL);
+      if (!r.ok) throw new Error(`status ${r.status}`);
+      const raw = await r.text();
+      const stripped = stripMdFromDocsUrls(raw);
+      const trimmed =
+        stripped.length > LLMS_TXT_MAX_BYTES
+          ? stripped.slice(0, LLMS_TXT_MAX_BYTES) + "\n\n…(truncated)…"
+          : stripped;
+      llmsCache = { fetchedAt: now, content: trimmed };
+      return trimmed;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "unknown";
+      logs.warn(`nexus: failed to fetch llms.txt: ${message}`);
+      // Keep a stale cache if we had one; otherwise return empty.
+      return llmsCache?.content ?? "";
+    } finally {
+      llmsInflight = null;
+    }
+  })();
+  return llmsInflight;
+}
+
+let packageListCache: { fetchedAt: number; content: string } | null = null;
+
+function summarizeContainerState(containers: PackageContainer[]): string {
+  if (!containers.length) return "no-containers";
+  const states = containers.map((c) => c.state).filter(Boolean);
+  if (states.length === 0) return "unknown";
+  if (states.every((s) => s === "running")) return "running";
+  // Show one entry per distinct state to keep it terse.
+  return Array.from(new Set(states)).join("/");
+}
+
+/** Builds a compact list of installed packages (60s in-memory cache). */
+async function describeInstalledPackages(): Promise<string> {
+  const now = Date.now();
+  if (packageListCache && now - packageListCache.fetchedAt < PACKAGE_LIST_TTL_MS) {
+    return packageListCache.content;
+  }
+
+  let pkgs: InstalledPackageData[];
+  try {
+    pkgs = await listPackages();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown";
+    logs.warn(`nexus: listPackages failed: ${message}`);
+    return "(unable to read the installed-package list right now)";
+  }
+
+  if (pkgs.length === 0) {
+    packageListCache = { fetchedAt: now, content: "(no packages installed)" };
+    return packageListCache.content;
+  }
+
+  // Non-core first, then alphabetical within each group.
+  const sorted = [...pkgs].sort((a, b) => {
+    if (a.isCore !== b.isCore) return a.isCore ? 1 : -1;
+    return a.dnpName.localeCompare(b.dnpName);
+  });
+
+  const lines = sorted.map((p) => {
+    const state = summarizeContainerState(p.containers || []);
+    const tags: string[] = [];
+    if (p.isCore) tags.push("core");
+    if (p.chain) tags.push(`chain:${p.chain}`);
+    const tagStr = tags.length ? ` [${tags.join(", ")}]` : "";
+    const version = p.version ? `v${p.version}` : "v?";
+    return `- ${p.dnpName} (${version}, ${state})${tagStr}`;
+  });
+
+  const content = lines.join("\n");
+  packageListCache = { fetchedAt: now, content };
+  return content;
+}
+
+/**
+ * Per-request page context — the admin UI passes the route the user is
+ * currently looking at when they hit Send. Used so vague references
+ * ("what is this", "explain this page") have an answer without an extra
+ * round-trip. Optional — chat works fine without it.
+ */
+interface DappmanagerPageContext {
+  path?: unknown;
+  search?: unknown;
+  hash?: unknown;
+  title?: unknown;
+}
+
+function describePageContext(raw: unknown): string | null {
+  if (!raw || typeof raw !== "object") return null;
+  const ctx = raw as DappmanagerPageContext;
+  const path = typeof ctx.path === "string" ? ctx.path : "";
+  if (!path) return null;
+  const search = typeof ctx.search === "string" ? ctx.search : "";
+  const hash = typeof ctx.hash === "string" ? ctx.hash : "";
+  const title = typeof ctx.title === "string" ? ctx.title.trim() : "";
+
+  const fullPath = path + search + hash;
+  const lines: string[] = [
+    "================ USER'S CURRENT PAGE (admin UI) ================",
+    `- Path: ${fullPath}`
+  ];
+  if (title) lines.push(`- Title: ${title}`);
+  lines.push(
+    "When the user asks vague things like \"what is this\" or \"how do I use this page\", assume they mean the page above. Otherwise treat it as ambient context — don't volunteer it unless relevant.",
+    "================ END USER'S CURRENT PAGE ================",
+    ""
+  );
+  return lines.join("\n");
+}
+
+/** Builds the full system prompt sent on every chat request. */
+async function buildSystemPrompt(pageContext?: unknown): Promise<string> {
+  // Kick off the docs cache warmup in the background — first chat of the
+  // session triggers it, subsequent calls await the same promise. By the
+  // time the model decides to call dappnode_search_docs, pages are cached.
+  startDocsWarmup();
+
+  const [docsIndex, packageList] = await Promise.all([
+    fetchLlmsContext(),
+    describeInstalledPackages()
+  ]);
+
+  const today = new Date().toISOString().slice(0, 10);
+  const parts: string[] = [
+    `You are an AI assistant embedded inside a user's Dappnode — a personal, sovereign node for Web3 infrastructure (staking, validators, dApps, AI inference).`,
+    `Today is ${today}.`,
+    "",
+    "## How to answer",
+    "",
+    "**The official docs at docs.dappnode.io are the source of truth.** For ANY question about DAppNode — concepts, packages, configuration, troubleshooting, staking, networking, VPN access, validators, Smooth, the DAO, hardware, installation — you MUST consult the docs via tools, NOT your training data. Training-data knowledge of DAppNode is often outdated or wrong; the docs are not.",
+    "",
+    "Workflow for any DAppNode-specific question:",
+    "1. Call `dappnode_search_docs(query)` with the user's keywords.",
+    "2. Read the returned snippets. If they answer the question, summarize them and cite the page URL.",
+    "3. If a snippet isn't enough, call `dappnode_fetch_doc(url)` to read the full page.",
+    "4. Only AFTER consulting the docs do you answer. If the docs don't cover it, say so explicitly.",
+    "",
+    "For questions about THIS Dappnode's runtime state (\"is X running\", \"what's eating my disk\"), use the runtime tools (`dappnode_list_packages`, `dappnode_get_package_logs`, `dappnode_diagnose`, etc.) instead of guessing from the package snapshot below.",
+    "",
+    "Be concise and direct. Use markdown (lists, headings, fenced code blocks) when it helps. When referring to a specific installed package, use its exact `dnpName`. When citing docs, link the URL.",
+    "",
+    "**Docs URL rule:** When you cite a docs.dappnode.io URL to the user, NEVER include a trailing `.md`. The `.md` form (e.g. `…/wireguard.md`) is the raw-markdown variant used internally by the docs-fetch tool — humans visit the same URL without `.md` (e.g. `…/wireguard`). If a doc page's content links to another page using a `.md` URL, drop the `.md` before showing it to the user.",
+    ""
+  ];
+
+  const pageBlock = describePageContext(pageContext);
+  if (pageBlock) parts.push(pageBlock);
+
+  if (docsIndex) {
+    parts.push("================ DAPPNODE DOCS — INDEX ONLY (from docs.dappnode.io/llms.txt) ================");
+    parts.push("This is the catalogue of available pages, NOT the docs themselves. To read a page's contents, call `dappnode_search_docs` or `dappnode_fetch_doc`.");
+    parts.push("");
+    parts.push(docsIndex);
+    parts.push("================ END DAPPNODE DOCS INDEX ================");
+    parts.push("");
+  }
+
+  parts.push("================ INSTALLED PACKAGES ON THIS DAPPNODE ================");
+  parts.push(packageList);
+  parts.push("================ END INSTALLED PACKAGES ================");
+  parts.push("");
+
+  // Surface the available MCP tools so the model knows what it can call.
+  const mutating = dappnodeToolList.filter((t) => t.mutating).map((t) => t.name);
+  if (mutating.length) {
+    parts.push(
+      `When invoking a MUTATING tool (${mutating.join(", ")}) you MUST first summarize the planned action in plain text and ask the user for explicit confirmation. NEVER invoke a mutating tool on the first turn without confirmation.`
+    );
+  }
+
+  return parts.join("\n");
+}
+
+function readStatus(): NexusStatus {
+  return {
+    configured: getApiKey() !== "",
+    gatewayUrl: getGatewayUrl(),
+    defaultModel: getDefaultModel()
+  };
+}
+
+/** GET /nexus/status — surfaces config for the UI. */
+export const nexusStatus = wrapHandler(async (_req: Request, res: ExpressResponse) => {
+  res.status(200).json(readStatus());
+});
+
+/* ──────────────────────────────────────────────────────────────────── *
+ * Chat history — server-side persistence in dbCache so conversations
+ * survive reloads. Capped at MAX_HISTORY entries (oldest pruned).
+ * ──────────────────────────────────────────────────────────────────── */
+
+const MAX_HISTORY_ENTRIES = 50;
+const MAX_TITLE_LENGTH = 80;
+
+function deriveTitle(messages: { role: string; content: string }[]): string {
+  const firstUser = messages.find((m) => m.role === "user");
+  const raw = firstUser?.content?.trim() ?? "";
+  if (!raw) return "New chat";
+  const oneLine = raw.replace(/\s+/g, " ");
+  return oneLine.length > MAX_TITLE_LENGTH ? oneLine.slice(0, MAX_TITLE_LENGTH) + "…" : oneLine;
+}
+
+interface HistorySummary {
+  id: string;
+  title: string;
+  messageCount: number;
+  createdAt: number;
+  updatedAt: number;
+}
+
+/** GET /nexus/chat/history — list of conversations sorted newest first. */
+export const nexusChatHistoryList = wrapHandler(async (_req: Request, res: ExpressResponse) => {
+  const all = db.nexusChatHistory.getAll();
+  const summaries: HistorySummary[] = Object.values(all)
+    .map((c) => ({
+      id: c.id,
+      title: c.title,
+      messageCount: c.messages.length,
+      createdAt: c.createdAt,
+      updatedAt: c.updatedAt
+    }))
+    .sort((a, b) => b.updatedAt - a.updatedAt);
+  res.status(200).json({ data: summaries });
+});
+
+/** GET /nexus/chat/history/:id — full conversation. */
+export const nexusChatHistoryGet = wrapHandler(async (req: Request, res: ExpressResponse) => {
+  const id = String(req.params.id || "");
+  if (!id) {
+    res.status(400).json({ error: { code: "invalid_request", message: "id required" } });
+    return;
+  }
+  const conv = db.nexusChatHistory.get(id);
+  if (!conv) {
+    res.status(404).json({ error: { code: "not_found", message: "conversation not found" } });
+    return;
+  }
+  res.status(200).json(conv);
+});
+
+/**
+ * PUT /nexus/chat/history/:id — upsert a conversation.
+ * Body: { messages: {role, content}[], title?: string }
+ */
+export const nexusChatHistoryUpsert = wrapHandler(async (req: Request, res: ExpressResponse) => {
+  const id = String(req.params.id || "");
+  if (!id) {
+    res.status(400).json({ error: { code: "invalid_request", message: "id required" } });
+    return;
+  }
+
+  const body = (req.body ?? {}) as { title?: unknown; messages?: unknown };
+  if (!Array.isArray(body.messages)) {
+    res.status(400).json({
+      error: { code: "invalid_request", message: "messages must be an array" }
+    });
+    return;
+  }
+
+  const messages = (body.messages as unknown[])
+    .map((raw) => {
+      if (!raw || typeof raw !== "object") return null;
+      const m = raw as { role?: unknown; content?: unknown };
+      if ((m.role !== "user" && m.role !== "assistant") || typeof m.content !== "string") return null;
+      return { role: m.role, content: m.content };
+    })
+    .filter((m): m is { role: "user" | "assistant"; content: string } => m !== null);
+
+  const existing = db.nexusChatHistory.get(id);
+  const now = Date.now();
+  const titleArg = typeof body.title === "string" ? body.title.trim() : "";
+  const title = titleArg || existing?.title || deriveTitle(messages);
+
+  const conv = {
+    id,
+    title,
+    messages,
+    createdAt: existing?.createdAt ?? now,
+    updatedAt: now
+  };
+
+  db.nexusChatHistory.set(id, conv);
+
+  // Prune oldest entries beyond MAX_HISTORY_ENTRIES.
+  const all = Object.values(db.nexusChatHistory.getAll());
+  if (all.length > MAX_HISTORY_ENTRIES) {
+    const toPrune = [...all]
+      .sort((a, b) => b.updatedAt - a.updatedAt)
+      .slice(MAX_HISTORY_ENTRIES);
+    for (const c of toPrune) db.nexusChatHistory.remove(c.id);
+  }
+
+  res.status(200).json(conv);
+});
+
+/** DELETE /nexus/chat/history/:id — remove a conversation. */
+export const nexusChatHistoryDelete = wrapHandler(async (req: Request, res: ExpressResponse) => {
+  const id = String(req.params.id || "");
+  if (!id) {
+    res.status(400).json({ error: { code: "invalid_request", message: "id required" } });
+    return;
+  }
+  db.nexusChatHistory.remove(id);
+  res.status(204).end();
+});
+
+/**
+ * POST /nexus/chat/confirm — UI callback that resolves a pending tool-call
+ * confirmation surfaced earlier on the same client's SSE stream.
+ * Body: { id: string, decision: "approve" | "deny", reason?: string }
+ */
+export const nexusChatConfirm = wrapHandler(async (req: Request, res: ExpressResponse) => {
+  const body = (req.body ?? {}) as { id?: unknown; decision?: unknown; reason?: unknown };
+  const id = typeof body.id === "string" ? body.id : "";
+  const decision = body.decision === "approve" || body.decision === "deny" ? body.decision : null;
+  if (!id || !decision) {
+    res.status(400).json({
+      error: { code: "invalid_request", message: "id and decision are required" }
+    });
+    return;
+  }
+  const reason = typeof body.reason === "string" ? body.reason : undefined;
+  const ok = resolveConfirmation(id, decision, reason);
+  res.status(ok ? 200 : 404).json({ ok });
+});
+
+/**
+ * GET /nexus/models — lists chat-capable models from the configured Nexus
+ * gateway. The dappmanager forwards the request with the stored API key
+ * and filters the response down to models that support /v1/chat/completions.
+ */
+export const nexusListModels = wrapHandler(async (_req: Request, res: ExpressResponse) => {
+  if (!getApiKey()) {
+    res.status(503).json({
+      error: { code: "nexus_not_configured", message: "NEXUS_API_KEY is not set on this DAppNode" }
+    });
+    return;
+  }
+
+  let upstream: Awaited<ReturnType<typeof fetch>>;
+  try {
+    upstream = await fetch(`${getGatewayUrl()}/models`, {
+      headers: {
+        accept: "application/json",
+        authorization: `Bearer ${getApiKey()}`
+      }
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Failed to reach Nexus gateway";
+    logs.warn(`nexus proxy: models fetch failed: ${message}`);
+    res.status(502).json({ error: { code: "upstream_unreachable", message } });
+    return;
+  }
+
+  if (!upstream.ok) {
+    const text = await upstream.text().catch(() => "");
+    logs.warn(`nexus proxy: models upstream ${upstream.status}: ${text.slice(0, 200)}`);
+    res
+      .status(upstream.status || 502)
+      .type(upstream.headers.get("content-type") || "application/json")
+      .send(text || JSON.stringify({ error: { code: "upstream_error", message: upstream.statusText } }));
+    return;
+  }
+
+  const payload = (await upstream.json()) as { data?: GatewayModel[] };
+  const all = Array.isArray(payload.data) ? payload.data : [];
+  // The gateway lists endpoints as `chat/completions` (relative) — older
+  // clients may have seen `/v1/chat/completions`. Match by suffix so either
+  // shape passes.
+  const chatModels = all.filter(
+    (m) => Array.isArray(m.endpoints) && m.endpoints.some((ep) => ep.endsWith("chat/completions"))
+  );
+
+  res.status(200).json({ data: chatModels });
+});
+
+interface GatewayModel {
+  id: string;
+  display_name?: string;
+  description?: string;
+  kind?: string;
+  endpoints?: string[];
+  features?: string[];
+  context_size?: number;
+  max_output_tokens?: number;
+  input_price_per_1m_tokens_cents?: number;
+  output_price_per_1m_tokens_cents?: number;
+}
+
+/**
+ * POST /nexus/chat/completions — OpenAI-compatible proxy. Streams the
+ * upstream SSE response straight back to the client; non-streaming
+ * responses are forwarded as JSON.
+ */
+export async function nexusChatCompletions(req: Request, res: ExpressResponse): Promise<void> {
+  const status = readStatus();
+
+  if (!status.configured) {
+    res.status(503).json({
+      error: { code: "nexus_not_configured", message: "NEXUS_API_KEY is not set on this DAppNode" },
+      status
+    });
+    return;
+  }
+
+  const body = (req.body ?? {}) as Record<string, unknown>;
+  if (!body.model || typeof body.model !== "string") {
+    body.model = status.defaultModel;
+  }
+
+  // Pull the dappmanager-only `dappmanager_page` field off the body so we
+  // don't forward an unknown key to the upstream gateway.
+  const pageContext = body.dappmanager_page;
+  delete body.dappmanager_page;
+
+  const requestedStream = body.stream === true;
+  // Default to streaming if the caller didn't say otherwise — it's the
+  // experience the UI is built around.
+  if (body.stream === undefined) {
+    body.stream = true;
+  }
+
+  // Inject the Dappnode system prompt at the head of the conversation so the
+  // model has docs + this node's installed-package list every turn. If the
+  // client already supplied a system message, keep it after ours.
+  try {
+    const systemPrompt = await buildSystemPrompt(pageContext);
+    const incoming = Array.isArray(body.messages) ? (body.messages as unknown[]) : [];
+    body.messages = [{ role: "system", content: systemPrompt }, ...incoming];
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown";
+    logs.warn(`nexus: failed to build system prompt: ${message}`);
+    // Fall through with the user's messages untouched — the chat still works.
+  }
+
+  // Attach the dappnode MCP tools so the model can drive the node. Honour
+  // any explicit `tool_choice: "none"` from the caller.
+  if (body.tool_choice !== "none" && !Array.isArray(body.tools)) {
+    body.tools = getOpenAITools();
+  }
+
+  // Forward an abort signal so the upstream call is cancelled when the
+  // browser disconnects mid-stream.
+  const ac = new AbortController();
+  const onClose = () => ac.abort();
+  req.on("close", onClose);
+
+  try {
+    if (!requestedStream && body.stream === false) {
+      // Non-streaming path: single shot, no tool loop.
+      const upstream = await fetch(`${status.gatewayUrl}/chat/completions`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "application/json",
+          authorization: `Bearer ${getApiKey()}`
+        },
+        body: JSON.stringify(body),
+        signal: ac.signal
+      });
+      const text = await upstream.text();
+      res
+        .status(upstream.status)
+        .type(upstream.headers.get("content-type") || "application/json")
+        .send(text);
+      return;
+    }
+
+    await runChatToolLoop(res, body, ac.signal);
+  } catch (err) {
+    if (!ac.signal.aborted && !res.writableEnded) {
+      const message = err instanceof Error ? err.message : "stream error";
+      logs.warn(`nexus proxy: ${message}`);
+      try {
+        res.write(`data: ${JSON.stringify({ error: { code: "stream_error", message } })}\n\n`);
+        res.write("data: [DONE]\n\n");
+      } catch {
+        /* swallow */
+      }
+    }
+  } finally {
+    req.off("close", onClose);
+    if (!res.writableEnded) res.end();
+  }
+}
+
+/* ──────────────────────────────────────────────────────────────────── *
+ * Tool-call loop — multi-step ReAct.
+ *
+ * Forwards the model's content deltas to the client as they arrive. When the
+ * upstream stream ends with `finish_reason: "tool_calls"`, dispatch each
+ * tool locally, append the result as a tool message, surface the activity
+ * as italicised content in the client stream, and re-invoke the gateway.
+ * Hard-capped at MAX_ITERATIONS to prevent runaway loops.
+ * ──────────────────────────────────────────────────────────────────── */
+
+const MAX_TOOL_ITERATIONS = 8;
+const MAX_TOOL_RESULT_BYTES = 50_000;
+
+interface AccumulatedToolCall {
+  id: string;
+  type: string;
+  function: { name: string; arguments: string };
+}
+
+interface GatewayStreamChunk {
+  model?: string;
+  choices?: {
+    delta?: {
+      content?: string;
+      tool_calls?: {
+        index?: number;
+        id?: string;
+        type?: string;
+        function?: { name?: string; arguments?: string };
+      }[];
+    };
+    finish_reason?: string | null;
+  }[];
+}
+
+async function runChatToolLoop(
+  res: ExpressResponse,
+  body: Record<string, unknown>,
+  signal: AbortSignal
+): Promise<void> {
+  res.status(200);
+  res.setHeader("content-type", "text/event-stream");
+  res.setHeader("cache-control", "no-cache, no-transform");
+  res.setHeader("x-accel-buffering", "no");
+  res.flushHeaders();
+
+  const messages: unknown[] = Array.isArray(body.messages) ? [...(body.messages as unknown[])] : [];
+  let responseModelId: string | null = null;
+
+  for (let iter = 0; iter < MAX_TOOL_ITERATIONS; iter++) {
+    if (signal.aborted) break;
+
+    const iterationBody = { ...body, messages, stream: true };
+    const upstream = await fetch(`${getGatewayUrl()}/chat/completions`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "text/event-stream",
+        authorization: `Bearer ${getApiKey()}`
+      },
+      body: JSON.stringify(iterationBody),
+      signal
+    });
+
+    if (!upstream.ok || !upstream.body) {
+      const text = await upstream.text().catch(() => "");
+      logs.warn(`nexus proxy: upstream ${upstream.status}: ${text.slice(0, 200)}`);
+      writeSyntheticContent(res, `\n\n_(upstream error ${upstream.status})_\n\n`, responseModelId);
+      break;
+    }
+
+    let assistantContent = "";
+    const toolCalls: AccumulatedToolCall[] = [];
+    let finishReason: string | null = null;
+
+    for await (const payload of readSSEPayloads(upstream.body)) {
+      let chunk: GatewayStreamChunk;
+      try {
+        chunk = JSON.parse(payload) as GatewayStreamChunk;
+      } catch {
+        continue;
+      }
+      if (chunk.model && !responseModelId) responseModelId = chunk.model;
+
+      const choice = chunk.choices?.[0];
+      if (!choice) continue;
+      const delta = choice.delta || {};
+
+      if (typeof delta.content === "string" && delta.content.length > 0) {
+        assistantContent += delta.content;
+        if (!res.writableEnded) res.write(`data: ${JSON.stringify(chunk)}\n\n`);
+      }
+
+      if (Array.isArray(delta.tool_calls)) {
+        for (const tc of delta.tool_calls) {
+          const idx = tc.index ?? 0;
+          if (!toolCalls[idx]) {
+            toolCalls[idx] = { id: "", type: "function", function: { name: "", arguments: "" } };
+          }
+          if (tc.id) toolCalls[idx].id = tc.id;
+          if (tc.type) toolCalls[idx].type = tc.type;
+          if (tc.function?.name) toolCalls[idx].function.name += tc.function.name;
+          if (tc.function?.arguments) toolCalls[idx].function.arguments += tc.function.arguments;
+        }
+      }
+
+      if (choice.finish_reason) finishReason = choice.finish_reason;
+    }
+
+    if (signal.aborted) break;
+
+    if (finishReason === "tool_calls" && toolCalls.length > 0) {
+      // Append the assistant turn (with the tool_calls).
+      messages.push({
+        role: "assistant",
+        content: assistantContent || null,
+        tool_calls: toolCalls
+      });
+
+      for (const tc of toolCalls) {
+        const toolName = tc.function.name || "(unnamed)";
+        let args: unknown = {};
+        try {
+          args = JSON.parse(tc.function.arguments || "{}");
+        } catch {
+          /* fall through with {} */
+        }
+
+        const toolDef = dappnodeTools[toolName];
+
+        // Mutating tools must pass through the confirmation flow before dispatch.
+        if (toolDef?.mutating) {
+          const { id, promise } = createPendingConfirmation(toolName, args, signal);
+          writeDappmanagerEvent(res, {
+            type: "confirm_required",
+            id,
+            tool: toolName,
+            args
+          });
+          const { decision, reason } = await promise;
+          writeDappmanagerEvent(res, {
+            type: "confirm_resolved",
+            id,
+            decision,
+            reason
+          });
+          if (decision === "deny") {
+            const reasonText = reason ? ` — ${reason}` : "";
+            writeSyntheticContent(
+              res,
+              `\n\n_skipped **${toolName}**${reasonText}_\n\n`,
+              responseModelId
+            );
+            messages.push({
+              role: "tool",
+              tool_call_id: tc.id,
+              content: JSON.stringify({ error: "user_denied", reason: reason ?? null })
+            });
+            continue;
+          }
+        }
+
+        writeSyntheticContent(res, `\n\n_using **${toolName}**…_\n\n`, responseModelId);
+
+        const result = await dispatchTool(toolName, args);
+        const payload = JSON.stringify(result.ok ? result.output : { error: result.error });
+        const content =
+          payload.length > MAX_TOOL_RESULT_BYTES
+            ? payload.slice(0, MAX_TOOL_RESULT_BYTES) + "…(truncated)"
+            : payload;
+
+        messages.push({
+          role: "tool",
+          tool_call_id: tc.id,
+          content
+        });
+      }
+
+      // Loop to next iteration.
+      continue;
+    }
+
+    // Terminal finish — flush [DONE] and exit.
+    if (!res.writableEnded) res.write("data: [DONE]\n\n");
+    return;
+  }
+
+  // Safety limit / aborted.
+  if (!res.writableEnded) res.write("data: [DONE]\n\n");
+}
+
+async function* readSSEPayloads(stream: ReadableStream<Uint8Array>): AsyncGenerator<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true }).replace(/\r\n/g, "\n");
+      let sep: number;
+      while ((sep = buffer.indexOf("\n\n")) !== -1) {
+        const event = buffer.slice(0, sep);
+        buffer = buffer.slice(sep + 2);
+        for (const line of event.split("\n")) {
+          if (!line.startsWith("data:")) continue;
+          const payload = line.slice(5).trim();
+          if (payload && payload !== "[DONE]") yield payload;
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function writeSyntheticContent(res: ExpressResponse, text: string, modelId: string | null): void {
+  if (res.writableEnded) return;
+  const chunk = {
+    id: "dappmanager",
+    object: "chat.completion.chunk",
+    created: Math.floor(Date.now() / 1000),
+    model: modelId,
+    choices: [{ index: 0, delta: { content: text }, finish_reason: null }]
+  };
+  res.write(`data: ${JSON.stringify(chunk)}\n\n`);
+}
+
+/**
+ * Out-of-band signal to the browser — not an OpenAI chunk. Distinguished
+ * client-side by the top-level `dappmanager` key.
+ */
+function writeDappmanagerEvent(res: ExpressResponse, payload: unknown): void {
+  if (res.writableEnded) return;
+  res.write(`data: ${JSON.stringify({ dappmanager: payload })}\n\n`);
+}

--- a/packages/dappmanager/src/api/routes/nexus.ts
+++ b/packages/dappmanager/src/api/routes/nexus.ts
@@ -30,8 +30,20 @@ function getGatewayUrl(): string {
   return raw.replace(/\/+$/, "");
 }
 
+/**
+ * The effective Nexus API key. A key set from the admin UI (persisted in
+ * dbMain) takes precedence over the `NEXUS_API_KEY` env var, so the user can
+ * configure it in-app without restarting the container.
+ */
 function getApiKey(): string {
-  return process.env.NEXUS_API_KEY || "";
+  return db.nexusApiKey.get() || process.env.NEXUS_API_KEY || "";
+}
+
+/** Where the effective key comes from — surfaced to the UI. */
+function getApiKeySource(): "db" | "env" | "none" {
+  if (db.nexusApiKey.get()) return "db";
+  if (process.env.NEXUS_API_KEY) return "env";
+  return "none";
 }
 
 function getDefaultModel(): string {
@@ -42,6 +54,8 @@ interface NexusStatus {
   configured: boolean;
   gatewayUrl: string;
   defaultModel: string;
+  /** Where the active key comes from: set in-app, from env, or unset. */
+  keySource: "db" | "env" | "none";
 }
 
 /* ──────────────────────────────────────────────────────────────────── *
@@ -217,6 +231,16 @@ async function buildSystemPrompt(pageContext?: unknown): Promise<string> {
     "Be concise and direct. Use markdown (lists, headings, fenced code blocks) when it helps. When referring to a specific installed package, use its exact `dnpName`. When citing docs, link the URL.",
     "",
     "**Docs URL rule:** When you cite a docs.dappnode.io URL to the user, NEVER include a trailing `.md`. The `.md` form (e.g. `…/wireguard.md`) is the raw-markdown variant used internally by the docs-fetch tool — humans visit the same URL without `.md` (e.g. `…/wireguard`). If a doc page's content links to another page using a `.md` URL, drop the `.md` before showing it to the user.",
+    "",
+    "**Local URL rule:** When giving the user a link to this DAppNode's UI or a package, use the `my.dappnode` host (e.g. `http://my.dappnode/...`). NEVER use `dappnode.local` — it is deprecated. If docs or other context show a `dappnode.local` URL, rewrite the host to `my.dappnode` before showing it.",
+    "",
+    "## Staking facts you MUST NOT get wrong",
+    "",
+    "On DAppNode, a staking setup with a **Web3Signer** package (e.g. `web3signer-<network>.dnp.dappnode.eth`) manages validator keys AND per-validator settings through its `brain` service. In that setup:",
+    "- **The fee recipient (rewards address) is configured in Web3Signer / the Staker UI, NOT in the consensus/validator client.** Web3Signer serves the fee recipient and validator registrations to the beacon node per-validator.",
+    "- The validator/consensus client's `FEE_RECIPIENT_ADDRESS` env var (often `0x0000000000000000000000000000000000000000`) is only a **fallback** that is overridden by Web3Signer. A `0x0` value there is **NORMAL and does NOT mean the setup is misconfigured** — do NOT report it as a problem or tell the user their rewards are being burned. The real, effective fee recipient is whatever Web3Signer holds (this is what shows up on-chain / on beaconcha.in).",
+    "- To read or change the fee recipient, point the user to Web3Signer's config / the Staker config page — not the consensus client's env vars.",
+    "- Likewise, MEV-Boost relay registration is handled through Web3Signer/Staker config. If beaconcha.in shows a correct fee recipient, the setup is working regardless of the client's fallback env value.",
     ""
   ];
 
@@ -252,12 +276,68 @@ function readStatus(): NexusStatus {
   return {
     configured: getApiKey() !== "",
     gatewayUrl: getGatewayUrl(),
-    defaultModel: getDefaultModel()
+    defaultModel: getDefaultModel(),
+    keySource: getApiKeySource()
   };
 }
 
 /** GET /nexus/status — surfaces config for the UI. */
 export const nexusStatus = wrapHandler(async (_req: Request, res: ExpressResponse) => {
+  res.status(200).json(readStatus());
+});
+
+/**
+ * Probes the Nexus gateway with a candidate key by listing models. Returns
+ * `null` on success, or a human-readable error string otherwise — so we never
+ * persist a key that can't actually talk to the gateway.
+ */
+async function validateApiKey(apiKey: string): Promise<string | null> {
+  let upstream: Awaited<ReturnType<typeof fetch>>;
+  try {
+    upstream = await fetch(`${getGatewayUrl()}/models`, {
+      headers: { accept: "application/json", authorization: `Bearer ${apiKey}` }
+    });
+  } catch (err) {
+    return err instanceof Error ? err.message : "Failed to reach the Nexus gateway";
+  }
+  if (upstream.status === 401 || upstream.status === 403) {
+    return "The Nexus gateway rejected this API key";
+  }
+  if (!upstream.ok) {
+    return `Nexus gateway error (${upstream.status})`;
+  }
+  return null;
+}
+
+/**
+ * POST /nexus/config — set the Nexus API key from the admin UI.
+ * Body: { apiKey: string }. The key is validated against the gateway before
+ * being persisted, so a bad key is rejected with 400 rather than stored.
+ */
+export const nexusSetApiKey = wrapHandler(async (req: Request, res: ExpressResponse) => {
+  const body = (req.body ?? {}) as { apiKey?: unknown };
+  const apiKey = typeof body.apiKey === "string" ? body.apiKey.trim() : "";
+  if (!apiKey) {
+    res.status(400).json({ error: { code: "invalid_request", message: "apiKey is required" } });
+    return;
+  }
+
+  const error = await validateApiKey(apiKey);
+  if (error) {
+    res.status(400).json({ error: { code: "invalid_api_key", message: error } });
+    return;
+  }
+
+  db.nexusApiKey.set(apiKey);
+  res.status(200).json(readStatus());
+});
+
+/**
+ * DELETE /nexus/config — clear the in-app Nexus API key. Falls back to the
+ * `NEXUS_API_KEY` env var afterwards if one is set.
+ */
+export const nexusClearApiKey = wrapHandler(async (_req: Request, res: ExpressResponse) => {
+  db.nexusApiKey.set("");
   res.status(200).json(readStatus());
 });
 

--- a/packages/dappmanager/src/api/routes/nexus.ts
+++ b/packages/dappmanager/src/api/routes/nexus.ts
@@ -690,6 +690,7 @@ async function runChatToolLoop(
         }
 
         const toolDef = dappnodeTools[toolName];
+        const displayName = toolDef?.displayName ?? toolName;
 
         // Mutating tools must pass through the confirmation flow before dispatch.
         if (toolDef?.mutating) {
@@ -698,6 +699,7 @@ async function runChatToolLoop(
             type: "confirm_required",
             id,
             tool: toolName,
+            displayName,
             args
           });
           const { decision, reason } = await promise;
@@ -711,7 +713,7 @@ async function runChatToolLoop(
             const reasonText = reason ? ` — ${reason}` : "";
             writeSyntheticContent(
               res,
-              `\n\n_skipped **${toolName}**${reasonText}_\n\n`,
+              `\n\n_Skipped **${displayName}**${reasonText}_\n\n`,
               responseModelId
             );
             messages.push({
@@ -723,7 +725,7 @@ async function runChatToolLoop(
           }
         }
 
-        writeSyntheticContent(res, `\n\n_using **${toolName}**…_\n\n`, responseModelId);
+        writeSyntheticContent(res, `\n\n_Running **${displayName}**…_\n\n`, responseModelId);
 
         const result = await dispatchTool(toolName, args);
         const payload = JSON.stringify(result.ok ? result.output : { error: result.error });

--- a/packages/dappmanager/src/api/startHttpApi.ts
+++ b/packages/dappmanager/src/api/startHttpApi.ts
@@ -17,6 +17,17 @@ import { EventBus } from "@dappnode/eventbus";
 import { subscriptionsFactory } from "@dappnode/common";
 import { RpcPayload, RpcResponse, LoggerMiddleware, Routes } from "@dappnode/types";
 import { getRpcHandler } from "./handler/index.js";
+import {
+  nexusChatCompletions,
+  nexusChatConfirm,
+  nexusChatHistoryDelete,
+  nexusChatHistoryGet,
+  nexusChatHistoryList,
+  nexusChatHistoryUpsert,
+  nexusListModels,
+  nexusStatus
+} from "./routes/nexus.js";
+import { handleMcpRequest } from "../mcp/server.js";
 import { params as dappnodeParams } from "@dappnode/params";
 
 export interface HttpApiParams extends ClientSideCookiesParams, AuthPasswordSessionParams {
@@ -159,6 +170,23 @@ export function startHttpApi({
   app.get("/download/:fileId", auth.onlyAdmin, routes.download);
   app.get("/user-action-logs", auth.onlyAdmin, routes.downloadUserActionLogs);
   app.post("/upload", auth.onlyAdmin, routes.upload);
+
+  // Nexus chat proxy (env-configured Nexus API key held server-side).
+  app.get("/nexus/status", auth.onlyAdmin, nexusStatus);
+  app.get("/nexus/models", auth.onlyAdmin, nexusListModels);
+  app.post("/nexus/chat/completions", auth.onlyAdmin, nexusChatCompletions);
+  app.post("/nexus/chat/confirm", auth.onlyAdmin, nexusChatConfirm);
+  app.get("/nexus/chat/history", auth.onlyAdmin, nexusChatHistoryList);
+  app.get("/nexus/chat/history/:id", auth.onlyAdmin, nexusChatHistoryGet);
+  app.put("/nexus/chat/history/:id", auth.onlyAdmin, nexusChatHistoryUpsert);
+  app.delete("/nexus/chat/history/:id", auth.onlyAdmin, nexusChatHistoryDelete);
+
+  // MCP server for this DAppNode — same tools the embedded chat uses, also
+  // reachable by external MCP clients (Claude Desktop, Cursor, etc.) once
+  // they authenticate as admin.
+  app.post("/mcp", auth.onlyAdmin, wrapHandler(handleMcpRequest));
+  app.get("/mcp", auth.onlyAdmin, wrapHandler(handleMcpRequest));
+  app.delete("/mcp", auth.onlyAdmin, wrapHandler(handleMcpRequest));
 
   // Open endpoints (no auth)
   app.get("/global-envs/:name?", routes.globalEnvs);

--- a/packages/dappmanager/src/api/startHttpApi.ts
+++ b/packages/dappmanager/src/api/startHttpApi.ts
@@ -24,7 +24,9 @@ import {
   nexusChatHistoryGet,
   nexusChatHistoryList,
   nexusChatHistoryUpsert,
+  nexusClearApiKey,
   nexusListModels,
+  nexusSetApiKey,
   nexusStatus
 } from "./routes/nexus.js";
 import { handleMcpRequest } from "../mcp/server.js";
@@ -173,6 +175,8 @@ export function startHttpApi({
 
   // Nexus chat proxy (env-configured Nexus API key held server-side).
   app.get("/nexus/status", auth.onlyAdmin, nexusStatus);
+  app.post("/nexus/config", auth.onlyAdmin, nexusSetApiKey);
+  app.delete("/nexus/config", auth.onlyAdmin, nexusClearApiKey);
   app.get("/nexus/models", auth.onlyAdmin, nexusListModels);
   app.post("/nexus/chat/completions", auth.onlyAdmin, nexusChatCompletions);
   app.post("/nexus/chat/confirm", auth.onlyAdmin, nexusChatConfirm);

--- a/packages/dappmanager/src/mcp/confirmation.ts
+++ b/packages/dappmanager/src/mcp/confirmation.ts
@@ -1,0 +1,104 @@
+import { randomUUID } from "crypto";
+import { logs } from "@dappnode/logger";
+
+/**
+ * Cross-request store of in-flight tool-call confirmations. When the chat
+ * proxy is about to dispatch a mutating tool it creates a pending entry,
+ * surfaces the prompt to the browser over the open SSE stream, and awaits
+ * the user's decision (delivered out-of-band via `POST /nexus/chat/confirm`).
+ */
+
+export type ConfirmationDecision = "approve" | "deny";
+
+export interface ConfirmationResult {
+  decision: ConfirmationDecision;
+  reason?: string;
+}
+
+interface PendingEntry {
+  id: string;
+  tool: string;
+  args: unknown;
+  createdAt: number;
+  resolve: (result: ConfirmationResult) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+const pending = new Map<string, PendingEntry>();
+
+/** How long to wait before auto-denying a confirmation (no user response). */
+const CONFIRMATION_TIMEOUT_MS = 5 * 60 * 1000;
+
+export interface CreatedConfirmation {
+  id: string;
+  promise: Promise<ConfirmationResult>;
+}
+
+/**
+ * Create a pending confirmation. The caller is responsible for surfacing the
+ * `id` (along with tool name + args) to the user, then awaiting `promise`.
+ *
+ * If `signal` is provided, an abort on it immediately resolves the promise
+ * with `decision: "deny"` and tears the entry down — so a closed SSE
+ * connection cleans up cleanly.
+ */
+export function createPendingConfirmation(
+  tool: string,
+  args: unknown,
+  signal?: AbortSignal
+): CreatedConfirmation {
+  const id = randomUUID();
+
+  if (signal?.aborted) {
+    return { id, promise: Promise.resolve({ decision: "deny", reason: "aborted" }) };
+  }
+
+  let resolveOuter: (result: ConfirmationResult) => void;
+  const promise = new Promise<ConfirmationResult>((resolve) => {
+    resolveOuter = resolve;
+  });
+
+  const timer = setTimeout(() => {
+    const entry = pending.get(id);
+    if (!entry) return;
+    pending.delete(id);
+    logs.warn(`MCP confirmation ${id} (${tool}) timed out — auto-denying`);
+    entry.resolve({ decision: "deny", reason: "timeout" });
+  }, CONFIRMATION_TIMEOUT_MS);
+
+  const entry: PendingEntry = {
+    id,
+    tool,
+    args,
+    createdAt: Date.now(),
+    resolve: (result) => {
+      clearTimeout(timer);
+      pending.delete(id);
+      resolveOuter(result);
+    },
+    timer
+  };
+  pending.set(id, entry);
+
+  if (signal) {
+    const onAbort = () => entry.resolve({ decision: "deny", reason: "aborted" });
+    signal.addEventListener("abort", onAbort, { once: true });
+  }
+
+  return { id, promise };
+}
+
+/**
+ * Resolve a confirmation from the UI's POST callback. Returns false if the
+ * id is unknown (already resolved or never existed).
+ */
+export function resolveConfirmation(
+  id: string,
+  decision: ConfirmationDecision,
+  reason?: string
+): boolean {
+  const entry = pending.get(id);
+  if (!entry) return false;
+  entry.resolve({ decision, reason });
+  return true;
+}

--- a/packages/dappmanager/src/mcp/dispatch.ts
+++ b/packages/dappmanager/src/mcp/dispatch.ts
@@ -1,0 +1,81 @@
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+import { logs } from "@dappnode/logger";
+import { dappnodeTools, dappnodeToolList, type DappnodeTool } from "./tools.js";
+
+/**
+ * In-process tool dispatcher used by the chat proxy. The MCP server (see
+ * ./server.ts) exposes the same registry over HTTP for external clients;
+ * this module skips the protocol overhead for the embedded chat.
+ */
+
+export interface OpenAITool {
+  type: "function";
+  function: {
+    name: string;
+    description: string;
+    parameters: Record<string, unknown>;
+  };
+}
+
+/** Converts a tool's Zod schema to the OpenAI function-calling format. */
+export function toOpenAIFormat(tool: DappnodeTool): OpenAITool {
+  const objectSchema = z.object(tool.schema);
+  const jsonSchema = zodToJsonSchema(objectSchema, {
+    $refStrategy: "none",
+    target: "openApi3"
+  }) as Record<string, unknown>;
+  // OpenAI tolerates plain JSON Schema; strip any top-level $schema.
+  delete jsonSchema.$schema;
+  return {
+    type: "function",
+    function: {
+      name: tool.name,
+      description: tool.description,
+      parameters: jsonSchema
+    }
+  };
+}
+
+/** Full tool catalogue in OpenAI format, ready to drop into `tools: [...]`. */
+export function getOpenAITools(): OpenAITool[] {
+  return dappnodeToolList.map(toOpenAIFormat);
+}
+
+export interface ToolDispatchResult {
+  ok: boolean;
+  output?: unknown;
+  error?: string;
+  mutating?: boolean;
+}
+
+/** Looks up the tool by name, validates its args, and runs `execute()`. */
+export async function dispatchTool(
+  name: string,
+  rawArgs: unknown
+): Promise<ToolDispatchResult> {
+  const tool = dappnodeTools[name];
+  if (!tool) return { ok: false, error: `Unknown tool: ${name}` };
+
+  const args = rawArgs && typeof rawArgs === "object" ? rawArgs : {};
+
+  // Validate args against the tool's Zod schema (best-effort — let the
+  // model see validation errors so it can retry).
+  const validation = z.object(tool.schema).safeParse(args);
+  if (!validation.success) {
+    return {
+      ok: false,
+      error: `Invalid arguments for ${name}: ${validation.error.message}`,
+      mutating: tool.mutating
+    };
+  }
+
+  try {
+    const output = await tool.execute(validation.data);
+    return { ok: true, output, mutating: tool.mutating };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logs.warn(`Tool dispatch ${name} failed: ${message}`);
+    return { ok: false, error: message, mutating: tool.mutating };
+  }
+}

--- a/packages/dappmanager/src/mcp/docs.ts
+++ b/packages/dappmanager/src/mcp/docs.ts
@@ -1,0 +1,316 @@
+import { logs } from "@dappnode/logger";
+
+/**
+ * In-process cache of the official DAppNode docs (docs.dappnode.io).
+ *
+ * Architecture: `llms.txt` is treated as the **index** — every `(url)` link
+ * pointing at docs.dappnode.io becomes an entry. The first time a search or
+ * fetch is requested we parallel-fetch every page (throttled), cache it in
+ * memory for 24h, then serve all subsequent calls from RAM.
+ *
+ * Why bother: the chat proxy exposes two tools (`dappnode_search_docs` and
+ * `dappnode_fetch_doc`) so the model can read the *actual* doc prose at
+ * call-time instead of relying on its training data — which may not know
+ * about Dappnode-specific conventions or the latest packages.
+ *
+ * Memory budget: ~130 pages × ~5KB each ≈ 700KB. Negligible for dappmanager.
+ */
+
+const LLMS_TXT_URL = "https://docs.dappnode.io/llms.txt";
+const INDEX_TTL_MS = 24 * 60 * 60 * 1000;
+const PAGE_TTL_MS = 24 * 60 * 60 * 1000;
+const PAGE_FETCH_TIMEOUT_MS = 8_000;
+const INDEX_FETCH_TIMEOUT_MS = 10_000;
+const CONCURRENT_FETCHES = 6;
+const MAX_PAGE_BYTES = 60_000; // each
+const MAX_SNIPPET_BYTES = 600;
+const DOCS_ORIGIN = "https://docs.dappnode.io/";
+
+interface DocEntry {
+  url: string;
+  title: string;
+  description: string;
+  /** Raw markdown of the page once fetched; undefined while uncached. */
+  content?: string;
+  /** Epoch ms of the last fetch attempt — set even on failure to avoid hammering. */
+  fetchedAt?: number;
+}
+
+const docsIndex: Map<string, DocEntry> = new Map();
+let indexFetchedAt = 0;
+let indexInflight: Promise<void> | null = null;
+let warmupPromise: Promise<void> | null = null;
+
+/**
+ * Strips Docusaurus's raw-markdown `.md` extension (and any trailing slash)
+ * so what we hand back to the model matches what the user sees in their
+ * browser. The `.md` is an implementation detail of the docs.dappnode.io
+ * routing — humans never type it.
+ *
+ *   https://docs.dappnode.io/docs/dao.md     → https://docs.dappnode.io/docs/dao
+ *   https://docs.dappnode.io/docs/dao.md/    → https://docs.dappnode.io/docs/dao
+ *   https://docs.dappnode.io/docs/dao        → https://docs.dappnode.io/docs/dao  (idempotent)
+ */
+export function canonicalDocUrl(url: string): string {
+  return url.replace(/\.md\/?$/i, "").replace(/\/+$/, "");
+}
+
+/** Inverse: appends `.md` so we hit the raw-markdown variant when fetching. */
+function rawMarkdownUrl(canonical: string): string {
+  return canonical.endsWith(".md") ? canonical : canonical + ".md";
+}
+
+async function fetchWithTimeout(url: string, timeoutMs: number): Promise<Response> {
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), timeoutMs);
+  try {
+    return await fetch(url, { signal: ac.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Parses an llms.txt body, looking for `- [title](url): description` lines
+ * where the URL is under docs.dappnode.io. Preserves any previously cached
+ * page content under matching URLs.
+ */
+function parseIndex(text: string): void {
+  // `- [title](url)` optionally followed by `: description` to end of line.
+  const re = /-\s*\[([^\]]+)\]\((https:\/\/docs\.dappnode\.io\/[^)]+)\)(?::\s*(.+))?$/gm;
+  const seen = new Set<string>();
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(text)) !== null) {
+    // Strip `.md` so the canonical key matches the user-facing URL. We add
+    // `.md` back internally when fetching the raw markdown.
+    const url = canonicalDocUrl(match[2]);
+    const title = match[1].trim();
+    const description = (match[3] || "").trim();
+    seen.add(url);
+    const existing = docsIndex.get(url);
+    if (existing) {
+      existing.title = title;
+      existing.description = description;
+    } else {
+      docsIndex.set(url, { url, title, description });
+    }
+  }
+  // Drop entries that disappeared from llms.txt (keep their cache if they
+  // reappear soon — but for now, prune to avoid stale results).
+  for (const url of [...docsIndex.keys()]) {
+    if (!seen.has(url)) docsIndex.delete(url);
+  }
+}
+
+async function refreshIndex(): Promise<void> {
+  if (indexInflight) return indexInflight;
+  indexInflight = (async () => {
+    try {
+      const r = await fetchWithTimeout(LLMS_TXT_URL, INDEX_FETCH_TIMEOUT_MS);
+      if (!r.ok) throw new Error(`status ${r.status}`);
+      const text = await r.text();
+      parseIndex(text);
+      indexFetchedAt = Date.now();
+      logs.info(`nexus docs: index refreshed (${docsIndex.size} entries)`);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logs.warn(`nexus docs: index refresh failed: ${message}`);
+      // Keep stale index in place — better than nothing.
+    } finally {
+      indexInflight = null;
+    }
+  })();
+  return indexInflight;
+}
+
+async function ensureIndex(): Promise<void> {
+  if (docsIndex.size === 0 || Date.now() - indexFetchedAt >= INDEX_TTL_MS) {
+    await refreshIndex();
+  }
+}
+
+async function ensurePage(entry: DocEntry): Promise<void> {
+  const now = Date.now();
+  if (entry.content !== undefined && entry.fetchedAt && now - entry.fetchedAt < PAGE_TTL_MS) {
+    return;
+  }
+  const fetchUrl = rawMarkdownUrl(entry.url);
+  try {
+    const r = await fetchWithTimeout(fetchUrl, PAGE_FETCH_TIMEOUT_MS);
+    if (!r.ok) throw new Error(`status ${r.status}`);
+    let body = await r.text();
+    if (body.length > MAX_PAGE_BYTES) body = body.slice(0, MAX_PAGE_BYTES) + "\n…(truncated)";
+    entry.content = body;
+    entry.fetchedAt = now;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logs.warn(`nexus docs: failed to fetch ${fetchUrl}: ${message}`);
+    // Mark attempted with empty body so we don't retry until the TTL expires.
+    if (entry.content === undefined) entry.content = "";
+    entry.fetchedAt = now;
+  }
+}
+
+/** Fetches every indexed page in parallel (throttled). Memoised. */
+async function warmAll(): Promise<void> {
+  await ensureIndex();
+  const queue = [...docsIndex.values()].filter(
+    (e) => e.content === undefined || !e.fetchedAt || Date.now() - e.fetchedAt >= PAGE_TTL_MS
+  );
+  if (queue.length === 0) return;
+  logs.info(`nexus docs: warming ${queue.length} pages…`);
+  const start = Date.now();
+  await Promise.all(
+    Array.from({ length: CONCURRENT_FETCHES }, async () => {
+      while (queue.length) {
+        const entry = queue.shift();
+        if (!entry) return;
+        await ensurePage(entry);
+      }
+    })
+  );
+  logs.info(`nexus docs: warmed ${docsIndex.size} pages in ${Date.now() - start}ms`);
+}
+
+/** Idempotent — first call schedules warmup, subsequent calls just await it. */
+export function ensureDocsWarm(): Promise<void> {
+  if (!warmupPromise) {
+    warmupPromise = warmAll().catch(() => {
+      /* swallow — fall back to whatever we have */
+    });
+  }
+  return warmupPromise;
+}
+
+/** Fire-and-forget kick used at startup / on first chat request. */
+export function startDocsWarmup(): void {
+  void ensureDocsWarm();
+}
+
+/* ────────────────────────────────────────────────────────────────────── *
+ * Search
+ * ────────────────────────────────────────────────────────────────────── */
+
+export interface DocSearchHit {
+  url: string;
+  title: string;
+  description: string;
+  snippet: string;
+  score: number;
+}
+
+function makeSnippet(content: string, position: number, term: string): string {
+  if (!content) return "";
+  const half = Math.floor(MAX_SNIPPET_BYTES / 2);
+  let start = Math.max(0, position - half);
+  let end = Math.min(content.length, position + half + term.length);
+  // Round to word-ish boundaries so we don't slice mid-word.
+  if (start > 0) {
+    const nextSpace = content.indexOf(" ", start);
+    if (nextSpace !== -1 && nextSpace - start < 30) start = nextSpace + 1;
+  }
+  if (end < content.length) {
+    const prevSpace = content.lastIndexOf(" ", end);
+    if (prevSpace !== -1 && end - prevSpace < 30) end = prevSpace;
+  }
+  const slice = content.slice(start, end).replace(/\s+/g, " ").trim();
+  return (start > 0 ? "…" : "") + slice + (end < content.length ? "…" : "");
+}
+
+export async function searchDocs(query: string, limit = 5): Promise<DocSearchHit[]> {
+  await ensureDocsWarm();
+  const cleaned = query.trim().toLowerCase();
+  if (!cleaned) return [];
+  const terms = cleaned.split(/\s+/).filter((t) => t.length >= 2);
+  if (terms.length === 0) return [];
+
+  const hits: DocSearchHit[] = [];
+  for (const entry of docsIndex.values()) {
+    const titleLower = entry.title.toLowerCase();
+    const descLower = entry.description.toLowerCase();
+    const contentLower = (entry.content || "").toLowerCase();
+    let score = 0;
+    let firstHitIdx = -1;
+    let firstHitTerm = "";
+    for (const term of terms) {
+      // Title matches dominate — that's where most "what is X" queries land.
+      if (titleLower.includes(term)) score += 10;
+      if (descLower.includes(term)) score += 4;
+      const idx = contentLower.indexOf(term);
+      if (idx !== -1) {
+        score += 1;
+        if (firstHitIdx === -1) {
+          firstHitIdx = idx;
+          firstHitTerm = term;
+        }
+      }
+    }
+    if (score === 0) continue;
+
+    let snippet = entry.description;
+    if (firstHitIdx !== -1 && entry.content) {
+      snippet = makeSnippet(entry.content, firstHitIdx, firstHitTerm);
+    }
+    hits.push({
+      url: entry.url,
+      title: entry.title,
+      description: entry.description,
+      snippet,
+      score
+    });
+  }
+  return hits.sort((a, b) => b.score - a.score).slice(0, Math.max(1, limit));
+}
+
+/* ────────────────────────────────────────────────────────────────────── *
+ * Direct fetch
+ * ────────────────────────────────────────────────────────────────────── */
+
+export interface DocPage {
+  url: string;
+  title: string;
+  description: string;
+  content: string;
+}
+
+export async function fetchDocPage(url: string): Promise<DocPage | null> {
+  // Strict whitelist: only the official docs origin. Prevents the model
+  // from being able to fetch arbitrary URLs through this tool.
+  if (!url.startsWith(DOCS_ORIGIN)) return null;
+
+  // Accept either form (with or without `.md`) — the model may receive
+  // either depending on where it picked the URL up. Normalize for cache lookup.
+  const canonical = canonicalDocUrl(url);
+
+  await ensureIndex();
+  let entry = docsIndex.get(canonical);
+  if (!entry) {
+    // Allow loading docs.dappnode.io URLs not (yet) in llms.txt — the index
+    // may be stale, and the model can follow links it discovers.
+    entry = { url: canonical, title: canonical.replace(DOCS_ORIGIN, "/"), description: "" };
+    docsIndex.set(canonical, entry);
+  }
+  await ensurePage(entry);
+  if (!entry.content) return null;
+  return {
+    url: entry.url,
+    title: entry.title,
+    description: entry.description,
+    content: entry.content
+  };
+}
+
+/** Returns the parsed index without page content — useful for diagnostics. */
+export async function getDocsIndex(): Promise<Pick<DocEntry, "url" | "title" | "description">[]> {
+  await ensureIndex();
+  return [...docsIndex.values()].map(({ url, title, description }) => ({ url, title, description }));
+}
+
+export function getDocsStats(): { entries: number; cachedPages: number; indexAgeMs: number } {
+  const cached = [...docsIndex.values()].filter((e) => e.content !== undefined && e.content.length > 0).length;
+  return {
+    entries: docsIndex.size,
+    cachedPages: cached,
+    indexAgeMs: indexFetchedAt ? Date.now() - indexFetchedAt : -1
+  };
+}

--- a/packages/dappmanager/src/mcp/server.ts
+++ b/packages/dappmanager/src/mcp/server.ts
@@ -1,0 +1,70 @@
+import { randomUUID } from "crypto";
+import type { Request, Response as ExpressResponse } from "express";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { logs } from "@dappnode/logger";
+import { dappnodeToolList } from "./tools.js";
+
+/**
+ * Single-session MCP server for this DAppNode. Mounted at `/mcp` behind
+ * `auth.onlyAdmin`. The same tool registry is used by the embedded chat
+ * proxy via in-process dispatch (see ./dispatch.ts), so behaviour is
+ * identical between internal chat and external MCP clients.
+ */
+
+let connectPromise: Promise<void> | null = null;
+const transport = new StreamableHTTPServerTransport({
+  sessionIdGenerator: () => randomUUID()
+});
+
+function buildServer(): McpServer {
+  const server = new McpServer({
+    name: "dappnode",
+    version: "0.1.0"
+  });
+
+  for (const tool of dappnodeToolList) {
+    server.tool(tool.name, tool.description, tool.schema, async (input: unknown) => {
+      try {
+        const output = await tool.execute(input || {});
+        return {
+          content: [{ type: "text", text: JSON.stringify(output, null, 2) }]
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        logs.warn(`MCP tool ${tool.name} failed: ${message}`);
+        return {
+          isError: true,
+          content: [{ type: "text", text: `Error: ${message}` }]
+        };
+      }
+    });
+  }
+
+  return server;
+}
+
+function ensureConnected(): Promise<void> {
+  if (!connectPromise) {
+    const server = buildServer();
+    connectPromise = server.connect(transport).catch((err) => {
+      logs.error(`MCP server failed to connect transport: ${err instanceof Error ? err.message : err}`);
+      connectPromise = null;
+      throw err;
+    });
+  }
+  return connectPromise;
+}
+
+/**
+ * Express handler for `/mcp` (GET / POST / DELETE). The streamable HTTP
+ * transport handles MCP protocol framing; we just pass `req`/`res` through.
+ */
+export async function handleMcpRequest(req: Request, res: ExpressResponse): Promise<void> {
+  await ensureConnected();
+  // The SDK's `handleRequest` accepts the parsed body for POST. For other
+  // verbs (GET / DELETE — used for session lifecycle and SSE listening) the
+  // body argument is ignored.
+  const body = req.method === "POST" ? req.body : undefined;
+  await transport.handleRequest(req, res, body);
+}

--- a/packages/dappmanager/src/mcp/tools.ts
+++ b/packages/dappmanager/src/mcp/tools.ts
@@ -1,0 +1,400 @@
+import { z } from "zod";
+import {
+  dockerContainerStart,
+  dockerContainerStop,
+  getVolumeSystemData,
+  getVolumesOwnershipData,
+  listPackage,
+  listPackages,
+  logContainer
+} from "@dappnode/dockerapi";
+import type { PackageContainer } from "@dappnode/types";
+import { logs } from "@dappnode/logger";
+import { packageRestart } from "../calls/packageRestart.js";
+import { packageInstall } from "../calls/packageInstall.js";
+import { statsCpuGet } from "../calls/statsCpuGet.js";
+import { statsMemoryGet } from "../calls/statsMemoryGet.js";
+import { statsDiskGet } from "../calls/statsDiskGet.js";
+import { systemInfoGet } from "../calls/systemInfoGet.js";
+import { diagnose } from "../calls/diagnose.js";
+import { autoUpdateDataGet } from "../calls/autoUpdateDataGet.js";
+import { notificationsGetAll } from "../calls/notifications.js";
+import { searchDocs, fetchDocPage } from "./docs.js";
+
+/**
+ * Shared tool registry consumed by both the MCP server (for external clients
+ * like Claude Desktop / Cursor) and the chat proxy's in-process dispatcher.
+ *
+ * Each tool defines a Zod schema for input validation + JSON-Schema export,
+ * plus an `execute()` that calls into existing dappmanager helpers. Tools
+ * marked `mutating: true` mutate state — the system prompt instructs the
+ * model to confirm with the user before invoking them.
+ */
+export interface DappnodeTool {
+  /** OpenAI/MCP tool name (snake_case, prefixed with `dappnode_`). */
+  name: string;
+  /** Short description shown to the model. */
+  description: string;
+  /** True if the tool mutates state (restart, install, set_env, …). */
+  mutating?: boolean;
+  /** Zod raw shape — `{ key: z.string(), ... }`. */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  schema: Record<string, z.ZodType<any>>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  execute: (input: any) => Promise<unknown>;
+}
+
+/* ────────────── Helpers ────────────── */
+
+function compactContainer(c: PackageContainer): Record<string, unknown> {
+  return {
+    name: c.containerName,
+    serviceName: c.serviceName,
+    state: c.state,
+    running: c.running,
+    image: c.image,
+    created: c.created
+  };
+}
+
+function truncate(s: string, max: number): string {
+  return s.length > max ? s.slice(0, max) + "\n…(truncated)" : s;
+}
+
+/* ────────────── Tools ────────────── */
+
+const listPackagesTool: DappnodeTool = {
+  name: "dappnode_list_packages",
+  description:
+    "List every package installed on this DAppNode with its version, container state, and core/chain tags. Use this to know what's running.",
+  schema: {},
+  async execute() {
+    const pkgs = await listPackages();
+    return pkgs.map((p) => ({
+      dnpName: p.dnpName,
+      version: p.version,
+      isCore: p.isCore,
+      chain: p.chain ?? null,
+      categories: p.categories ?? [],
+      origin: p.origin ?? null,
+      containers: (p.containers || []).map(compactContainer)
+    }));
+  }
+};
+
+const getPackageDetailsTool: DappnodeTool = {
+  name: "dappnode_get_package_details",
+  description:
+    "Get full details for a specific package by its dnpName: containers, ports, volumes, env summary, dependencies.",
+  schema: {
+    dnpName: z
+      .string()
+      .min(1)
+      .describe("The package dnpName, e.g. 'mev-boost-hoodi.dnp.dappnode.eth'")
+  },
+  async execute({ dnpName }: { dnpName: string }) {
+    const pkg = await listPackage({ dnpName });
+    // Return as-is — listPackage already returns InstalledPackageData.
+    return pkg;
+  }
+};
+
+const getPackageLogsTool: DappnodeTool = {
+  name: "dappnode_get_package_logs",
+  description:
+    "Fetch the tail of container logs for a package. Returns one log block per container in the package.",
+  schema: {
+    dnpName: z.string().min(1).describe("The package dnpName"),
+    tail: z
+      .number()
+      .int()
+      .min(1)
+      .max(500)
+      .optional()
+      .describe("Number of trailing lines per container. Default 100, max 500.")
+  },
+  async execute({ dnpName, tail = 100 }: { dnpName: string; tail?: number }) {
+    const pkg = await listPackage({ dnpName });
+    const out: Record<string, string> = {};
+    for (const c of pkg.containers || []) {
+      try {
+        const raw = await logContainer(c.containerName, { tail, stdout: true, stderr: true });
+        out[c.containerName] = truncate(raw, 40_000);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        out[c.containerName] = `(failed to fetch logs: ${message})`;
+      }
+    }
+    return { dnpName, tail, containers: out };
+  }
+};
+
+const getSystemInfoTool: DappnodeTool = {
+  name: "dappnode_get_system_info",
+  description:
+    "Get system-level info for this DAppNode: CPU usage, memory, disk usage, hostname, IPs, version data.",
+  schema: {},
+  async execute() {
+    const [cpu, memory, disk, system] = await Promise.allSettled([
+      statsCpuGet(),
+      statsMemoryGet(),
+      statsDiskGet(),
+      systemInfoGet()
+    ]);
+    return {
+      cpu: cpu.status === "fulfilled" ? cpu.value : { error: String(cpu.reason) },
+      memory: memory.status === "fulfilled" ? memory.value : { error: String(memory.reason) },
+      disk: disk.status === "fulfilled" ? disk.value : { error: String(disk.reason) },
+      system:
+        system.status === "fulfilled"
+          ? {
+              name: system.value.name,
+              dappnodeWebName: system.value.dappnodeWebName,
+              internalIp: system.value.internalIp,
+              publicIp: system.value.publicIp,
+              staticIp: system.value.staticIp,
+              domain: system.value.domain,
+              versionData: system.value.versionData
+            }
+          : { error: String(system.reason) }
+    };
+  }
+};
+
+const restartPackageTool: DappnodeTool = {
+  name: "dappnode_restart_package",
+  description:
+    "Restart a package's containers (re-creates them). Causes brief downtime for the package's services. Ask the user to confirm before calling this.",
+  mutating: true,
+  schema: {
+    dnpName: z.string().min(1).describe("The package dnpName to restart"),
+    serviceNames: z
+      .array(z.string())
+      .optional()
+      .describe("Optional list of service names to restart. If omitted, restarts all containers.")
+  },
+  async execute({ dnpName, serviceNames }: { dnpName: string; serviceNames?: string[] }) {
+    logs.info(`MCP: dappnode_restart_package(${dnpName})`);
+    await packageRestart({ dnpName, serviceNames });
+    return {
+      ok: true,
+      dnpName,
+      serviceNames: serviceNames ?? "all"
+    };
+  }
+};
+
+const startPackageTool: DappnodeTool = {
+  name: "dappnode_start_package",
+  description:
+    "Start every container of a package by dnpName. Use when a package is exited and the user wants it running. Ask the user to confirm before calling.",
+  mutating: true,
+  schema: {
+    dnpName: z.string().min(1).describe("The package dnpName to start")
+  },
+  async execute({ dnpName }: { dnpName: string }) {
+    logs.info(`MCP: dappnode_start_package(${dnpName})`);
+    const pkg = await listPackage({ dnpName });
+    const results: { container: string; ok: boolean; error?: string }[] = [];
+    for (const c of pkg.containers || []) {
+      try {
+        await dockerContainerStart(c.containerName);
+        results.push({ container: c.containerName, ok: true });
+      } catch (err) {
+        results.push({
+          container: c.containerName,
+          ok: false,
+          error: err instanceof Error ? err.message : String(err)
+        });
+      }
+    }
+    return { dnpName, results };
+  }
+};
+
+const stopPackageTool: DappnodeTool = {
+  name: "dappnode_stop_package",
+  description:
+    "Stop every container of a package by dnpName. The package's services will become unavailable until started again. Ask the user to confirm before calling.",
+  mutating: true,
+  schema: {
+    dnpName: z.string().min(1).describe("The package dnpName to stop")
+  },
+  async execute({ dnpName }: { dnpName: string }) {
+    logs.info(`MCP: dappnode_stop_package(${dnpName})`);
+    const pkg = await listPackage({ dnpName });
+    const results: { container: string; ok: boolean; error?: string }[] = [];
+    for (const c of pkg.containers || []) {
+      try {
+        await dockerContainerStop(c.containerName);
+        results.push({ container: c.containerName, ok: true });
+      } catch (err) {
+        results.push({
+          container: c.containerName,
+          ok: false,
+          error: err instanceof Error ? err.message : String(err)
+        });
+      }
+    }
+    return { dnpName, results };
+  }
+};
+
+const updatePackageTool: DappnodeTool = {
+  name: "dappnode_update_package",
+  description:
+    "Update a package to a specific version, or to its latest version if `version` is omitted. Re-runs the install flow — may cause brief downtime. Ask the user to confirm, including the version, before calling.",
+  mutating: true,
+  schema: {
+    dnpName: z.string().min(1).describe("The package dnpName to update"),
+    version: z
+      .string()
+      .optional()
+      .describe("Optional target version (semver or IPFS hash). Defaults to latest.")
+  },
+  async execute({ dnpName, version }: { dnpName: string; version?: string }) {
+    logs.info(`MCP: dappnode_update_package(${dnpName}, ${version ?? "latest"})`);
+    await packageInstall({
+      name: dnpName,
+      version,
+      userSettings: {},
+      notificationsSettings: {},
+      options: {}
+    });
+    return { ok: true, dnpName, version: version ?? "latest" };
+  }
+};
+
+const diagnoseTool: DappnodeTool = {
+  name: "dappnode_diagnose",
+  description:
+    "Run a system-level diagnostic of the DAppNode host (network, services, docker, disk, memory). Use proactively if the user reports anything wrong.",
+  schema: {},
+  async execute() {
+    return await diagnose();
+  }
+};
+
+const listNotificationsTool: DappnodeTool = {
+  name: "dappnode_list_notifications",
+  description:
+    "Get recent notifications from the DAppNode notifier — health alerts, update prompts, validator events. Returns the newest first.",
+  schema: {
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(200)
+      .optional()
+      .describe("Maximum number of notifications to return. Default 25, max 200.")
+  },
+  async execute({ limit = 25 }: { limit?: number }) {
+    const all = await notificationsGetAll();
+    // Sort newest first (timestamp is usually epoch).
+    const sorted = [...all].sort((a, b) => (b.timestamp ?? 0) - (a.timestamp ?? 0));
+    return sorted.slice(0, limit);
+  }
+};
+
+const getAvailableUpdatesTool: DappnodeTool = {
+  name: "dappnode_get_available_updates",
+  description:
+    "List packages that have updates available, plus current auto-update settings and the auto-update registry of past runs.",
+  schema: {},
+  async execute() {
+    return await autoUpdateDataGet();
+  }
+};
+
+const getDiskUsageTool: DappnodeTool = {
+  name: "dappnode_get_disk_usage",
+  description:
+    "Disk usage grouped by docker volume (and by owning package). Answers questions like 'what's eating my disk'. Returns sizes in bytes.",
+  schema: {},
+  async execute() {
+    const [ownership, systemData] = await Promise.all([
+      getVolumesOwnershipData(),
+      getVolumeSystemData()
+    ]);
+    // Aggregate volume sizes by owner dnpName for the model's convenience.
+    const byOwner: Record<string, { totalBytes: number; volumes: { name: string; size?: number | string }[] }> = {};
+    for (const o of ownership) {
+      const sys = systemData.find((s) => s.name === o.name);
+      const sizeNum = typeof sys?.size === "number" ? sys.size : 0;
+      const owner = o.owner || "unowned";
+      if (!byOwner[owner]) byOwner[owner] = { totalBytes: 0, volumes: [] };
+      byOwner[owner].totalBytes += sizeNum;
+      byOwner[owner].volumes.push({ name: o.name, size: sys?.size });
+    }
+    return {
+      grouped: byOwner,
+      total: Object.values(byOwner).reduce((acc, b) => acc + b.totalBytes, 0)
+    };
+  }
+};
+
+/* ────────────── Docs tools (official docs.dappnode.io as source of truth) ────────────── */
+
+const searchDocsTool: DappnodeTool = {
+  name: "dappnode_search_docs",
+  description:
+    "Search the official DAppNode docs at docs.dappnode.io. Use this for ANY question about DAppNode concepts, packages, configuration, troubleshooting, staking, networking, or how-to. The docs are the source of truth — prefer them over training-data memory. Returns ranked matches with title, URL, and a snippet around the matched text. After reading the snippet, call dappnode_fetch_doc on the URL if you need the full page.",
+  schema: {
+    query: z
+      .string()
+      .min(2)
+      .describe(
+        "Free-text keywords. Use specific terms — e.g. 'mev-boost configuration', 'wireguard setup', 'tailscale access', 'smooth subscription'."
+      ),
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(10)
+      .optional()
+      .describe("Max number of results. Default 5.")
+  },
+  async execute({ query, limit }: { query: string; limit?: number }) {
+    return await searchDocs(query, limit ?? 5);
+  }
+};
+
+const fetchDocTool: DappnodeTool = {
+  name: "dappnode_fetch_doc",
+  description:
+    "Fetch the full markdown of a single DAppNode docs page by its docs.dappnode.io URL. Use this AFTER dappnode_search_docs when a snippet isn't enough and you need the whole page (e.g. step-by-step instructions, full reference tables).",
+  schema: {
+    url: z
+      .string()
+      .url()
+      .describe(
+        "Full https://docs.dappnode.io/... URL of the doc page (typically obtained from dappnode_search_docs or from the index in the system prompt)."
+      )
+  },
+  async execute({ url }: { url: string }) {
+    const page = await fetchDocPage(url);
+    if (!page) {
+      return { error: "Page not found, fetch failed, or URL is not under docs.dappnode.io" };
+    }
+    return page;
+  }
+};
+
+export const dappnodeTools: Record<string, DappnodeTool> = {
+  [searchDocsTool.name]: searchDocsTool,
+  [fetchDocTool.name]: fetchDocTool,
+  [listPackagesTool.name]: listPackagesTool,
+  [getPackageDetailsTool.name]: getPackageDetailsTool,
+  [getPackageLogsTool.name]: getPackageLogsTool,
+  [getSystemInfoTool.name]: getSystemInfoTool,
+  [getDiskUsageTool.name]: getDiskUsageTool,
+  [getAvailableUpdatesTool.name]: getAvailableUpdatesTool,
+  [listNotificationsTool.name]: listNotificationsTool,
+  [diagnoseTool.name]: diagnoseTool,
+  [startPackageTool.name]: startPackageTool,
+  [stopPackageTool.name]: stopPackageTool,
+  [restartPackageTool.name]: restartPackageTool,
+  [updatePackageTool.name]: updatePackageTool
+};
+
+export const dappnodeToolList: DappnodeTool[] = Object.values(dappnodeTools);

--- a/packages/dappmanager/src/mcp/tools.ts
+++ b/packages/dappmanager/src/mcp/tools.ts
@@ -8,10 +8,13 @@ import {
   listPackages,
   logContainer
 } from "@dappnode/dockerapi";
-import type { PackageContainer } from "@dappnode/types";
+import { Network, PortProtocol } from "@dappnode/types";
+import type { PackageContainer, PortMapping, StakerConfigSet, UserSettingsAllDnps } from "@dappnode/types";
 import { logs } from "@dappnode/logger";
 import { packageRestart } from "../calls/packageRestart.js";
 import { packageInstall } from "../calls/packageInstall.js";
+import { packageSetEnvironment } from "../calls/packageSetEnvironment.js";
+import { packageSetPortMappings } from "../calls/packageSetPortMappings.js";
 import { statsCpuGet } from "../calls/statsCpuGet.js";
 import { statsMemoryGet } from "../calls/statsMemoryGet.js";
 import { statsDiskGet } from "../calls/statsDiskGet.js";
@@ -19,6 +22,9 @@ import { systemInfoGet } from "../calls/systemInfoGet.js";
 import { diagnose } from "../calls/diagnose.js";
 import { autoUpdateDataGet } from "../calls/autoUpdateDataGet.js";
 import { notificationsGetAll } from "../calls/notifications.js";
+import { stakerConfigGet, stakerConfigSet } from "../calls/stakerConfig.js";
+import { fetchDnpRequest } from "../calls/fetchDnpRequest.js";
+import { fetchRegistry } from "../calls/fetchRegistry.js";
 import { searchDocs, fetchDocPage } from "./docs.js";
 
 /**
@@ -33,6 +39,8 @@ import { searchDocs, fetchDocPage } from "./docs.js";
 export interface DappnodeTool {
   /** OpenAI/MCP tool name (snake_case, prefixed with `dappnode_`). */
   name: string;
+  /** Human-friendly label shown in the chat UI ("Restart package" vs the raw `dappnode_restart_package`). */
+  displayName: string;
   /** Short description shown to the model. */
   description: string;
   /** True if the tool mutates state (restart, install, set_env, …). */
@@ -65,6 +73,7 @@ function truncate(s: string, max: number): string {
 
 const listPackagesTool: DappnodeTool = {
   name: "dappnode_list_packages",
+  displayName: "List installed packages",
   description:
     "List every package installed on this DAppNode with its version, container state, and core/chain tags. Use this to know what's running.",
   schema: {},
@@ -84,6 +93,7 @@ const listPackagesTool: DappnodeTool = {
 
 const getPackageDetailsTool: DappnodeTool = {
   name: "dappnode_get_package_details",
+  displayName: "Get package details",
   description:
     "Get full details for a specific package by its dnpName: containers, ports, volumes, env summary, dependencies.",
   schema: {
@@ -101,6 +111,7 @@ const getPackageDetailsTool: DappnodeTool = {
 
 const getPackageLogsTool: DappnodeTool = {
   name: "dappnode_get_package_logs",
+  displayName: "Read package logs",
   description:
     "Fetch the tail of container logs for a package. Returns one log block per container in the package.",
   schema: {
@@ -131,6 +142,7 @@ const getPackageLogsTool: DappnodeTool = {
 
 const getSystemInfoTool: DappnodeTool = {
   name: "dappnode_get_system_info",
+  displayName: "Get system info",
   description:
     "Get system-level info for this DAppNode: CPU usage, memory, disk usage, hostname, IPs, version data.",
   schema: {},
@@ -163,6 +175,7 @@ const getSystemInfoTool: DappnodeTool = {
 
 const restartPackageTool: DappnodeTool = {
   name: "dappnode_restart_package",
+  displayName: "Restart package",
   description:
     "Restart a package's containers (re-creates them). Causes brief downtime for the package's services. Ask the user to confirm before calling this.",
   mutating: true,
@@ -186,6 +199,7 @@ const restartPackageTool: DappnodeTool = {
 
 const startPackageTool: DappnodeTool = {
   name: "dappnode_start_package",
+  displayName: "Start package",
   description:
     "Start every container of a package by dnpName. Use when a package is exited and the user wants it running. Ask the user to confirm before calling.",
   mutating: true,
@@ -214,6 +228,7 @@ const startPackageTool: DappnodeTool = {
 
 const stopPackageTool: DappnodeTool = {
   name: "dappnode_stop_package",
+  displayName: "Stop package",
   description:
     "Stop every container of a package by dnpName. The package's services will become unavailable until started again. Ask the user to confirm before calling.",
   mutating: true,
@@ -242,6 +257,7 @@ const stopPackageTool: DappnodeTool = {
 
 const updatePackageTool: DappnodeTool = {
   name: "dappnode_update_package",
+  displayName: "Update package",
   description:
     "Update a package to a specific version, or to its latest version if `version` is omitted. Re-runs the install flow — may cause brief downtime. Ask the user to confirm, including the version, before calling.",
   mutating: true,
@@ -267,6 +283,7 @@ const updatePackageTool: DappnodeTool = {
 
 const diagnoseTool: DappnodeTool = {
   name: "dappnode_diagnose",
+  displayName: "Run system diagnostic",
   description:
     "Run a system-level diagnostic of the DAppNode host (network, services, docker, disk, memory). Use proactively if the user reports anything wrong.",
   schema: {},
@@ -277,6 +294,7 @@ const diagnoseTool: DappnodeTool = {
 
 const listNotificationsTool: DappnodeTool = {
   name: "dappnode_list_notifications",
+  displayName: "List notifications",
   description:
     "Get recent notifications from the DAppNode notifier — health alerts, update prompts, validator events. Returns the newest first.",
   schema: {
@@ -298,6 +316,7 @@ const listNotificationsTool: DappnodeTool = {
 
 const getAvailableUpdatesTool: DappnodeTool = {
   name: "dappnode_get_available_updates",
+  displayName: "Check for updates",
   description:
     "List packages that have updates available, plus current auto-update settings and the auto-update registry of past runs.",
   schema: {},
@@ -308,6 +327,7 @@ const getAvailableUpdatesTool: DappnodeTool = {
 
 const getDiskUsageTool: DappnodeTool = {
   name: "dappnode_get_disk_usage",
+  displayName: "Check disk usage",
   description:
     "Disk usage grouped by docker volume (and by owning package). Answers questions like 'what's eating my disk'. Returns sizes in bytes.",
   schema: {},
@@ -337,6 +357,7 @@ const getDiskUsageTool: DappnodeTool = {
 
 const searchDocsTool: DappnodeTool = {
   name: "dappnode_search_docs",
+  displayName: "Search DAppNode docs",
   description:
     "Search the official DAppNode docs at docs.dappnode.io. Use this for ANY question about DAppNode concepts, packages, configuration, troubleshooting, staking, networking, or how-to. The docs are the source of truth — prefer them over training-data memory. Returns ranked matches with title, URL, and a snippet around the matched text. After reading the snippet, call dappnode_fetch_doc on the URL if you need the full page.",
   schema: {
@@ -361,6 +382,7 @@ const searchDocsTool: DappnodeTool = {
 
 const fetchDocTool: DappnodeTool = {
   name: "dappnode_fetch_doc",
+  displayName: "Read DAppNode doc page",
   description:
     "Fetch the full markdown of a single DAppNode docs page by its docs.dappnode.io URL. Use this AFTER dappnode_search_docs when a snippet isn't enough and you need the whole page (e.g. step-by-step instructions, full reference tables).",
   schema: {
@@ -380,6 +402,258 @@ const fetchDocTool: DappnodeTool = {
   }
 };
 
+/* ────────────── Staker config tools ────────────── */
+
+const getStakerConfigTool: DappnodeTool = {
+  name: "dappnode_get_staker_config",
+  displayName: "Get staker config",
+  description:
+    "Read the current staker configuration for a network: which execution client, consensus client, mev-boost and web3signer are selected, plus the full list of available options per slot. Use this before suggesting changes so you know the starting state.",
+  schema: {
+    network: z
+      .nativeEnum(Network)
+      .describe("Staker network: 'mainnet', 'gnosis', 'lukso', 'hoodi', 'holesky', 'sepolia', 'prater', 'starknet', 'starknet-sepolia'.")
+  },
+  async execute({ network }: { network: Network }) {
+    return await stakerConfigGet({ network });
+  }
+};
+
+const setStakerConfigTool: DappnodeTool = {
+  name: "dappnode_set_staker_config",
+  displayName: "Change staker config",
+  description:
+    "Change the staker setup on a network: pick (or clear) the execution/consensus/mev-boost/web3signer clients, and update the mev-boost relay list. Each *DnpName field is optional and defaults to 'unset that slot' (null). This touches multiple packages — ask the user to confirm before calling.",
+  mutating: true,
+  schema: {
+    network: z.nativeEnum(Network).describe("Staker network to configure."),
+    executionDnpName: z
+      .string()
+      .nullable()
+      .optional()
+      .describe("Execution client dnpName, or null to unset. Omit to leave unchanged is NOT supported — pass null explicitly."),
+    consensusDnpName: z
+      .string()
+      .nullable()
+      .optional()
+      .describe("Consensus client dnpName, or null to unset."),
+    mevBoostDnpName: z
+      .string()
+      .nullable()
+      .optional()
+      .describe("MEV-boost dnpName, or null to unset."),
+    web3signerDnpName: z
+      .string()
+      .nullable()
+      .optional()
+      .describe("Web3signer dnpName, or null to unset."),
+    relays: z
+      .array(z.string())
+      .optional()
+      .describe("List of MEV-boost relay URLs. Defaults to empty.")
+  },
+  async execute({
+    network,
+    executionDnpName = null,
+    consensusDnpName = null,
+    mevBoostDnpName = null,
+    web3signerDnpName = null,
+    relays = []
+  }: {
+    network: Network;
+    executionDnpName?: string | null;
+    consensusDnpName?: string | null;
+    mevBoostDnpName?: string | null;
+    web3signerDnpName?: string | null;
+    relays?: string[];
+  }) {
+    logs.info(`MCP: dappnode_set_staker_config(${network})`);
+    const stakerConfig: StakerConfigSet = {
+      network,
+      executionDnpName,
+      consensusDnpName,
+      mevBoostDnpName,
+      web3signerDnpName,
+      relays
+    };
+    await stakerConfigSet({ stakerConfig });
+    return { ok: true, network, applied: stakerConfig };
+  }
+};
+
+/* ────────────── Package env / port tools ────────────── */
+
+const setPackageEnvironmentTool: DappnodeTool = {
+  name: "dappnode_set_package_environment",
+  displayName: "Edit package env vars",
+  description:
+    "Edit environment variables of a package, per service. The package will be re-upped (brief downtime) so the new env applies. Pass `environmentByService` as `{ serviceName: { KEY: 'value', ... } }`. Use dappnode_get_package_details first to inspect the current env. Ask the user to confirm before calling.",
+  mutating: true,
+  schema: {
+    dnpName: z.string().min(1).describe("The package dnpName whose env to edit"),
+    environmentByService: z
+      .record(z.record(z.string()))
+      .describe("Map of serviceName → { envKey: envValue }. Existing keys are merged.")
+  },
+  async execute({
+    dnpName,
+    environmentByService
+  }: {
+    dnpName: string;
+    environmentByService: Record<string, Record<string, string>>;
+  }) {
+    logs.info(`MCP: dappnode_set_package_environment(${dnpName})`);
+    await packageSetEnvironment({ dnpName, environmentByService });
+    return { ok: true, dnpName, environmentByService };
+  }
+};
+
+const setPackagePortMappingsTool: DappnodeTool = {
+  name: "dappnode_set_package_port_mappings",
+  displayName: "Edit package port mappings",
+  description:
+    "Edit host-port mappings of a package, per service. The package will be re-upped (brief downtime). Auto-rolls-back if the new host port is already in use. Pass `portMappingsByService` as `{ serviceName: [{ host?: number, container: number, protocol: 'TCP'|'UDP' }, ...] }`. Set `merge: true` to add to existing mappings; otherwise the list is replaced. Ask the user to confirm before calling.",
+  mutating: true,
+  schema: {
+    dnpName: z.string().min(1).describe("The package dnpName whose ports to edit"),
+    portMappingsByService: z
+      .record(
+        z.array(
+          z.object({
+            host: z.number().int().min(1).max(65535).optional(),
+            container: z.number().int().min(1).max(65535),
+            protocol: z.nativeEnum(PortProtocol)
+          })
+        )
+      )
+      .describe("Map of serviceName → array of port mappings."),
+    merge: z
+      .boolean()
+      .optional()
+      .describe("If true, merge with existing mappings instead of replacing them. Default false.")
+  },
+  async execute({
+    dnpName,
+    portMappingsByService,
+    merge = false
+  }: {
+    dnpName: string;
+    portMappingsByService: Record<string, PortMapping[]>;
+    merge?: boolean;
+  }) {
+    logs.info(`MCP: dappnode_set_package_port_mappings(${dnpName}, merge=${merge})`);
+    await packageSetPortMappings({ dnpName, portMappingsByService, options: { merge } });
+    return { ok: true, dnpName, portMappingsByService, merge };
+  }
+};
+
+/* ────────────── Registry / install tools ────────────── */
+
+const searchRegistryTool: DappnodeTool = {
+  name: "dappnode_search_registry",
+  displayName: "Browse package registry",
+  description:
+    "Browse the DAppNode public package registry. Returns packages with their name, description, categories and install status. NOTE: this scans the chain — slower than the other read tools, so call sparingly (e.g. once when the user asks 'what's available' or 'what can I install for X'). Optional `query` filters by case-insensitive substring on name and description.",
+  schema: {
+    query: z
+      .string()
+      .optional()
+      .describe("Optional case-insensitive substring filter on name/description."),
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(100)
+      .optional()
+      .describe("Max entries to return. Default 25, max 100.")
+  },
+  async execute({ query, limit = 25 }: { query?: string; limit?: number }) {
+    const entries = await fetchRegistry();
+    const needle = query?.trim().toLowerCase();
+    const filtered = needle
+      ? entries.filter((e) => {
+          const name = e.name?.toLowerCase() ?? "";
+          const description = e.status === "ok" ? e.description?.toLowerCase() ?? "" : "";
+          return name.includes(needle) || description.includes(needle);
+        })
+      : entries;
+    return filtered.slice(0, limit).map((e) => ({
+      name: e.name,
+      status: e.status,
+      description: e.status === "ok" ? e.description : undefined,
+      categories: e.status === "ok" ? e.categories : undefined,
+      isInstalled: e.status === "ok" ? e.isInstalled : undefined,
+      isUpdated: e.status === "ok" ? e.isUpdated : undefined,
+      error: e.status === "error" ? e.message : undefined
+    }));
+  }
+};
+
+const fetchInstallPreviewTool: DappnodeTool = {
+  name: "dappnode_fetch_install_preview",
+  displayName: "Preview package install",
+  description:
+    "Fetch the install preview of a package: special permissions it needs, its dependency tree, signature status, compatibility checks and the setup-wizard fields the user would fill in. ALWAYS call this BEFORE dappnode_install_package so you can present the permissions and required setup to the user.",
+  schema: {
+    name: z.string().min(1).describe("Package dnpName, e.g. 'bitcoin.dnp.dappnode.eth'"),
+    version: z
+      .string()
+      .optional()
+      .describe("Optional target version (semver or IPFS hash). Defaults to latest.")
+  },
+  async execute({ name, version }: { name: string; version?: string }) {
+    return await fetchDnpRequest({ id: name, version });
+  }
+};
+
+const installPackageTool: DappnodeTool = {
+  name: "dappnode_install_package",
+  displayName: "Install package",
+  description:
+    "Install a new package, resolving dependencies and starting its containers. ALWAYS call dappnode_fetch_install_preview first and present the special permissions + dependency list + version to the user. Only call this AFTER explicit user confirmation. `userSettings` shape is per-package (driven by the setup wizard from the preview) — pass it as the same nested object the UI would build.",
+  mutating: true,
+  schema: {
+    name: z.string().min(1).describe("Package dnpName to install"),
+    version: z
+      .string()
+      .optional()
+      .describe("Optional target version (semver or IPFS hash). Defaults to latest."),
+    userSettings: z
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .record(z.any())
+      .optional()
+      .describe("Per-package settings (env vars, port mappings, named-volume mountpoints, …). Structure matches the setup wizard returned by dappnode_fetch_install_preview."),
+    options: z
+      .object({
+        BYPASS_RESOLVER: z.boolean().optional(),
+        BYPASS_CORE_RESTRICTION: z.boolean().optional()
+      })
+      .optional()
+      .describe("Advanced install flags. Omit unless the user explicitly asked for them.")
+  },
+  async execute({
+    name,
+    version,
+    userSettings,
+    options
+  }: {
+    name: string;
+    version?: string;
+    userSettings?: UserSettingsAllDnps;
+    options?: { BYPASS_RESOLVER?: boolean; BYPASS_CORE_RESTRICTION?: boolean };
+  }) {
+    logs.info(`MCP: dappnode_install_package(${name}, ${version ?? "latest"})`);
+    await packageInstall({
+      name,
+      version,
+      userSettings: userSettings ?? {},
+      notificationsSettings: {},
+      options: options ?? {}
+    });
+    return { ok: true, name, version: version ?? "latest" };
+  }
+};
+
 export const dappnodeTools: Record<string, DappnodeTool> = {
   [searchDocsTool.name]: searchDocsTool,
   [fetchDocTool.name]: fetchDocTool,
@@ -394,7 +668,14 @@ export const dappnodeTools: Record<string, DappnodeTool> = {
   [startPackageTool.name]: startPackageTool,
   [stopPackageTool.name]: stopPackageTool,
   [restartPackageTool.name]: restartPackageTool,
-  [updatePackageTool.name]: updatePackageTool
+  [updatePackageTool.name]: updatePackageTool,
+  [getStakerConfigTool.name]: getStakerConfigTool,
+  [setStakerConfigTool.name]: setStakerConfigTool,
+  [setPackageEnvironmentTool.name]: setPackageEnvironmentTool,
+  [setPackagePortMappingsTool.name]: setPackagePortMappingsTool,
+  [searchRegistryTool.name]: searchRegistryTool,
+  [fetchInstallPreviewTool.name]: fetchInstallPreviewTool,
+  [installPackageTool.name]: installPackageTool
 };
 
 export const dappnodeToolList: DappnodeTool[] = Object.values(dappnodeTools);

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -7,6 +7,7 @@ export * from "./ipfsClient.js";
 export * from "./mirrorProvider.js";
 export * from "./fileTransferPath.js";
 export * from "./network.js";
+export * from "./nexus.js";
 export * from "./notification.js";
 export * from "./optimismConfig.js";
 export * from "./package.js";

--- a/packages/db/src/nexus.ts
+++ b/packages/db/src/nexus.ts
@@ -1,4 +1,4 @@
-import { dbCache } from "./dbFactory.js";
+import { dbCache, dbMain } from "./dbFactory.js";
 
 /**
  * Persisted chat conversations. Stored in dbCache (non-critical — can be
@@ -24,3 +24,13 @@ export const nexusChatHistory = dbCache.indexedByKey<NexusStoredConversation, st
   rootKey: NEXUS_CHAT_HISTORY,
   getKey: (id) => id
 });
+
+/**
+ * Nexus API key configured from the admin UI. Stored in dbMain (critical,
+ * never wiped) since it's a credential the user can set in-app instead of
+ * passing the `NEXUS_API_KEY` env var to the dappmanager container. When set,
+ * it takes precedence over the env var.
+ */
+const NEXUS_API_KEY = "nexus-api-key";
+
+export const nexusApiKey = dbMain.staticKey<string>(NEXUS_API_KEY, "");

--- a/packages/db/src/nexus.ts
+++ b/packages/db/src/nexus.ts
@@ -1,0 +1,26 @@
+import { dbCache } from "./dbFactory.js";
+
+/**
+ * Persisted chat conversations. Stored in dbCache (non-critical — can be
+ * wiped by the user) so conversations survive page reloads on the same
+ * DAppNode. The proxy caps the registry at MAX_HISTORY entries.
+ */
+export interface NexusStoredChatMessage {
+  role: "user" | "assistant";
+  content: string;
+}
+
+export interface NexusStoredConversation {
+  id: string;
+  title: string;
+  messages: NexusStoredChatMessage[];
+  createdAt: number;
+  updatedAt: number;
+}
+
+const NEXUS_CHAT_HISTORY = "nexus-chat-history";
+
+export const nexusChatHistory = dbCache.indexedByKey<NexusStoredConversation, string>({
+  rootKey: NEXUS_CHAT_HISTORY,
+  getKey: (id) => id
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1371,6 +1371,7 @@ __metadata:
     react-toastify: "npm:^4.1.0"
     redux: "npm:^4.0.0"
     redux-thunk: "npm:^2.3.0"
+    remark-gfm: "npm:^3.0.1"
     sass: "npm:^1.49.7"
     semver: "npm:^7.3.8"
     shadcn: "npm:^4.0.8"
@@ -1483,6 +1484,7 @@ __metadata:
     "@dappnode/types": "workspace:^0.1.0"
     "@dappnode/upnpc": "workspace:^0.1.0"
     "@dappnode/utils": "workspace:^0.1.0"
+    "@modelcontextprotocol/sdk": "npm:^1.29.0"
     "@types/async-retry": "npm:^1.4.2"
     "@types/bcryptjs": "npm:^2.4.2"
     "@types/compression": "npm:^1.7.0"
@@ -1528,6 +1530,8 @@ __metadata:
     socket.io: "npm:^4.5.1"
     socket.io-client: "npm:^4.5.1"
     systeminformation: "npm:^5.21.24"
+    zod: "npm:^3.25.0"
+    zod-to-json-schema: "npm:^3.25.1"
   languageName: unknown
   linkType: soft
 
@@ -3679,6 +3683,39 @@ __metadata:
     zod:
       optional: false
   checksum: 10c0/1b8ad87093c9e43174c7d65864b3d826a8dd050d5c32248f5da49fd72c51b556ebd702e3e49a7f1cc7fa25717a3f7fcee22ed89edd5bd3d8f4e1f8ca499b365e
+  languageName: node
+  linkType: hard
+
+"@modelcontextprotocol/sdk@npm:^1.29.0":
+  version: 1.29.0
+  resolution: "@modelcontextprotocol/sdk@npm:1.29.0"
+  dependencies:
+    "@hono/node-server": "npm:^1.19.9"
+    ajv: "npm:^8.17.1"
+    ajv-formats: "npm:^3.0.1"
+    content-type: "npm:^1.0.5"
+    cors: "npm:^2.8.5"
+    cross-spawn: "npm:^7.0.5"
+    eventsource: "npm:^3.0.2"
+    eventsource-parser: "npm:^3.0.0"
+    express: "npm:^5.2.1"
+    express-rate-limit: "npm:^8.2.1"
+    hono: "npm:^4.11.4"
+    jose: "npm:^6.1.3"
+    json-schema-typed: "npm:^8.0.2"
+    pkce-challenge: "npm:^5.0.0"
+    raw-body: "npm:^3.0.0"
+    zod: "npm:^3.25 || ^4.0"
+    zod-to-json-schema: "npm:^3.25.1"
+  peerDependencies:
+    "@cfworker/json-schema": ^4.1.1
+    zod: ^3.25 || ^4.0
+  peerDependenciesMeta:
+    "@cfworker/json-schema":
+      optional: true
+    zod:
+      optional: false
+  checksum: 10c0/7c4bc339205b1652330cd4e6b121cc859079655f2b9c0506bbb15563ba0d07924bda3d949705530532db7f4d2cb86d633dc8f92bc32803d97c7bece2ac63e29f
   languageName: node
   linkType: hard
 
@@ -9434,6 +9471,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ccount@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "ccount@npm:2.0.1"
+  checksum: 10c0/3939b1664390174484322bc3f45b798462e6c07ee6384cb3d645e0aa2f318502d174845198c1561930e1d431087f74cf1fe291ae9a4722821a9f4ba67e574350
+  languageName: node
+  linkType: hard
+
 "chai@npm:^4.3.10":
   version: 4.3.10
   resolution: "chai@npm:4.3.10"
@@ -11552,6 +11596,13 @@ __metadata:
   version: 1.0.5
   resolution: "escape-string-regexp@npm:1.0.5"
   checksum: 10c0/a968ad453dd0c2724e14a4f20e177aaf32bb384ab41b674a8454afe9a41c5e6fe8903323e0a1052f56289d04bd600f81278edf140b0fcc02f5cac98d0f5b5371
+  languageName: node
+  linkType: hard
+
+"escape-string-regexp@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "escape-string-regexp@npm:5.0.0"
+  checksum: 10c0/6366f474c6f37a802800a435232395e04e9885919873e382b157ab7e8f0feb8fed71497f84a6f6a81a49aab41815522f5839112bd38026d203aea0c91622df95
   languageName: node
   linkType: hard
 
@@ -15767,6 +15818,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"longest-streak@npm:^3.0.0":
+  version: 3.1.0
+  resolution: "longest-streak@npm:3.1.0"
+  checksum: 10c0/7c2f02d0454b52834d1bcedef79c557bd295ee71fdabb02d041ff3aa9da48a90b5df7c0409156dedbc4df9b65da18742652aaea4759d6ece01f08971af6a7eaa
+  languageName: node
+  linkType: hard
+
 "loose-envify@npm:^1.0.0, loose-envify@npm:^1.1.0, loose-envify@npm:^1.4.0":
   version: 1.4.0
   resolution: "loose-envify@npm:1.4.0"
@@ -15935,6 +15993,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"markdown-table@npm:^3.0.0":
+  version: 3.0.4
+  resolution: "markdown-table@npm:3.0.4"
+  checksum: 10c0/1257b31827629a54c24a5030a3dac952256c559174c95ce3ef89bebd6bff0cb1444b1fd667b1a1bb53307f83278111505b3e26f0c4e7b731e0060d435d2d930b
+  languageName: node
+  linkType: hard
+
 "math-intrinsics@npm:^1.1.0":
   version: 1.1.0
   resolution: "math-intrinsics@npm:1.1.0"
@@ -15964,6 +16029,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mdast-util-find-and-replace@npm:^2.0.0":
+  version: 2.2.2
+  resolution: "mdast-util-find-and-replace@npm:2.2.2"
+  dependencies:
+    "@types/mdast": "npm:^3.0.0"
+    escape-string-regexp: "npm:^5.0.0"
+    unist-util-is: "npm:^5.0.0"
+    unist-util-visit-parents: "npm:^5.0.0"
+  checksum: 10c0/ce935f4bd4aeab47f91531a7f09dfab89aaeea62ad31029b43185c5b626921357703d8e5093c13073c097fdabfc57cb2f884d7dfad83dbe7239e351375d6797c
+  languageName: node
+  linkType: hard
+
 "mdast-util-from-markdown@npm:^1.0.0":
   version: 1.3.1
   resolution: "mdast-util-from-markdown@npm:1.3.1"
@@ -15984,6 +16061,86 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mdast-util-gfm-autolink-literal@npm:^1.0.0":
+  version: 1.0.3
+  resolution: "mdast-util-gfm-autolink-literal@npm:1.0.3"
+  dependencies:
+    "@types/mdast": "npm:^3.0.0"
+    ccount: "npm:^2.0.0"
+    mdast-util-find-and-replace: "npm:^2.0.0"
+    micromark-util-character: "npm:^1.0.0"
+  checksum: 10c0/750e312eae73c3f2e8aa0e8c5232cb1b905357ff37ac236927f1af50cdbee7c2cfe2379b148ac32fa4137eeb3b24601e1bb6135084af926c7cd808867804193f
+  languageName: node
+  linkType: hard
+
+"mdast-util-gfm-footnote@npm:^1.0.0":
+  version: 1.0.2
+  resolution: "mdast-util-gfm-footnote@npm:1.0.2"
+  dependencies:
+    "@types/mdast": "npm:^3.0.0"
+    mdast-util-to-markdown: "npm:^1.3.0"
+    micromark-util-normalize-identifier: "npm:^1.0.0"
+  checksum: 10c0/767973e46b9e2ae44e80e51a5e38ad0b032fc7f06a1a3095aa96c2886ba333941c764474a56b82e7db05efc56242a4789bc7fbbcc753d61512750e86a4192fe8
+  languageName: node
+  linkType: hard
+
+"mdast-util-gfm-strikethrough@npm:^1.0.0":
+  version: 1.0.3
+  resolution: "mdast-util-gfm-strikethrough@npm:1.0.3"
+  dependencies:
+    "@types/mdast": "npm:^3.0.0"
+    mdast-util-to-markdown: "npm:^1.3.0"
+  checksum: 10c0/29616b3dfdd33d3cd13f9b3181a8562fa2fbacfcb04a37dba3c690ba6829f0231b145444de984726d9277b2bc90dd7d96fb9df9f6292d5e77d65a8659ee2f52b
+  languageName: node
+  linkType: hard
+
+"mdast-util-gfm-table@npm:^1.0.0":
+  version: 1.0.7
+  resolution: "mdast-util-gfm-table@npm:1.0.7"
+  dependencies:
+    "@types/mdast": "npm:^3.0.0"
+    markdown-table: "npm:^3.0.0"
+    mdast-util-from-markdown: "npm:^1.0.0"
+    mdast-util-to-markdown: "npm:^1.3.0"
+  checksum: 10c0/a37a05a936292c4f48394123332d3c034a6e1b15bb3e7f3b94e6bce3260c9184fd388abbc4100827edd5485a6563098306994d15a729bde3c96de7a62ed5720b
+  languageName: node
+  linkType: hard
+
+"mdast-util-gfm-task-list-item@npm:^1.0.0":
+  version: 1.0.2
+  resolution: "mdast-util-gfm-task-list-item@npm:1.0.2"
+  dependencies:
+    "@types/mdast": "npm:^3.0.0"
+    mdast-util-to-markdown: "npm:^1.3.0"
+  checksum: 10c0/91fa91f7d1a8797bf129008dab12d23917015ad12df00044e275b4459e8b383fbec6234338953a0089ef9c3a114d0a360c3e652eb0ebf6ece7e7a8fd3b5977c6
+  languageName: node
+  linkType: hard
+
+"mdast-util-gfm@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "mdast-util-gfm@npm:2.0.2"
+  dependencies:
+    mdast-util-from-markdown: "npm:^1.0.0"
+    mdast-util-gfm-autolink-literal: "npm:^1.0.0"
+    mdast-util-gfm-footnote: "npm:^1.0.0"
+    mdast-util-gfm-strikethrough: "npm:^1.0.0"
+    mdast-util-gfm-table: "npm:^1.0.0"
+    mdast-util-gfm-task-list-item: "npm:^1.0.0"
+    mdast-util-to-markdown: "npm:^1.0.0"
+  checksum: 10c0/5b7f7f98a90a2962d7e0787e080c4e55b70119100c7685bbdb772d8d7865524aeffd1757edba5afba434250e0246b987c0617c2c635baaf51c26dbbb3b72dbec
+  languageName: node
+  linkType: hard
+
+"mdast-util-phrasing@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "mdast-util-phrasing@npm:3.0.1"
+  dependencies:
+    "@types/mdast": "npm:^3.0.0"
+    unist-util-is: "npm:^5.0.0"
+  checksum: 10c0/5e00e303652a7581593549dbce20dfb69d687d79a972f7928f6ca1920ef5385bceb737a3d5292ab6d937ed8c67bb59771e80e88f530b78734fe7d155f833e32b
+  languageName: node
+  linkType: hard
+
 "mdast-util-to-hast@npm:^12.1.0":
   version: 12.3.0
   resolution: "mdast-util-to-hast@npm:12.3.0"
@@ -16000,7 +16157,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mdast-util-to-string@npm:^3.1.0":
+"mdast-util-to-markdown@npm:^1.0.0, mdast-util-to-markdown@npm:^1.3.0":
+  version: 1.5.0
+  resolution: "mdast-util-to-markdown@npm:1.5.0"
+  dependencies:
+    "@types/mdast": "npm:^3.0.0"
+    "@types/unist": "npm:^2.0.0"
+    longest-streak: "npm:^3.0.0"
+    mdast-util-phrasing: "npm:^3.0.0"
+    mdast-util-to-string: "npm:^3.0.0"
+    micromark-util-decode-string: "npm:^1.0.0"
+    unist-util-visit: "npm:^4.0.0"
+    zwitch: "npm:^2.0.0"
+  checksum: 10c0/9831d14aa6c097750a90c7b87b4e814b040731c30606a794c9b136dc746633dd9ec07154ca97d4fec4eaf732cf89d14643424e2581732d6ee18c9b0e51ff7664
+  languageName: node
+  linkType: hard
+
+"mdast-util-to-string@npm:^3.0.0, mdast-util-to-string@npm:^3.1.0":
   version: 3.2.0
   resolution: "mdast-util-to-string@npm:3.2.0"
   dependencies:
@@ -16143,7 +16316,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"micromark-core-commonmark@npm:^1.0.1":
+"micromark-core-commonmark@npm:^1.0.0, micromark-core-commonmark@npm:^1.0.1":
   version: 1.1.0
   resolution: "micromark-core-commonmark@npm:1.1.0"
   dependencies:
@@ -16164,6 +16337,99 @@ __metadata:
     micromark-util-types: "npm:^1.0.1"
     uvu: "npm:^0.5.0"
   checksum: 10c0/b3bf7b7004ce7dbb3ae151dcca4db1d12546f1b943affb2418da4b90b9ce59357373c433ee2eea4c868aee0791dafa355aeed19f5ef2b0acaf271f32f1ecbe6a
+  languageName: node
+  linkType: hard
+
+"micromark-extension-gfm-autolink-literal@npm:^1.0.0":
+  version: 1.0.5
+  resolution: "micromark-extension-gfm-autolink-literal@npm:1.0.5"
+  dependencies:
+    micromark-util-character: "npm:^1.0.0"
+    micromark-util-sanitize-uri: "npm:^1.0.0"
+    micromark-util-symbol: "npm:^1.0.0"
+    micromark-util-types: "npm:^1.0.0"
+  checksum: 10c0/4964a52605ac36d24501d427e2d173fa39b5e0402275cb45068eba4898f4cb9cc57f7007b21b7514f0ab5f7b371b1701a5156a10b6ac8e77a7f36e830cf481d4
+  languageName: node
+  linkType: hard
+
+"micromark-extension-gfm-footnote@npm:^1.0.0":
+  version: 1.1.2
+  resolution: "micromark-extension-gfm-footnote@npm:1.1.2"
+  dependencies:
+    micromark-core-commonmark: "npm:^1.0.0"
+    micromark-factory-space: "npm:^1.0.0"
+    micromark-util-character: "npm:^1.0.0"
+    micromark-util-normalize-identifier: "npm:^1.0.0"
+    micromark-util-sanitize-uri: "npm:^1.0.0"
+    micromark-util-symbol: "npm:^1.0.0"
+    micromark-util-types: "npm:^1.0.0"
+    uvu: "npm:^0.5.0"
+  checksum: 10c0/b8090876cc3da5436c6253b0b40e39ceaa470c2429f699c19ee4163cef3102c4cd16c4ac2ec8caf916037fad310cfb52a9ef182c75d50fca7419ba08faad9b39
+  languageName: node
+  linkType: hard
+
+"micromark-extension-gfm-strikethrough@npm:^1.0.0":
+  version: 1.0.7
+  resolution: "micromark-extension-gfm-strikethrough@npm:1.0.7"
+  dependencies:
+    micromark-util-chunked: "npm:^1.0.0"
+    micromark-util-classify-character: "npm:^1.0.0"
+    micromark-util-resolve-all: "npm:^1.0.0"
+    micromark-util-symbol: "npm:^1.0.0"
+    micromark-util-types: "npm:^1.0.0"
+    uvu: "npm:^0.5.0"
+  checksum: 10c0/b45fe93a7a412fc44bae7a183b92a988e17b49ed9d683bd80ee4dde96d462e1ca6b316dd64bda7759e4086d6d8686790a711e53c244f1f4d2b37e1cfe852884d
+  languageName: node
+  linkType: hard
+
+"micromark-extension-gfm-table@npm:^1.0.0":
+  version: 1.0.7
+  resolution: "micromark-extension-gfm-table@npm:1.0.7"
+  dependencies:
+    micromark-factory-space: "npm:^1.0.0"
+    micromark-util-character: "npm:^1.0.0"
+    micromark-util-symbol: "npm:^1.0.0"
+    micromark-util-types: "npm:^1.0.0"
+    uvu: "npm:^0.5.0"
+  checksum: 10c0/38b5af80ecab8206845a057338235bee6f47fb6cb904208be4b76e87906765821683e25bef85dfa485809f931eaf8cd55f16cd2f4d6e33b84f56edfaf1dfb129
+  languageName: node
+  linkType: hard
+
+"micromark-extension-gfm-tagfilter@npm:^1.0.0":
+  version: 1.0.2
+  resolution: "micromark-extension-gfm-tagfilter@npm:1.0.2"
+  dependencies:
+    micromark-util-types: "npm:^1.0.0"
+  checksum: 10c0/7e1bf278255cf2a8d2dda9de84bc238b39c53100e25ba8d7168220d5b00dc74869a6cb038fbf2e76b8ae89efc66906762311797a906d7d9cdd71e07bfe1ed505
+  languageName: node
+  linkType: hard
+
+"micromark-extension-gfm-task-list-item@npm:^1.0.0":
+  version: 1.0.5
+  resolution: "micromark-extension-gfm-task-list-item@npm:1.0.5"
+  dependencies:
+    micromark-factory-space: "npm:^1.0.0"
+    micromark-util-character: "npm:^1.0.0"
+    micromark-util-symbol: "npm:^1.0.0"
+    micromark-util-types: "npm:^1.0.0"
+    uvu: "npm:^0.5.0"
+  checksum: 10c0/2179742fa2cbb243cc06bd9e43fbb94cd98e4814c9d368ddf8b4b5afa0348023f335626ae955e89d679e2c2662a7f82c315117a3b060c87bdb4420fee5a219d1
+  languageName: node
+  linkType: hard
+
+"micromark-extension-gfm@npm:^2.0.0":
+  version: 2.0.3
+  resolution: "micromark-extension-gfm@npm:2.0.3"
+  dependencies:
+    micromark-extension-gfm-autolink-literal: "npm:^1.0.0"
+    micromark-extension-gfm-footnote: "npm:^1.0.0"
+    micromark-extension-gfm-strikethrough: "npm:^1.0.0"
+    micromark-extension-gfm-table: "npm:^1.0.0"
+    micromark-extension-gfm-tagfilter: "npm:^1.0.0"
+    micromark-extension-gfm-task-list-item: "npm:^1.0.0"
+    micromark-util-combine-extensions: "npm:^1.0.0"
+    micromark-util-types: "npm:^1.0.0"
+  checksum: 10c0/53056376d14caf3fab2cc44881c1ad49d975776cc2267bca74abda2cb31f2a77ec0fb2bdb2dd97565f0d9943ad915ff192b89c1cee5d9d727569a5e38505799b
   languageName: node
   linkType: hard
 
@@ -19567,6 +19833,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"remark-gfm@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "remark-gfm@npm:3.0.1"
+  dependencies:
+    "@types/mdast": "npm:^3.0.0"
+    mdast-util-gfm: "npm:^2.0.0"
+    micromark-extension-gfm: "npm:^2.0.0"
+    unified: "npm:^10.0.0"
+  checksum: 10c0/53c4e82204f82f81949a170efdeb49d3c45137b7bca06a7ff857a483aac1a44b55ef0de8fb1bbe4f1292f2a378058e2e42e644f2c61f3e0cdc3e56afa4ec2a2c
+  languageName: node
+  linkType: hard
+
 "remark-parse@npm:^10.0.0":
   version: 10.0.2
   resolution: "remark-parse@npm:10.0.2"
@@ -22436,7 +22714,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unist-util-visit-parents@npm:^5.1.1":
+"unist-util-visit-parents@npm:^5.0.0, unist-util-visit-parents@npm:^5.1.1":
   version: 5.1.3
   resolution: "unist-util-visit-parents@npm:5.1.3"
   dependencies:
@@ -23826,7 +24104,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:^3.24.1":
+"zod@npm:^3.24.1, zod@npm:^3.25.0":
   version: 3.25.76
   resolution: "zod@npm:3.25.76"
   checksum: 10c0/5718ec35e3c40b600316c5b4c5e4976f7fee68151bc8f8d90ec18a469be9571f072e1bbaace10f1e85cf8892ea12d90821b200e980ab46916a6166a4260a983c
@@ -23837,5 +24115,12 @@ __metadata:
   version: 4.3.6
   resolution: "zod@npm:4.3.6"
   checksum: 10c0/860d25a81ab41d33aa25f8d0d07b091a04acb426e605f396227a796e9e800c44723ed96d0f53a512b57be3d1520f45bf69c0cb3b378a232a00787a2609625307
+  languageName: node
+  linkType: hard
+
+"zwitch@npm:^2.0.0":
+  version: 2.0.4
+  resolution: "zwitch@npm:2.0.4"
+  checksum: 10c0/3c7830cdd3378667e058ffdb4cf2bb78ac5711214e2725900873accb23f3dfe5f9e7e5a06dcdc5f29605da976fc45c26d9a13ca334d6eea2245a15e77b8fc06e
   languageName: node
   linkType: hard


### PR DESCRIPTION
# Nexus chat in the DAppNode UI + MCP server

## Summary

Adds a chat panel that talks to a Nexus gateway through this DAppNode, plus an MCP server that exposes the same tool registry to external clients (Claude Desktop, Cursor, etc.).

- **Backend (dappmanager)** — new `/nexus/*` routes proxy chat completions to a Nexus gateway with the API key held server-side (`NEXUS_API_KEY` env), persist chat history, and stream SSE back to the browser. A multi-step tool loop dispatches DAppNode-specific tools (list packages, fetch logs, diagnose, restart/start/stop/update package, search/fetch docs) and surfaces mutating calls to the UI for explicit confirmation before running.
- **MCP server** — same tool registry mounted at `POST/GET/DELETE /mcp` behind `auth.onlyAdmin` using the streamable HTTP transport from `@modelcontextprotocol/sdk`. External MCP clients can authenticate as admin and call the same tools the embedded chat uses.
- **Docs cache** — in-process cache of `docs.dappnode.io` driven by `llms.txt`. The chat is prompted to consult docs over training-data memory for any DAppNode-specific question; pages are pre-warmed on first chat so latency is negligible.
- **Frontend (admin-ui)** — `ChatPanel` rendered both on `/ai/nexus` (full-page) and as a floating launcher mounted app-wide. Includes model picker (last-used persisted in `localStorage`), confirmation dialog for mutating tool calls, persisted conversation history (server-side via dbCache), markdown rendering with GFM tables, and a smooth-stream pacer so token deltas read at a steady rate. The NexusPage marketing landing is replaced by the chat surface; the existing "About Nexus" link stays in the footer.

## Notable design choices

- **System prompt every turn.** The proxy injects a fresh system prompt with (a) the docs index from `llms.txt`, (b) this node's installed-package snapshot (60 s in-mem cache), and (c) the current admin-UI page (passed by the browser as `dappmanager_page`). The model is instructed to consult `dappnode_search_docs` / `dappnode_fetch_doc` before answering DAppNode-specific questions.
- **Mutating tools require confirmation.** `restart_package`, `start_package`, `stop_package`, and `update_package` go through `createPendingConfirmation` → SSE `confirm_required` event → UI dialog → `POST /nexus/chat/confirm`. A 5-minute server-side timeout auto-denies abandoned prompts.
- **Single in-process tool registry.** `mcp/tools.ts` is consumed by both the chat's in-process dispatcher (`mcp/dispatch.ts`) and the MCP server (`mcp/server.ts`), so behaviour is identical whether the caller is the embedded chat or an external MCP client.

## New environment variables

All three are read by the `dappmanager` container (see [docker-compose.yml](docker-compose.yml#L28) and [docker-compose-dev.yml](docker-compose-dev.yml#L32)). The chat is disabled until `NEXUS_API_KEY` is set.

| Variable | Required | Default | Purpose |
| --- | --- | --- | --- |
| `NEXUS_API_KEY` | **yes** | _(empty)_ | Bearer token sent to the Nexus gateway. Held server-side; never reaches the browser. With it unset, `/nexus/status` reports `configured: false` and the UI shows the "not configured" panel. |
| `NEXUS_GATEWAY_URL` | no | `https://nexus-api.dappnode.com/v1` | Base URL of the Nexus-compatible OpenAI endpoint. Override to point at a staging/self-hosted gateway. |
| `NEXUS_DEFAULT_MODEL` | no | `nexus/router` | Model used when the request body doesn't specify one. Whatever you set must be present in the gateway's `/models` list. |

Set them on the dappmanager service (`docker-compose.yml` → `services.dappmanager.environment`) and restart the container. There are no other config touchpoints — the key is read fresh from `process.env` per request, so changing it requires a container restart.

## How to test

Prerequisites: `NEXUS_API_KEY` exported in the dappmanager container's environment; container restarted.

1. **Status & model list.** Open `/ai/nexus` → header shows the model picker populated from `/nexus/models`. With `NEXUS_API_KEY` unset, the page shows the "not configured" panel and the floating bubble's panel does the same.
2. **Streaming chat.** Pick a model, send "List the packages installed on this DAppNode" → answer streams smoothly and reflects this node's actual `listPackages()` output (model called `dappnode_list_packages` under the hood).
3. **Docs grounding.** Ask "How do I set up Wireguard?" → model should call `dappnode_search_docs` then `dappnode_fetch_doc` and cite a `docs.dappnode.io/...` URL (no trailing `.md`).
4. **Mutating-tool confirmation.** Ask "restart my-package" → confirmation card renders with tool name + args. Click Deny → assistant continues with a `_skipped restart_package — …_` line. Repeat and Approve → the package is actually restarted, assistant continues.
5. **History.** Send a couple of messages, reload the page, open the history dropdown → conversation is listed and restorable. Delete it from the dropdown → entry disappears and reload confirms it's gone.
6. **Floating launcher + page context.** Navigate to `/packages`, click the bubble, ask "what is this page?" → answer references the packages page. Navigate to `/system` while the panel stays open, ask again → answer reflects the new path (the panel samples location lazily on each send).
7. **MCP from an external client.** From Claude Desktop / Cursor configured with this DAppNode's admin cookie at `POST/GET/DELETE https://<dappnode>/mcp`, list tools → matches `dappnodeToolList` from `mcp/tools.ts`. Calling `dappnode_list_packages` returns the same JSON the embedded chat sees.
8. **Override knobs.**
   - Set `NEXUS_DEFAULT_MODEL=openai/gpt-4o`, restart → header dropdown defaults to that model on fresh visits.
   - Point `NEXUS_GATEWAY_URL` at a stub server and confirm requests hit it instead of `nexus-api.dappnode.com`.
9. **Secret hygiene.** `git grep "sk-"` against the branch returns no committed API keys.
