### PR TITLE
Banner not dissapearing fix

### DIFF
--- a/packages/daemons/src/hostReboot/index.ts
+++ b/packages/daemons/src/hostReboot/index.ts
@@ -1,13 +1,38 @@
 import { logs } from "@dappnode/logger";
 import { runAtMostEvery } from "@dappnode/utils";
 import { notifications } from "@dappnode/notifications";
-import { Category, Priority, Status } from "@dappnode/types";
+import { Category, Notification, Priority, Status } from "@dappnode/types";
 import { getRebootRequiredMemoized } from "@dappnode/hostscriptsservices";
 import { params } from "@dappnode/params";
 
 const CHECK_INTERVAL = 7 * 24 * 60 * 60 * 1000; // 7 days
+const BANNER_LOOKBACK_SECONDS = 30 * 24 * 60 * 60; // 30 days
+const CORRELATION_ID = "core-reboot-required";
 
 let notificationSent = false;
+
+export function getLatestNotificationByCorrelationId(
+  notificationList: Notification[],
+  correlationId: string
+): Notification | undefined {
+  return notificationList
+    .filter((notification) => notification.correlationId === correlationId && !notification.errors)
+    .sort((a, b) => b.timestamp - a.timestamp)[0];
+}
+
+async function getLatestRebootBannerNotification(): Promise<Notification | undefined> {
+  try {
+    const { isNotifierRunning } = await notifications.notificationsPackageStatus();
+    if (!isNotifierRunning) return undefined;
+
+    const timestamp = Math.floor(Date.now() / 1000) - BANNER_LOOKBACK_SECONDS;
+    const bannerNotifications = await notifications.getBannerNotifications(timestamp);
+    return getLatestNotificationByCorrelationId(bannerNotifications, CORRELATION_ID);
+  } catch (e) {
+    logs.warn("Error getting previous host reboot banner notification", e);
+    return undefined;
+  }
+}
 
 /**
  * Monitors if the host requires a reboot.
@@ -17,12 +42,15 @@ let notificationSent = false;
 async function monitorHostReboot(): Promise<void> {
   try {
     const rebootRequired = await getRebootRequiredMemoized();
-    const correlationId = "core-reboot-required";
+    const latestNotification = await getLatestRebootBannerNotification();
+    const isRebootNotificationActive = latestNotification
+      ? latestNotification.status === Status.triggered
+      : notificationSent;
 
     if (rebootRequired?.rebootRequired) {
       logs.warn("Host reboot is required");
 
-      if (!notificationSent) {
+      if (!isRebootNotificationActive) {
         await notifications
           .sendNotification({
             title: "DAppNode host reboot required",
@@ -37,13 +65,13 @@ async function monitorHostReboot(): Promise<void> {
             status: Status.triggered,
             isBanner: true,
             isRemote: false,
-            correlationId
+            correlationId: CORRELATION_ID
           })
           .catch((e) => logs.error("Error sending host reboot notification", e));
-        notificationSent = true;
       }
+      notificationSent = true;
     } else {
-      if (notificationSent) {
+      if (isRebootNotificationActive) {
         logs.info("Host reboot no longer required, sending resolve notification");
 
         await notifications
@@ -54,13 +82,13 @@ async function monitorHostReboot(): Promise<void> {
             category: Category.system,
             priority: Priority.low,
             status: Status.resolved,
-            isBanner: false,
+            isBanner: true,
             isRemote: false,
-            correlationId
+            correlationId: CORRELATION_ID
           })
           .catch((e) => logs.error("Error sending host reboot resolve notification", e));
-        notificationSent = false;
       }
+      notificationSent = false;
     }
   } catch (e) {
     logs.error("Error monitoring host reboot requirement", e);

--- a/packages/daemons/src/internetConnection/index.ts
+++ b/packages/daemons/src/internetConnection/index.ts
@@ -72,7 +72,7 @@ async function monitorInternetConnection(): Promise<void> {
             category: Category.system,
             priority: Priority.critical,
             status: Status.resolved,
-            isBanner: false,
+            isBanner: true,
             isRemote: false,
             correlationId
           })

--- a/packages/daemons/src/repositoryHealth/index.ts
+++ b/packages/daemons/src/repositoryHealth/index.ts
@@ -48,7 +48,7 @@ async function checkIpfsHealth(): Promise<void> {
         category: Category.system,
         priority: Priority.high,
         status: Status.resolved,
-        isBanner: false,
+        isBanner: true,
         isRemote: false,
         correlationId
       });
@@ -121,7 +121,7 @@ Syncing and access to Ethereum chain data should now resume normally.`,
         category: Category.system,
         priority: Priority.high,
         status: Status.resolved,
-        isBanner: false,
+        isBanner: true,
         isRemote: false,
         correlationId
       });

--- a/packages/daemons/test/unit/hostReboot.test.ts
+++ b/packages/daemons/test/unit/hostReboot.test.ts
@@ -1,0 +1,68 @@
+import "mocha";
+import { expect } from "chai";
+import { Category, Notification, Priority, Status } from "@dappnode/types";
+import { getLatestNotificationByCorrelationId } from "../../src/hostReboot/index.js";
+
+function notification({
+  id,
+  correlationId,
+  timestamp,
+  status = Status.triggered,
+  errors
+}: {
+  id: number;
+  correlationId: string;
+  timestamp: number;
+  status?: Status;
+  errors?: string;
+}): Notification {
+  return {
+    id,
+    timestamp,
+    title: "Notification",
+    body: "Body",
+    dnpName: "core.dnp.dappnode.eth",
+    category: Category.system,
+    priority: Priority.low,
+    status,
+    isBanner: true,
+    isRemote: false,
+    seen: false,
+    correlationId,
+    errors
+  };
+}
+
+describe("daemons > hostReboot", () => {
+  describe("getLatestNotificationByCorrelationId", () => {
+    it("returns the newest notification for the correlation id", () => {
+      const result = getLatestNotificationByCorrelationId(
+        [
+          notification({ id: 1, correlationId: "core-reboot-required", timestamp: 100 }),
+          notification({ id: 2, correlationId: "other", timestamp: 300 }),
+          notification({
+            id: 3,
+            correlationId: "core-reboot-required",
+            timestamp: 200,
+            status: Status.resolved
+          })
+        ],
+        "core-reboot-required"
+      );
+
+      expect(result?.id).to.equal(3);
+    });
+
+    it("ignores notifications with errors", () => {
+      const result = getLatestNotificationByCorrelationId(
+        [
+          notification({ id: 1, correlationId: "core-reboot-required", timestamp: 100 }),
+          notification({ id: 2, correlationId: "core-reboot-required", timestamp: 200, errors: "failed" })
+        ],
+        "core-reboot-required"
+      );
+
+      expect(result?.id).to.equal(1);
+    });
+  });
+});


### PR DESCRIPTION
This pull request improves the handling and consistency of banner notifications for system events (such as host reboot, internet connection, and repository health) in the daemon services. The main focus is on ensuring that banner notifications are managed correctly using correlation IDs, and on adding robust utilities and tests for notification management.

Key changes include:

**Host Reboot Notification Logic Improvements:**
- Added a utility function `getLatestNotificationByCorrelationId` to retrieve the most recent notification for a given correlation ID, filtering out any with errors. This helps prevent duplicate or outdated notifications.
- Updated the host reboot monitoring logic to check for existing active notifications using the new utility, ensuring only one active banner notification is sent or resolved as needed. The notification logic now consistently uses the `core-reboot-required` correlation ID. [[1]](diffhunk://#diff-32fb10cefbe0d276d38b2532ecd649616596beba537723f62fe215279cd6fd31L20-R53) [[2]](diffhunk://#diff-32fb10cefbe0d276d38b2532ecd649616596beba537723f62fe215279cd6fd31L40-R74) [[3]](diffhunk://#diff-32fb10cefbe0d276d38b2532ecd649616596beba537723f62fe215279cd6fd31L57-R91)

**Banner Notification Consistency:**
- Changed resolved notifications for internet connection and repository health events to set `isBanner: true`, ensuring these resolved notifications are also displayed as banners for user visibility. [[1]](diffhunk://#diff-2d634f47a35c2e2eefc2ef99768f6ee72a2aeb5e54fa996f9f9abc2607c6acdbL75-R75) [[2]](diffhunk://#diff-fba40a1bcabf2493b1b0aeaa171ae8e87dab3c41098c7509df752c08aff563f6L51-R51) [[3]](diffhunk://#diff-fba40a1bcabf2493b1b0aeaa171ae8e87dab3c41098c7509df752c08aff563f6L124-R124)

**Testing and Utilities:**
- Added unit tests for `getLatestNotificationByCorrelationId` to verify correct selection of the latest valid notification and proper handling of notifications with errors.