### PR TITLE
wireguard creds fix 

### DIFF
--- a/packages/admin-ui/src/__mock-backend__/wireguard.ts
+++ b/packages/admin-ui/src/__mock-backend__/wireguard.ts
@@ -5,7 +5,11 @@ const devicesState = new Set<string>(initialDevices);
 
 export const wireguard: Pick<
   Routes,
-  "wireguardDeviceAdd" | "wireguardDeviceGet" | "wireguardDeviceRemove" | "wireguardDevicesGet"
+  | "wireguardDeviceAdd"
+  | "wireguardDeviceConfigGet"
+  | "wireguardDeviceGet"
+  | "wireguardDeviceRemove"
+  | "wireguardDevicesGet"
 > = {
   wireguardDeviceAdd: async (id) => {
     devicesState.add(id);
@@ -14,7 +18,7 @@ export const wireguard: Pick<
     devicesState.delete(id);
   },
   wireguardDevicesGet: async () => Array.from(devicesState.values()),
-  wireguardDeviceGet: async (id) => {
+  wireguardDeviceConfigGet: async ({ device: id, isLocal }) => {
     if (!devicesState.has(id)) throw Error(`No device id ${id}`);
     const configRemote = `[Interface]
 Address = 172.34.1.2
@@ -37,6 +41,11 @@ PublicKey = AAAAABBBBBAAAAABBBBBAAAAABBBBBAAAAABBBBBAAA=
 Endpoint = 192.168.1.45:51820
 AllowedIPs = 172.33.0.0/16`;
 
+    return isLocal ? configLocal : configRemote;
+  },
+  wireguardDeviceGet: async (id) => {
+    const configRemote = await wireguard.wireguardDeviceConfigGet({ device: id, isLocal: false });
+    const configLocal = await wireguard.wireguardDeviceConfigGet({ device: id, isLocal: true });
     return { configRemote, configLocal };
   }
 };

--- a/packages/admin-ui/src/pages/vpn/components/wireguard/WireguardDeviceDetails.tsx
+++ b/packages/admin-ui/src/pages/vpn/components/wireguard/WireguardDeviceDetails.tsx
@@ -16,16 +16,28 @@ import { apiRoutes } from "api";
 import { FiDownload } from "react-icons/fi";
 import { GoCopy } from "react-icons/go";
 import { FaQrcode } from "react-icons/fa";
-import { WireguardDeviceCredentials } from "@dappnode/types";
 // Utils
 import { urlJoin } from "utils/url";
 import SubTitle from "components/SubTitle";
 
-function WireguardDeviceDetailsLoaded({ id, device }: { id: string; device: WireguardDeviceCredentials }) {
+function WireguardDeviceDetailsLoaded({
+  id,
+  config,
+  showLocalCreds,
+  setShowLocalCreds,
+  isLoadingLocalConfig,
+  localConfigError
+}: {
+  id: string;
+  config: string;
+  showLocalCreds: boolean;
+  setShowLocalCreds: React.Dispatch<React.SetStateAction<boolean>>;
+  isLoadingLocalConfig?: boolean;
+  localConfigError?: Error;
+}) {
   const [showQr, setShowQr] = useState(false);
-  const [showLocalCreds, setShowLocalCreds] = useState(false);
-  const config = showLocalCreds ? device.configLocal : device.configRemote;
-  const configType = showLocalCreds ? "local" : "";
+  const isShowingLocalConfig = showLocalCreds && !isLoadingLocalConfig && !localConfigError;
+  const configType = isShowingLocalConfig ? "local" : "";
 
   useEffect(() => {
     // Activate the copy functionality
@@ -55,7 +67,7 @@ function WireguardDeviceDetailsLoaded({ id, device }: { id: string; device: Wire
         <a
           href={apiRoutes.downloadWireguardConfig({
             device: id,
-            isLocal: showLocalCreds
+            isLocal: isShowingLocalConfig
           })}
         >
           <Button>
@@ -83,6 +95,18 @@ function WireguardDeviceDetailsLoaded({ id, device }: { id: string; device: Wire
         </Button>
       </div>
 
+      {isLoadingLocalConfig && (
+        <div className="alert alert-secondary" role="alert">
+          Loading local credentials. Remote credentials are shown below.
+        </div>
+      )}
+
+      {localConfigError && (
+        <div className="alert alert-warning" role="alert">
+          Local credentials could not be loaded. Use the remote credentials shown below instead.
+        </div>
+      )}
+
       <Form.Group>
         <Form.Label>VPN {configType} credentials</Form.Label>
         <div className="credentials-config">{config}</div>
@@ -97,20 +121,53 @@ function WireguardDeviceDetailsLoaded({ id, device }: { id: string; device: Wire
   );
 }
 
+function WireguardDeviceDetailsWithLocal({
+  id,
+  configRemote,
+  setShowLocalCreds
+}: {
+  id: string;
+  configRemote: string;
+  setShowLocalCreds: React.Dispatch<React.SetStateAction<boolean>>;
+}) {
+  const localConfig = useApi.wireguardDeviceConfigGet({ device: id, isLocal: true });
+
+  return (
+    <WireguardDeviceDetailsLoaded
+      id={id}
+      config={localConfig.data || configRemote}
+      showLocalCreds={true}
+      setShowLocalCreds={setShowLocalCreds}
+      isLoadingLocalConfig={localConfig.isValidating && !localConfig.data && !localConfig.error}
+      localConfigError={localConfig.error}
+    />
+  );
+}
+
 export const WireguardDeviceDetails: React.FC = () => {
   const params = useParams();
   const id = params.id || "";
-  const device = useApi.wireguardDeviceGet(id);
+  const [showLocalCreds, setShowLocalCreds] = useState(false);
+  const config = useApi.wireguardDeviceConfigGet({ device: id, isLocal: false });
 
   return (
     <>
       <SubTitle>{id}</SubTitle>
 
-      {device.data ? (
-        <WireguardDeviceDetailsLoaded id={id} device={device.data} />
-      ) : device.error ? (
-        <ErrorView error={device.error} />
-      ) : device.isValidating ? (
+      {config.data ? (
+        showLocalCreds ? (
+          <WireguardDeviceDetailsWithLocal id={id} configRemote={config.data} setShowLocalCreds={setShowLocalCreds} />
+        ) : (
+          <WireguardDeviceDetailsLoaded
+            id={id}
+            config={config.data}
+            showLocalCreds={showLocalCreds}
+            setShowLocalCreds={setShowLocalCreds}
+          />
+        )
+      ) : config.error ? (
+        <ErrorView error={config.error} />
+      ) : config.isValidating ? (
         <Loading steps={["Loading device credentials"]} />
       ) : null}
     </>

--- a/packages/dappmanager/src/api/routes/downloadWireguardConfig.ts
+++ b/packages/dappmanager/src/api/routes/downloadWireguardConfig.ts
@@ -11,17 +11,17 @@ interface Params {
  * - /device_admin/
  */
 export const downloadWireguardConfig = wrapHandlerHtml<Params>(async (req, res) => {
-  const isLocal = req.query.local === "" || req.query.local;
+  const isLocal = req.query.local === "" || Boolean(req.query.local);
 
   const device = req.params.device;
   if (!device) throw Error(`Must provide device`);
 
-  const { configRemote, configLocal } = await calls.wireguardDeviceGet(device);
+  const config = await calls.wireguardDeviceConfigGet({ device, isLocal });
 
   const filename = `wireguard-${isLocal ? "local" : ""}config-${device}.txt`;
   const mimetype = "text/plain";
   res.setHeader("Content-disposition", "attachment; filename=" + filename);
   res.setHeader("Content-type", mimetype);
 
-  res.status(200).send(isLocal ? configLocal : configRemote);
+  res.status(200).send(config);
 });

--- a/packages/dappmanager/src/calls/wireguard.ts
+++ b/packages/dappmanager/src/calls/wireguard.ts
@@ -3,6 +3,7 @@ import { params } from "@dappnode/params";
 import { packageSetEnvironment } from "./packageSetEnvironment.js";
 import { ComposeFileEditor } from "@dappnode/dockercompose";
 import { WireguardDeviceCredentials } from "@dappnode/types";
+import { logs } from "@dappnode/logger";
 
 const { WIREGUARD_API_URL, WIREGUARD_DEVICES_ENVNAME, WIREGUARD_DNP_NAME, WIREGUARD_ISCORE, WIREGUARD_MAIN_SERVICE } =
   params;
@@ -16,7 +17,10 @@ class WireguardClient {
     const service = compose.services()[WIREGUARD_MAIN_SERVICE];
     if (!service) throw Error(`Wireguard service ${WIREGUARD_MAIN_SERVICE} does not exist`);
     const peersCsv = service.getEnvs()[WIREGUARD_DEVICES_ENVNAME] || "";
-    return peersCsv.split(",");
+    return peersCsv
+      .split(",")
+      .map((device) => device.trim())
+      .filter(Boolean);
   }
 
   async addDevice(device: string): Promise<void> {
@@ -53,15 +57,34 @@ class WireguardClient {
   // - local:     '/dappnode_admin?local'
   // - local qr:  '/dappnode_admin?local&qr'
   async getDeviceCredentials(device: string): Promise<WireguardDeviceCredentials> {
-    const url = urlJoin(WIREGUARD_API_URL, device);
-    const remoteConfigUrl = url;
-    const localConfigUrl = `${url}?local=true`;
-    const [configRemote, configLocal] = await Promise.all([
-      fetchWireguardConfigFile(remoteConfigUrl),
-      fetchWireguardConfigFile(localConfigUrl)
-    ]);
+    this.ensureDeviceExists(device);
+
+    const configRemote = await this.fetchRemoteDeviceConfig(device);
+    const configLocal = await this.fetchLocalDeviceConfig(device);
 
     return { configRemote, configLocal };
+  }
+
+  async getDeviceConfig(device: string, isLocal: boolean): Promise<string> {
+    this.ensureDeviceExists(device);
+    return isLocal ? this.fetchLocalDeviceConfig(device) : this.fetchRemoteDeviceConfig(device);
+  }
+
+  private ensureDeviceExists(device: string): void {
+    if (!this.getDevices().includes(device)) throw Error(`Device ${device} is not registered in WireGuard PEERS`);
+  }
+
+  private async fetchRemoteDeviceConfig(device: string): Promise<string> {
+    return fetchWireguardConfigFile(urlJoin(WIREGUARD_API_URL, device));
+  }
+
+  private async fetchLocalDeviceConfig(device: string): Promise<string> {
+    const url = `${urlJoin(WIREGUARD_API_URL, device)}?local=true`;
+
+    return fetchWireguardConfigFile(url).catch((e) => {
+      logs.warn(`Error fetching local WireGuard credentials for ${device}: ${e.message}`);
+      throw e;
+    });
   }
 }
 
@@ -93,6 +116,10 @@ export async function wireguardDeviceRemove(device: string): Promise<void> {
 
 export async function wireguardDeviceGet(device: string): Promise<WireguardDeviceCredentials> {
   return wireguardClient.getDeviceCredentials(device);
+}
+
+export async function wireguardDeviceConfigGet({ device, isLocal }: { device: string; isLocal: boolean }): Promise<string> {
+  return wireguardClient.getDeviceConfig(device, isLocal);
 }
 
 export async function wireguardDevicesGet(): Promise<string[]> {

--- a/packages/types/src/routes.ts
+++ b/packages/types/src/routes.ts
@@ -885,6 +885,9 @@ export interface Routes {
   /** Get credentials for a single Wireguard device */
   wireguardDeviceGet(device: string): Promise<WireguardDeviceCredentials>;
 
+  /** Get a remote or local config for a single Wireguard device */
+  wireguardDeviceConfigGet(options: { device: string; isLocal: boolean }): Promise<string>;
+
   /** Get URLs to a single Wireguard credentials */
   wireguardDevicesGet(): Promise<string[]>;
 }
@@ -1040,6 +1043,7 @@ export const routesData: { [P in keyof Routes]: RouteData } = {
   wireguardDeviceAdd: { log: true },
   wireguardDeviceRemove: { log: true },
   wireguardDeviceGet: {},
+  wireguardDeviceConfigGet: {},
   wireguardDevicesGet: {}
 };
 


### PR DESCRIPTION
This pull request refactors how WireGuard device configuration is fetched and displayed, introducing a new API route to retrieve either the remote or local configuration for a device. The UI is updated to handle loading and error states for local configs, and the backend logic is simplified and made more robust. The main changes are grouped below:

**API and Backend Enhancements:**

* Added a new API route `wireguardDeviceConfigGet` to fetch either the remote or local configuration for a WireGuard device, and updated the `Routes` interface and route data accordingly. [[1]](diffhunk://#diff-f1007f2f8b6e1bbd9b12d1bcdb26fbf6d6d6cdfd2b10f679a8865176cc962bdfR888-R890) [[2]](diffhunk://#diff-f1007f2f8b6e1bbd9b12d1bcdb26fbf6d6d6cdfd2b10f679a8865176cc962bdfR1046) [[3]](diffhunk://#diff-ec5e41716610811397ef5e823088b99f23e5944ec357f48e84a2be0ac2636760L8-R12) [[4]](diffhunk://#diff-ec5e41716610811397ef5e823088b99f23e5944ec357f48e84a2be0ac2636760L17-R21) [[5]](diffhunk://#diff-ec5e41716610811397ef5e823088b99f23e5944ec357f48e84a2be0ac2636760R44-R48) [[6]](diffhunk://#diff-e778c30b002507175f6e61d6b5ca5d56b9725c88bf6881d73c1aa8298ea4f42fR121-R124)
* Refactored backend logic to separate fetching of remote and local configs, added device existence checks, improved error handling with logging, and trimmed device names to avoid empty entries. [[1]](diffhunk://#diff-e778c30b002507175f6e61d6b5ca5d56b9725c88bf6881d73c1aa8298ea4f42fL19-R23) [[2]](diffhunk://#diff-e778c30b002507175f6e61d6b5ca5d56b9725c88bf6881d73c1aa8298ea4f42fL56-R88) [[3]](diffhunk://#diff-e778c30b002507175f6e61d6b5ca5d56b9725c88bf6881d73c1aa8298ea4f42fR6)

**Frontend/UI Improvements:**

* Updated the device details UI to use the new `wireguardDeviceConfigGet` route, allowing independent fetching of local and remote configs, and added UI feedback for loading and error states when retrieving local credentials. [[1]](diffhunk://#diff-94f6c88f8fee69279a114edba390fc44fd45264b98ec8f920fd247410f00dc8eL19-R40) [[2]](diffhunk://#diff-94f6c88f8fee69279a114edba390fc44fd45264b98ec8f920fd247410f00dc8eL58-R70) [[3]](diffhunk://#diff-94f6c88f8fee69279a114edba390fc44fd45264b98ec8f920fd247410f00dc8eR98-R109) [[4]](diffhunk://#diff-94f6c88f8fee69279a114edba390fc44fd45264b98ec8f920fd247410f00dc8eR124-R170)
* Refactored the download handler to use the new config API and improved the logic for determining if the local config should be fetched.

These changes make the WireGuard configuration retrieval more modular, robust, and user-friendly.