### PR TITLE
Allow versionless Docker Compose files

### DIFF
--- a/packages/dockerCompose/src/clean.ts
+++ b/packages/dockerCompose/src/clean.ts
@@ -11,7 +11,7 @@ import { Compose } from "@dappnode/types";
  */
 export function cleanCompose(compose: Compose): Compose {
   return {
-    version: compose.version,
+    ...(compose.version === undefined ? {} : { version: compose.version }),
     ...omitBy(compose, isOmitable),
     services: mapValues(compose.services, (service) => ({
       ...omitBy(service, isOmitable),

--- a/packages/dockerCompose/src/compose_v3x.schema.json
+++ b/packages/dockerCompose/src/compose_v3x.schema.json
@@ -1,7 +1,7 @@
 {
   "title": "compose",
   "type": "object",
-  "required": ["version"],
+  "required": ["services"],
   "properties": {
     "version": { "type": "string" },
 

--- a/packages/dockerCompose/src/setDappnodeComposeDefaults.ts
+++ b/packages/dockerCompose/src/setDappnodeComposeDefaults.ts
@@ -13,7 +13,6 @@ import {
   dockerComposeSafeKeys,
   Manifest
 } from "@dappnode/types";
-import { lt } from "semver";
 
 /**
  * Returns the compose file for the given manifest
@@ -25,7 +24,7 @@ export function setDappnodeComposeDefaults(composeUnsafe: Compose, manifest: Man
   const isMonoService = getIsMonoService(composeUnsafe);
 
   return cleanCompose({
-    version: ensureMinimumComposeVersion(composeUnsafe.version),
+    version: composeUnsafe.version,
 
     services: mapValues(composeUnsafe.services, (serviceUnsafe, serviceName) => {
       return sortServiceKeys({
@@ -66,21 +65,6 @@ export function setDappnodeComposeDefaults(composeUnsafe: Compose, manifest: Man
 
     networks: setNetworks(composeUnsafe.networks)
   });
-}
-
-/**
- * TEMPORARY: Ensure the compose version is at least 3.5. This will be eventually removed
- * and the SDK will not allow to build packages with older compose version than 3.5.
- * See https://github.com/dappnode/DAppNodeSDK/issues/241
- *
- * Use of new compose feature "name" only available in version 3.5
- * https://docs.docker.com/compose/compose-file/compose-file-v3/#name-1
- */
-function ensureMinimumComposeVersion(composeFileVersion: string): string {
-  if (lt(composeFileVersion + ".0", params.MINIMUM_COMPOSE_VERSION + ".0"))
-    composeFileVersion = params.MINIMUM_COMPOSE_VERSION;
-
-  return composeFileVersion;
 }
 
 /**

--- a/packages/dockerCompose/test/unit/setDappnodeComposeDefaults.test.ts
+++ b/packages/dockerCompose/test/unit/setDappnodeComposeDefaults.test.ts
@@ -5,6 +5,49 @@ import { Compose, Manifest } from "@dappnode/types";
 import { setDappnodeComposeDefaults } from "../../src/index.js";
 
 describe("setDappnodeComposeDefaults", () => {
+  it("Should not add a version to a versionless compose", () => {
+    const compose: Compose = {
+      services: {
+        serviceA: {
+          image: "some.image:1.0.0"
+        }
+      }
+    };
+    const manifest: Manifest = {
+      name: "some.dnp.dappnode.eth",
+      version: "1.0.0",
+      description: "Test package",
+      type: "service",
+      license: "GPL-3.0"
+    };
+
+    const composeWithDefaults = setDappnodeComposeDefaults(compose, manifest);
+
+    expect(composeWithDefaults).to.not.have.property("version");
+  });
+
+  it("Should preserve a legacy compose version", () => {
+    const compose: Compose = {
+      version: "2",
+      services: {
+        serviceA: {
+          image: "some.image:1.0.0"
+        }
+      }
+    };
+    const manifest: Manifest = {
+      name: "some.dnp.dappnode.eth",
+      version: "1.0.0",
+      description: "Test package",
+      type: "service",
+      license: "GPL-3.0"
+    };
+
+    const composeWithDefaults = setDappnodeComposeDefaults(compose, manifest);
+
+    expect(composeWithDefaults.version).to.equal("2");
+  });
+
   it("Should set dappnode defaults to a validated compose from a non-core package", () => {
     const compose: Compose = {
       version: "3.5",

--- a/packages/dockerCompose/test/unit/validate.test.ts
+++ b/packages/dockerCompose/test/unit/validate.test.ts
@@ -10,6 +10,17 @@ describe("validateCompose", () => {
     expect(validateCompose(compose)).to.deep.equal(compose);
   });
 
+  it("Should validate a compose without a version", () => {
+    const compose = { ...mockCompose };
+    delete compose.version;
+    expect(validateCompose(compose)).to.deep.equal(compose);
+  });
+
+  it("Should validate a compose with a legacy version", () => {
+    const compose: Compose = { ...mockCompose, version: "2" };
+    expect(validateCompose(compose)).to.deep.equal(compose);
+  });
+
   it("Should reject an empty compose", () => {
     expect(function () {
       validateCompose({} as Compose);

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -37,7 +37,6 @@
   },
   "dependencies": {
     "@dappnode/types": "^0.1.40",
-    "ajv": "^8.17.1",
-    "semver": "^7.5.0"
+    "ajv": "^8.17.1"
   }
 }

--- a/packages/schemas/src/params.ts
+++ b/packages/schemas/src/params.ts
@@ -29,6 +29,5 @@ export const dockerParams = {
     "bind.dappnode"
   ],
   DNS_SERVICE: "172.33.1.2",
-  MINIMUM_COMPOSE_FILE_VERSION: "3.4",
   SKIP_COMPOSE_VALIDATION: /true/i.test(process.env.SKIP_COMPOSE_VALIDATION || "")
 };

--- a/packages/schemas/src/validateDappnodeCompose.ts
+++ b/packages/schemas/src/validateDappnodeCompose.ts
@@ -1,4 +1,3 @@
-import semver from "semver";
 import { Compose, ComposeService, Manifest, dockerComposeSafeKeys } from "@dappnode/types";
 import { dockerParams } from "./params.js";
 
@@ -28,7 +27,6 @@ export function validateDappnodeCompose(compose: Compose, manifest: Manifest): v
 
   // COMPOSE TOP LEVEL restrictions
 
-  validateComposeVersion(compose);
   validateComposeNetworks(compose);
 
   // SERVICE LEVEL restrictions
@@ -41,16 +39,6 @@ export function validateDappnodeCompose(compose: Compose, manifest: Manifest): v
 
   if (aggregatedError.length > 0)
     throw Error(`Error validating compose file with dappnode requirements:\n\n${aggregatedError.join("\n")}`);
-}
-
-/**
- * Ensures the docker compose version is supported
- */
-function validateComposeVersion(compose: Compose): void {
-  if (semver.lt(compose.version + ".0", dockerParams.MINIMUM_COMPOSE_FILE_VERSION + ".0"))
-    err(
-      `Compose version ${compose.version} is not supported. Minimum version is ${dockerParams.MINIMUM_COMPOSE_FILE_VERSION}`
-    );
 }
 
 /**

--- a/packages/schemas/test/unit/validateDappnodeCompose.test.ts
+++ b/packages/schemas/test/unit/validateDappnodeCompose.test.ts
@@ -107,6 +107,12 @@ describe("files / compose / validateDappnodeCompose", () => {
     validateDappnodeCompose(compose, manifest);
   });
 
+  it("Should validate a compose file without a version", () => {
+    const composeWithoutVersion = { ...compose };
+    delete composeWithoutVersion.version;
+    validateDappnodeCompose(composeWithoutVersion, manifest);
+  });
+
   it("Should throw an error due to unsafe networks", () => {
     expect(() =>
       validateDappnodeCompose(
@@ -166,18 +172,8 @@ service validator volume /var/run/docker.sock:/var/run/docker.sock is a bind-mou
 service validator has key credential_spec that is not allowed. Allowed keys are: cap_add,cap_drop,command,depends_on,devices,entrypoint,environment,expose,extra_hosts,healthcheck,labels,logging,network_mode,networks,ports,privileged,restart,stop_grace_period,stop_signal,user,volumes,working_dir,security_opt,image,build,volumes,environment`);
   });
 
-  it("Should throw an error due to unsafe compose version", () => {
-    expect(() =>
-      validateDappnodeCompose(
-        {
-          ...compose,
-          version: "3.3"
-        },
-        manifest
-      )
-    ).to.throw(`Error validating compose file with dappnode requirements:
-
-Compose version 3.3 is not supported. Minimum version is 3.4`);
+  it("Should validate a compose file with a legacy version", () => {
+    validateDappnodeCompose({ ...compose, version: "2" }, manifest);
   });
 
   it("Should throw an error due to unsafe service networks in string format", () => {
@@ -231,12 +227,12 @@ service validator has the network danger_network with reserved docker alias. Ali
 service validator has a non-whitelisted docker network: other_network. Only docker networks dncore_network,dnpublic_network are allowed`);
   });
 
-  it("Should throw an error due to unsafe compose version and unsafe volumes", () => {
+  it("Should only reject unsafe volumes when a legacy compose version is present", () => {
     expect(() =>
       validateDappnodeCompose(
         {
           ...compose,
-          version: "3.3",
+          version: "2",
           services: {
             ...compose.services,
             validator: {
@@ -249,7 +245,6 @@ service validator has a non-whitelisted docker network: other_network. Only dock
       )
     ).to.throw(`Error validating compose file with dappnode requirements:
 
-Compose version 3.3 is not supported. Minimum version is 3.4
 service validator volume /var/run/docker.sock:/var/run/docker.sock is a bind-mount, only named non-external volumes are allowed`);
   });
 });

--- a/packages/types/src/compose.ts
+++ b/packages/types/src/compose.ts
@@ -124,7 +124,8 @@ export interface ComposeNetwork {
 }
 
 export interface Compose {
-  version: string; // "3.4"
+  /** Obsolete in the Compose Specification, but accepted for backwards compatibility. */
+  version?: string; // "3.4"
   // dnpName: "dappmanager.dnp.dappnode.eth"
   services: {
     [dnpName: string]: ComposeService;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1551,7 +1551,6 @@ __metadata:
     "@types/mocha": "npm:^10"
     ajv: "npm:^8.17.1"
     mocha: "npm:^10.7.0"
-    semver: "npm:^7.5.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Context

The Compose Specification no longer requires the top-level version field. DAppNode currently rejects versionless Compose files and enforces or rewrites legacy versions.

## Approach

- Make the Compose version field optional while continuing to accept it as a string.
- Require services in the bundled schema instead of version.
- Remove minimum-version validation and automatic version upgrades.
- Preserve legacy version fields when they are present and keep versionless files versionless.
- Add coverage for versionless and legacy Compose files.

## Test instructions

1. Run the Docker Compose unit tests:

    yarn workspace @dappnode/dockercompose test

2. Run the DAppNode Compose validation tests:

    yarn workspace @dappnode/schemas test

3. Verify a Compose file without version is accepted, and a file with version: 2 remains accepted and preserves the field.