### PR TITLE
feat(mcp): allow passing options to dappnode_update_package

### DIFF
--- a/packages/dappmanager/src/mcp/tools.ts
+++ b/packages/dappmanager/src/mcp/tools.ts
@@ -408,9 +408,24 @@ const updatePackageTool: DappnodeTool = {
   mutating: true,
   schema: {
     dnpName: z.string().min(1).describe("The package dnpName to update"),
-    version: z.string().optional().describe("Optional target version (semver or IPFS hash). Defaults to latest.")
+    version: z.string().optional().describe("Optional target version (semver or IPFS hash). Defaults to latest."),
+    options: z
+      .object({
+        BYPASS_RESOLVER: z.boolean().optional(),
+        BYPASS_CORE_RESTRICTION: z.boolean().optional()
+      })
+      .optional()
+      .describe("Advanced update flags. Omit unless the user explicitly asked for them.")
   },
-  async execute({ dnpName, version }: { dnpName: string; version?: string }) {
+  async execute({
+    dnpName,
+    version,
+    options
+  }: {
+    dnpName: string;
+    version?: string;
+    options?: { BYPASS_RESOLVER?: boolean; BYPASS_CORE_RESTRICTION?: boolean };
+  }) {
     logs.info(`MCP: dappnode_update_package(${dnpName}, ${version ?? "latest"})`);
     const { packageInstall } = await import("../calls/packageInstall.js");
     await packageInstall({
@@ -418,7 +433,7 @@ const updatePackageTool: DappnodeTool = {
       version,
       userSettings: {},
       notificationsSettings: {},
-      options: {}
+      options: options ?? {}
     });
     return { ok: true, dnpName, version: version ?? "latest" };
   }

--- a/packages/dappmanager/src/mcp/tools.ts
+++ b/packages/dappmanager/src/mcp/tools.ts
@@ -412,7 +412,8 @@ const updatePackageTool: DappnodeTool = {
     options: z
       .object({
         BYPASS_RESOLVER: z.boolean().optional(),
-        BYPASS_CORE_RESTRICTION: z.boolean().optional()
+        BYPASS_CORE_RESTRICTION: z.boolean().optional(),
+        BYPASS_SIGNED_RESTRICTION: z.boolean().optional()
       })
       .optional()
       .describe("Advanced update flags. Omit unless the user explicitly asked for them.")
@@ -424,7 +425,7 @@ const updatePackageTool: DappnodeTool = {
   }: {
     dnpName: string;
     version?: string;
-    options?: { BYPASS_RESOLVER?: boolean; BYPASS_CORE_RESTRICTION?: boolean };
+    options?: { BYPASS_RESOLVER?: boolean; BYPASS_CORE_RESTRICTION?: boolean; BYPASS_SIGNED_RESTRICTION?: boolean };
   }) {
     logs.info(`MCP: dappnode_update_package(${dnpName}, ${version ?? "latest"})`);
     const { packageInstall } = await import("../calls/packageInstall.js");
@@ -1061,7 +1062,8 @@ const installPackageTool: DappnodeTool = {
     options: z
       .object({
         BYPASS_RESOLVER: z.boolean().optional(),
-        BYPASS_CORE_RESTRICTION: z.boolean().optional()
+        BYPASS_CORE_RESTRICTION: z.boolean().optional(),
+        BYPASS_SIGNED_RESTRICTION: z.boolean().optional()
       })
       .optional()
       .describe("Advanced install flags. Omit unless the user explicitly asked for them.")
@@ -1075,7 +1077,11 @@ const installPackageTool: DappnodeTool = {
     name: string;
     version?: string;
     userSettings?: UserSettingsAllDnps;
-    options?: { BYPASS_RESOLVER?: boolean; BYPASS_CORE_RESTRICTION?: boolean };
+    options?: {
+      BYPASS_RESOLVER?: boolean;
+      BYPASS_CORE_RESTRICTION?: boolean;
+      BYPASS_SIGNED_RESTRICTION?: boolean;
+    };
   }) {
     logs.info(`MCP: dappnode_install_package(${name}, ${version ?? "latest"})`);
     const { packageInstall } = await import("../calls/packageInstall.js");


### PR DESCRIPTION
## Context

`dappnode_install_package` already accepts an `options` field (`BYPASS_RESOLVER`, `BYPASS_CORE_RESTRICTION`) that gets forwarded to `packageInstall`. `dappnode_update_package` re-runs the **same** `packageInstall` flow under the hood, but its MCP schema silently dropped the field, defaulting `options` to `{}` and making advanced update flags unreachable for MCP clients.

## Approach

Mirror the install tool's options schema on `dappnode_update_package`:

- Added `options: { BYPASS_RESOLVER?, BYPASS_CORE_RESTRICTION? }` (both optional) to the Zod schema, with the same description used on the install tool.
- Forwarded `options ?? {}` into the `packageInstall` call instead of the hard-coded `{}`.
- Updated the `execute` signature to type the new field.

Default behavior is unchanged when `options` is omitted.

## Test instructions

1. `yarn build` (or at least type-check `packages/dappmanager`).
2. Inspect `packages/dappmanager/src/mcp/tools.ts` — the `updatePackageTool` schema now exposes `options`, and `execute` forwards it to `packageInstall`.
3. Smoke-test via MCP: call `dappnode_update_package` with `dnpName` only (no `options`) — should behave exactly as before.
4. Call it again with `options: { BYPASS_CORE_RESTRICTION: true }` on a core package — should accept the flag and update without erroring out at the core restriction check.