### PR TITLE
Support multiple IPFS gateways with ordered failover

### DIFF
--- a/packages/admin-ui/src/__mock-backend__/index.ts
+++ b/packages/admin-ui/src/__mock-backend__/index.ts
@@ -262,7 +262,7 @@ export const otherCalls: Omit<Routes, keyof typeof namedSpacedCalls> = {
   ipfsClientTargetSet: async () => {},
   ipfsClientTargetGet: async () => ({
     ipfsClientTarget: IpfsClientTarget.remote,
-    ipfsGateway: "https://ipfs-gateway.dappnode.net"
+    ipfsGateway: ["https://ipfs-gateway.dappnode.net"]
   }),
   mirrorProviderGet: async () => ({ enabled: false }),
   mirrorProviderSet: async () => {},

--- a/packages/admin-ui/src/components/IpfsClient.tsx
+++ b/packages/admin-ui/src/components/IpfsClient.tsx
@@ -40,9 +40,9 @@ export function IpfsClient({
   localRequiresInstall = false
 }: {
   clientTarget: IpfsClientTarget | null;
-  gatewayTarget: string | null;
+  gatewayTarget: string[] | null;
   onClientTargetChange: (newTarget: IpfsClientTarget) => void;
-  onGatewayTargetChange: (newTarget: string) => void;
+  onGatewayTargetChange: (newTarget: string[]) => void;
   localRequiresInstall?: boolean;
 }) {
   return (
@@ -75,12 +75,43 @@ export function IpfsClient({
                 </div>
               ) : null}
 
-              {option === "remote" && (
-                <Input
-                  placeholder="https://ipfs-gateway.dappnode.net"
-                  value={gatewayTarget || ""}
-                  onValueChange={onGatewayTargetChange}
-                />
+              {option === "remote" && gatewayTarget && (
+                <div className="ipfs-gateway-list">
+                  {gatewayTarget.map((gateway, index) => (
+                    <Input
+                      key={index}
+                      placeholder="https://ipfs-gateway.dappnode.net"
+                      value={gateway}
+                      onValueChange={(value) =>
+                        onGatewayTargetChange(
+                          gatewayTarget.map((currentGateway, currentIndex) =>
+                            currentIndex === index ? value : currentGateway
+                          )
+                        )
+                      }
+                      append={
+                        gatewayTarget.length > 1 ? (
+                          <button
+                            type="button"
+                            className="btn btn-outline-secondary"
+                            aria-label={`Remove gateway ${index + 1}`}
+                            onClick={() => onGatewayTargetChange(gatewayTarget.filter((_, i) => i !== index))}
+                          >
+                            Remove
+                          </button>
+                        ) : undefined
+                      }
+                    />
+                  ))}
+                  <button
+                    type="button"
+                    className="btn btn-outline-secondary"
+                    onClick={() => onGatewayTargetChange([...gatewayTarget, ""])}
+                  >
+                    Add gateway
+                  </button>
+                  <div className="description">Gateways are tried from top to bottom.</div>
+                </div>
               )}
             </Card>
           );

--- a/packages/admin-ui/src/components/multiClient.scss
+++ b/packages/admin-ui/src/components/multiClient.scss
@@ -99,6 +99,10 @@
 .ipfs-gateway-list {
   display: grid;
   gap: 0.5rem;
+
+  input::placeholder {
+    opacity: 0.35;
+  }
 }
 
 .eth-multi-clients-and-fallback {

--- a/packages/admin-ui/src/components/multiClient.scss
+++ b/packages/admin-ui/src/components/multiClient.scss
@@ -55,7 +55,10 @@
       color: var(--dappnode-color);
     }
   }
-  transition: color 0.15s, background-color 0.15s, border-color 0.15s,
+  transition:
+    color 0.15s,
+    background-color 0.15s,
+    border-color 0.15s,
     box-shadow 0.15s;
 }
 
@@ -91,6 +94,11 @@
     font-size: var(--eth-multi-client-description-font-size);
     color: var(--eth-multi-client-description-color);
   }
+}
+
+.ipfs-gateway-list {
+  display: grid;
+  gap: 0.5rem;
 }
 
 .eth-multi-clients-and-fallback {

--- a/packages/admin-ui/src/pages/system/components/Ipfs/IpfsNode.tsx
+++ b/packages/admin-ui/src/pages/system/components/Ipfs/IpfsNode.tsx
@@ -20,7 +20,7 @@ export default function IpfsNode({
 }) {
   const ipfsRepository = useApi.ipfsClientTargetGet();
   const [ipfsClientTarget, setIpfsClientTarget] = useState<IpfsClientTarget | null>(null);
-  const [ipfsGatewayTarget, setIpfsGatewayTarget] = useState<string | null>(null);
+  const [ipfsGatewayTarget, setIpfsGatewayTarget] = useState<string[] | null>(null);
 
   useEffect(() => {
     if (ipfsRepository.data) setIpfsClientTarget(ipfsRepository.data.ipfsClientTarget);
@@ -28,7 +28,7 @@ export default function IpfsNode({
   }, [ipfsRepository.data]);
 
   async function changeIpfsClient() {
-    if (!ipfsClientTarget || !ipfsGatewayTarget) return;
+    if (!ipfsClientTarget || !ipfsGatewayTarget || ipfsGatewayTarget.every((gateway) => !gateway.trim())) return;
 
     const switchingFromRemoteToLocal =
       ipfsRepository.data?.ipfsClientTarget === IpfsClientTarget.remote && ipfsClientTarget === IpfsClientTarget.local;
@@ -61,7 +61,7 @@ export default function IpfsNode({
         api.ipfsClientTargetSet({
           ipfsRepository: {
             ipfsClientTarget: ipfsClientTarget,
-            ipfsGateway: ipfsGatewayTarget
+            ipfsGateway: ipfsGatewayTarget.map((gateway) => gateway.trim()).filter(Boolean)
           }
         }),
       {
@@ -104,7 +104,7 @@ export default function IpfsNode({
                 disabled={
                   !ipfsClientTarget ||
                   (ipfsRepository.data.ipfsClientTarget === ipfsClientTarget &&
-                    ipfsRepository.data.ipfsGateway === ipfsGatewayTarget)
+                    JSON.stringify(ipfsRepository.data.ipfsGateway) === JSON.stringify(ipfsGatewayTarget))
                 }
               >
                 Change

--- a/packages/daemons/src/repositoryHealth/index.ts
+++ b/packages/daemons/src/repositoryHealth/index.ts
@@ -3,7 +3,7 @@ import { runAtMostEvery } from "@dappnode/utils";
 import { notifications } from "@dappnode/notifications";
 import { Category, Priority, Status } from "@dappnode/types";
 import * as db from "@dappnode/db";
-import { getIpfsUrl } from "@dappnode/installer";
+import { getIpfsUrls } from "@dappnode/installer";
 import { params } from "@dappnode/params";
 import { eventBus } from "@dappnode/eventbus";
 
@@ -16,27 +16,36 @@ let ethNotificationSent = false;
 
 async function checkIpfsHealth(): Promise<void> {
   const ipfsClientTarget = db.ipfsClientTarget.get();
-  const ipfsUrl = getIpfsUrl();
-
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 10_000);
+  const ipfsUrls = getIpfsUrls();
 
   const correlationId = "core-ipfs-check";
 
   try {
     // check health by fetching CID of empty directory QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn. Most of ipfs nodes should have it.
     // checked against: https://ipfs.io https://gateway-dev.ipfs.dappnode.io https://ipfs-gateway.dappnode.net
-    const res = await fetch(`${ipfsUrl}/ipfs/QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn`, {
-      method: "GET",
-      headers: { "Content-Type": "application/json" },
-      signal: controller.signal
-    });
+    let healthyUrl: string | undefined;
+    const errors: string[] = [];
+    for (const ipfsUrl of ipfsUrls) {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 10_000);
+      try {
+        const res = await fetch(`${ipfsUrl}/ipfs/QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn`, {
+          method: "GET",
+          headers: { "Content-Type": "application/json" },
+          signal: controller.signal
+        });
+        if (!res.ok) throw new Error(`Status ${res.status}`);
+        healthyUrl = ipfsUrl;
+        break;
+      } catch (error) {
+        errors.push(`${ipfsUrl}: ${error}`);
+      } finally {
+        clearTimeout(timeout);
+      }
+    }
+    if (!healthyUrl) throw new Error(errors.join("; "));
 
-    clearTimeout(timeout);
-
-    if (!res.ok) throw new Error(`Status ${res.status}`);
-
-    logs.info(`IPFS endpoint (${ipfsClientTarget}) at ${ipfsUrl} is healthy`);
+    logs.info(`IPFS endpoint (${ipfsClientTarget}) at ${healthyUrl} is healthy`);
 
     // reset failure count on success
     ipfsFailureCount = 0;
@@ -55,8 +64,7 @@ async function checkIpfsHealth(): Promise<void> {
       ipfsNotificationSent = false;
     }
   } catch (error) {
-    clearTimeout(timeout);
-    logs.error(`IPFS endpoint (${ipfsClientTarget}) at ${ipfsUrl} is unhealthy: ${error}`);
+    logs.error(`IPFS endpoints (${ipfsClientTarget}) at ${ipfsUrls.join(", ")} are unhealthy: ${error}`);
 
     // increment failure count and send notification after threshold
     ipfsFailureCount += 1;
@@ -64,7 +72,7 @@ async function checkIpfsHealth(): Promise<void> {
       await notifications.sendNotification({
         title: "Your Dappnode IPFS endpoint is not resolving content correctly.",
         dnpName: params.dappmanagerDnpName,
-        body: `Dappnode IPFS endpoint (${ipfsClientTarget}) at ${ipfsUrl} is currently unreachable or not resolving content correctly. This may affect access to decentralized content or applications relying on IPFS.`,
+        body: `Dappnode IPFS endpoints (${ipfsClientTarget}) at ${ipfsUrls.join(", ")} are currently unreachable or not resolving content correctly. This may affect access to decentralized content or applications relying on IPFS.`,
         category: Category.system,
         priority: Priority.high,
         status: Status.triggered,

--- a/packages/dappmanager/src/calls/ipfsClientTargetGet.ts
+++ b/packages/dappmanager/src/calls/ipfsClientTargetGet.ts
@@ -2,9 +2,8 @@ import * as db from "@dappnode/db";
 import { IpfsRepository } from "@dappnode/types";
 
 export async function ipfsClientTargetGet(): Promise<IpfsRepository> {
-  const storedGateway = db.ipfsGateway.get();
   return {
     ipfsClientTarget: db.ipfsClientTarget.get(),
-    ipfsGateway: Array.isArray(storedGateway) ? storedGateway : [storedGateway]
+    ipfsGateway: db.getIpfsGateways()
   };
 }

--- a/packages/dappmanager/src/calls/ipfsClientTargetGet.ts
+++ b/packages/dappmanager/src/calls/ipfsClientTargetGet.ts
@@ -2,8 +2,9 @@ import * as db from "@dappnode/db";
 import { IpfsRepository } from "@dappnode/types";
 
 export async function ipfsClientTargetGet(): Promise<IpfsRepository> {
+  const storedGateway = db.ipfsGateway.get();
   return {
     ipfsClientTarget: db.ipfsClientTarget.get(),
-    ipfsGateway: db.ipfsGateway.get()
+    ipfsGateway: Array.isArray(storedGateway) ? storedGateway : [storedGateway]
   };
 }

--- a/packages/dappmanager/src/calls/ipfsClientTargetSet.ts
+++ b/packages/dappmanager/src/calls/ipfsClientTargetSet.ts
@@ -23,23 +23,31 @@ export async function ipfsClientTargetSet({ ipfsRepository }: { ipfsRepository: 
  * @param nextTarget "local" | "remote"
  * @param nextGateway Gateway endpoint to be used by remote node. By default dappnode gateway
  */
-async function changeIpfsClient(nextTarget: IpfsClientTarget, nextGateway?: string): Promise<void> {
+async function changeIpfsClient(nextTarget: IpfsClientTarget, nextGateway?: string[]): Promise<void> {
   try {
     // Return if targets and gateways are equal
     const currentTarget = db.ipfsClientTarget.get();
     const currentGateway = db.ipfsGateway.get();
-    if (currentTarget === nextTarget && currentGateway === nextGateway) return;
+    if (currentTarget === nextTarget && JSON.stringify(currentGateway) === JSON.stringify(nextGateway)) return;
 
     if (nextTarget === IpfsClientTarget.local) {
       db.ipfsClientTarget.set(IpfsClientTarget.local);
       dappnodeInstaller.changeIpfsGatewayUrl(params.IPFS_LOCAL);
     } else {
       // Set new values in db
-      db.ipfsGateway.set(nextGateway || params.IPFS_GATEWAY);
+      const gateways = (nextGateway || []).map((gateway) => gateway.trim()).filter(Boolean);
+      if (gateways.length === 0) throw new Error("At least one remote IPFS gateway is required");
+      for (const gateway of gateways) {
+        const protocol = new URL(gateway).protocol;
+        if (protocol !== "http:" && protocol !== "https:") {
+          throw new Error(`IPFS gateway must use HTTP or HTTPS: ${gateway}`);
+        }
+      }
+      db.ipfsGateway.set(gateways);
       db.ipfsClientTarget.set(IpfsClientTarget.remote);
 
       // Change IPFS host
-      dappnodeInstaller.changeIpfsGatewayUrl(db.ipfsGateway.get());
+      dappnodeInstaller.changeIpfsGatewayUrl(gateways);
     }
   } catch (e) {
     throw Error(`Error changing ipfs client to ${nextTarget}, ${e}`);

--- a/packages/dappmanager/src/calls/ipfsClientTargetSet.ts
+++ b/packages/dappmanager/src/calls/ipfsClientTargetSet.ts
@@ -27,7 +27,7 @@ async function changeIpfsClient(nextTarget: IpfsClientTarget, nextGateway?: stri
   try {
     // Return if targets and gateways are equal
     const currentTarget = db.ipfsClientTarget.get();
-    const currentGateway = db.ipfsGateway.get();
+    const currentGateway = db.getIpfsGateways();
     if (currentTarget === nextTarget && JSON.stringify(currentGateway) === JSON.stringify(nextGateway)) return;
 
     if (nextTarget === IpfsClientTarget.local) {
@@ -43,7 +43,7 @@ async function changeIpfsClient(nextTarget: IpfsClientTarget, nextGateway?: stri
           throw new Error(`IPFS gateway must use HTTP or HTTPS: ${gateway}`);
         }
       }
-      db.ipfsGateway.set(gateways);
+      db.setIpfsGateways(gateways);
       db.ipfsClientTarget.set(IpfsClientTarget.remote);
 
       // Change IPFS host

--- a/packages/dappmanager/src/index.ts
+++ b/packages/dappmanager/src/index.ts
@@ -8,7 +8,7 @@ import {
   copyHostServices,
   copyHostTimers
 } from "@dappnode/hostscriptsservices";
-import { DappnodeInstaller, getIpfsUrl, postRestartPatch } from "@dappnode/installer";
+import { DappnodeInstaller, getIpfsUrls, postRestartPatch } from "@dappnode/installer";
 import * as calls from "./calls/index.js";
 import { routesLogger, subscriptionsLogger, logs } from "@dappnode/logger";
 import * as routes from "./api/routes/index.js";
@@ -47,11 +47,11 @@ initializeDb()
   .then(() => logs.info("Initialized Database"))
   .catch((e) => logs.error("Error inititializing Database", e));
 
-let ipfsUrl = params.IPFS_LOCAL;
+let ipfsUrls = [params.IPFS_LOCAL];
 try {
-  ipfsUrl = getIpfsUrl(); // Attempt to update with value from getIpfsUrl
+  ipfsUrls = getIpfsUrls();
 } catch (e) {
-  logs.error(`Error getting ipfsUrl: ${e.message}. Using default: ${ipfsUrl}`);
+  logs.error(`Error getting IPFS URLs: ${e.message}. Using default: ${ipfsUrls}`);
 }
 
 // Read and print version data
@@ -75,7 +75,7 @@ const providers = new MultiUrlJsonRpcProvider(
 
 // Required db to be initialized
 export const directory = new DappNodeDirectory(providers);
-export const dappnodeInstaller = new DappnodeInstaller(ipfsUrl, providers);
+export const dappnodeInstaller = new DappnodeInstaller(ipfsUrls, providers);
 
 export const publicRegistry = new DappNodeRegistry("public");
 

--- a/packages/dappmanager/src/initializeDb.ts
+++ b/packages/dappmanager/src/initializeDb.ts
@@ -47,7 +47,6 @@ export async function initializeDb(): Promise<void> {
     if (!ipfsContainer) {
       logs.info("IPFS package not found, setting ipfsClientTarget to remote");
       db.ipfsClientTarget.set(IpfsClientTarget.remote);
-      db.ipfsGateway.set([params.IPFS_REMOTE]);
     } else {
       const ipfsClientTarget = db.ipfsClientTarget.get();
       if (!ipfsClientTarget) {
@@ -64,10 +63,10 @@ export async function initializeDb(): Promise<void> {
    * Migrate ipfs remote gateway endpoint from http://ipfs.dappnode.io:8081 to https://ipfs.gateway.dappnode.io
    * The endpoint http://ipfs.dappnode.io:8081 is being deprecated
    */
-  const storedIpfsGateway = db.ipfsGateway.get();
-  if (typeof storedIpfsGateway === "string") {
-    db.ipfsGateway.set([storedIpfsGateway === "http://ipfs.dappnode.io:8081" ? params.IPFS_REMOTE : storedIpfsGateway]);
-  }
+  const storedIpfsGateways = db.getIpfsGateways();
+  db.setIpfsGateways(
+    storedIpfsGateways.map((gateway) => (gateway === "http://ipfs.dappnode.io:8081" ? params.IPFS_REMOTE : gateway))
+  );
 
   /**
    * Initialize telegram notifications settings

--- a/packages/dappmanager/src/initializeDb.ts
+++ b/packages/dappmanager/src/initializeDb.ts
@@ -47,7 +47,7 @@ export async function initializeDb(): Promise<void> {
     if (!ipfsContainer) {
       logs.info("IPFS package not found, setting ipfsClientTarget to remote");
       db.ipfsClientTarget.set(IpfsClientTarget.remote);
-      db.ipfsGateway.set(params.IPFS_REMOTE);
+      db.ipfsGateway.set([params.IPFS_REMOTE]);
     } else {
       const ipfsClientTarget = db.ipfsClientTarget.get();
       if (!ipfsClientTarget) {
@@ -64,7 +64,10 @@ export async function initializeDb(): Promise<void> {
    * Migrate ipfs remote gateway endpoint from http://ipfs.dappnode.io:8081 to https://ipfs.gateway.dappnode.io
    * The endpoint http://ipfs.dappnode.io:8081 is being deprecated
    */
-  if (db.ipfsGateway.get() === "http://ipfs.dappnode.io:8081") db.ipfsGateway.set(params.IPFS_REMOTE);
+  const storedIpfsGateway = db.ipfsGateway.get();
+  if (typeof storedIpfsGateway === "string") {
+    db.ipfsGateway.set([storedIpfsGateway === "http://ipfs.dappnode.io:8081" ? params.IPFS_REMOTE : storedIpfsGateway]);
+  }
 
   /**
    * Initialize telegram notifications settings

--- a/packages/db/src/ipfsClient.ts
+++ b/packages/db/src/ipfsClient.ts
@@ -1,13 +1,43 @@
-import { dbMain } from "./dbFactory.js";
+import { dbFactory, dbMain } from "./dbFactory.js";
 import { IpfsClientTarget } from "@dappnode/types";
 import { params } from "@dappnode/params";
 
 // User chosen properties
 const IPFS_CLIENT_TARGET = "ipfs-client-target";
 const IPFS_GATEWAY = "ipfs-gateway";
+const IPFS_GATEWAYS = "ipfs-gateways";
 
 export const ipfsClientTarget = dbMain.staticKey<IpfsClientTarget>(IPFS_CLIENT_TARGET, IpfsClientTarget.local);
 
-// The union keeps pre-migration databases readable. initializeDb migrates the
-// legacy single string to an ordered array.
-export const ipfsGateway = dbMain.staticKey<string | string[]>(IPFS_GATEWAY, [params.IPFS_REMOTE]);
+type Db = ReturnType<typeof dbFactory>;
+
+/**
+ * Keep the legacy key readable as an array so databases written by the first
+ * failover implementation can be repaired. All normal writes keep it a string.
+ */
+export function createIpfsGatewayDb(db: Db, defaultGateway: string) {
+  const ipfsGateway = db.staticKey<string | string[]>(IPFS_GATEWAY, defaultGateway);
+  const ipfsGateways = db.staticKey<string[] | null>(IPFS_GATEWAYS, null);
+
+  function getIpfsGateways(): string[] {
+    const gateways = ipfsGateways.get();
+    if (Array.isArray(gateways) && gateways.length > 0) return gateways;
+
+    const legacyGateway = ipfsGateway.get();
+    return Array.isArray(legacyGateway) ? legacyGateway : [legacyGateway];
+  }
+
+  function setIpfsGateways(gateways: string[]): void {
+    if (gateways.length === 0) throw Error("At least one IPFS gateway is required");
+
+    ipfsGateways.set(gateways);
+    ipfsGateway.set(gateways[0]);
+  }
+
+  return { ipfsGateway, ipfsGateways, getIpfsGateways, setIpfsGateways };
+}
+
+export const { ipfsGateway, ipfsGateways, getIpfsGateways, setIpfsGateways } = createIpfsGatewayDb(
+  dbMain,
+  params.IPFS_REMOTE
+);

--- a/packages/db/src/ipfsClient.ts
+++ b/packages/db/src/ipfsClient.ts
@@ -8,4 +8,6 @@ const IPFS_GATEWAY = "ipfs-gateway";
 
 export const ipfsClientTarget = dbMain.staticKey<IpfsClientTarget>(IPFS_CLIENT_TARGET, IpfsClientTarget.local);
 
-export const ipfsGateway = dbMain.staticKey<string>(IPFS_GATEWAY, params.IPFS_REMOTE);
+// The union keeps pre-migration databases readable. initializeDb migrates the
+// legacy single string to an ordered array.
+export const ipfsGateway = dbMain.staticKey<string | string[]>(IPFS_GATEWAY, [params.IPFS_REMOTE]);

--- a/packages/db/test/unit/ipfsClient.test.ts
+++ b/packages/db/test/unit/ipfsClient.test.ts
@@ -1,0 +1,53 @@
+import fs from "fs";
+import path from "path";
+import { expect } from "chai";
+import { dbFactory } from "../../src/dbFactory.js";
+import { createIpfsGatewayDb } from "../../src/ipfsClient.js";
+
+const testDir = "./test_files/";
+const defaultGateway = "https://default.gateway";
+
+describe("IPFS gateway database compatibility", () => {
+  const dbPath = path.join(testDir, "ipfs-client-db.json");
+
+  function createDb() {
+    fs.rmSync(dbPath, { force: true });
+    return createIpfsGatewayDb(dbFactory(dbPath), defaultGateway);
+  }
+
+  it("reads a legacy string-only database as a gateway list", () => {
+    const db = createDb();
+    db.ipfsGateway.set("https://legacy.gateway");
+
+    expect(db.getIpfsGateways()).to.deep.equal(["https://legacy.gateway"]);
+  });
+
+  it("prefers the new gateway array over the legacy string", () => {
+    const db = createDb();
+    db.ipfsGateway.set("https://legacy.gateway");
+    db.ipfsGateways.set(["https://primary.gateway", "https://fallback.gateway"]);
+
+    expect(db.getIpfsGateways()).to.deep.equal(["https://primary.gateway", "https://fallback.gateway"]);
+  });
+
+  it("recovers a legacy key that was previously migrated to an array", () => {
+    const db = createDb();
+    db.ipfsGateway.set(["https://primary.gateway", "https://fallback.gateway"]);
+
+    const recoveredGateways = db.getIpfsGateways();
+    db.setIpfsGateways(recoveredGateways);
+
+    expect(db.ipfsGateways.get()).to.deep.equal(["https://primary.gateway", "https://fallback.gateway"]);
+    expect(db.ipfsGateway.get()).to.equal("https://primary.gateway");
+  });
+
+  it("always writes the first gateway to the legacy key as a string", () => {
+    const db = createDb();
+
+    db.setIpfsGateways(["https://primary.gateway", "https://fallback.gateway"]);
+
+    expect(db.ipfsGateways.get()).to.deep.equal(["https://primary.gateway", "https://fallback.gateway"]);
+    expect(db.ipfsGateway.get()).to.equal("https://primary.gateway");
+    expect(db.ipfsGateway.get()).to.be.a("string");
+  });
+});

--- a/packages/installer/src/dappnodeInstaller.ts
+++ b/packages/installer/src/dappnodeInstaller.ts
@@ -32,30 +32,35 @@ import { JsonRpcApiProvider } from "ethers";
 /**
  * Returns the ipfsUrl to initialize the ipfs instance
  */
-export function getIpfsUrl(): string {
+export function getIpfsUrls(): string[] {
   // Fort testing
-  if (params.IPFS_HOST) return params.IPFS_HOST;
+  if (params.IPFS_HOST) return [params.IPFS_HOST];
 
   const ipfsClientTarget = db.ipfsClientTarget.get();
   if (!ipfsClientTarget) throw Error("Ipfs client target is not set");
   // local
-  if (ipfsClientTarget === IpfsClientTarget.local) return params.IPFS_LOCAL;
+  if (ipfsClientTarget === IpfsClientTarget.local) return [params.IPFS_LOCAL];
   // remote
-  return db.ipfsGateway.get();
+  const gateways = db.ipfsGateway.get();
+  return Array.isArray(gateways) ? gateways : [gateways];
 }
 
 export class DappnodeInstaller extends DappnodeRepository {
-  constructor(ipfsUrl: string, provider: JsonRpcApiProvider) {
+  constructor(ipfsUrl: string | string[], provider: JsonRpcApiProvider) {
     super(
       ipfsUrl,
       provider,
-      { baseUrl: params.CONTENT_MIRROR_BASE_URL, timeoutMs: params.CONTENT_MIRROR_TIMEOUT_MS, maxBytes: params.CONTENT_MIRROR_MAX_BYTES },
+      {
+        baseUrl: params.CONTENT_MIRROR_BASE_URL,
+        timeoutMs: params.CONTENT_MIRROR_TIMEOUT_MS,
+        maxBytes: params.CONTENT_MIRROR_MAX_BYTES
+      },
       () => db.mirrorProviderEnabled.get()
     );
   }
 
   private async updateProviders(): Promise<void> {
-    const newIpfsUrl = getIpfsUrl();
+    const newIpfsUrl = getIpfsUrls();
     // super.changeEthProvider();
     super.changeIpfsGatewayUrl(newIpfsUrl);
   }

--- a/packages/installer/src/dappnodeInstaller.ts
+++ b/packages/installer/src/dappnodeInstaller.ts
@@ -41,8 +41,7 @@ export function getIpfsUrls(): string[] {
   // local
   if (ipfsClientTarget === IpfsClientTarget.local) return [params.IPFS_LOCAL];
   // remote
-  const gateways = db.ipfsGateway.get();
-  return Array.isArray(gateways) ? gateways : [gateways];
+  return db.getIpfsGateways();
 }
 
 export class DappnodeInstaller extends DappnodeRepository {

--- a/packages/installer/src/index.ts
+++ b/packages/installer/src/index.ts
@@ -1,5 +1,5 @@
 export * from "./dappGet/index.js";
 export * from "./installer/index.js";
-export { DappnodeInstaller, getIpfsUrl } from "./dappnodeInstaller.js";
+export { DappnodeInstaller, getIpfsUrls } from "./dappnodeInstaller.js";
 // calls
 export * from "./calls/index.js";

--- a/packages/toolkit/src/repository/ipfsGatewayClient.ts
+++ b/packages/toolkit/src/repository/ipfsGatewayClient.ts
@@ -1,0 +1,41 @@
+export class IpfsGatewayClient {
+  private gatewayUrls: string[];
+
+  constructor(gatewayUrls: string | string[]) {
+    this.gatewayUrls = normalizeGatewayUrls(gatewayUrls);
+  }
+
+  public setGatewayUrls(gatewayUrls: string | string[]): void {
+    this.gatewayUrls = normalizeGatewayUrls(gatewayUrls);
+  }
+
+  /**
+   * Tries each gateway in order. The response consumer runs inside the retry
+   * boundary, so failures while reading or parsing a response also try the next
+   * gateway.
+   */
+  public async fetch<T>(ipfsPath: string, init: RequestInit, consume: (response: Response) => Promise<T>): Promise<T> {
+    const errors: string[] = [];
+
+    for (const gatewayUrl of this.gatewayUrls) {
+      try {
+        const response = await fetch(`${gatewayUrl}${ipfsPath}`, init);
+        if (!response.ok) throw new Error(`${response.status} ${response.statusText}`);
+        return await consume(response);
+      } catch (error) {
+        errors.push(`${gatewayUrl}: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    }
+
+    throw new Error(`All IPFS gateways failed (${errors.join("; ")})`);
+  }
+}
+
+function normalizeGatewayUrls(gatewayUrls: string | string[]): string[] {
+  const normalized = (Array.isArray(gatewayUrls) ? gatewayUrls : [gatewayUrls])
+    .map((gatewayUrl) => gatewayUrl.trim().replace(/\/?$/, ""))
+    .filter(Boolean);
+
+  if (normalized.length === 0) throw new Error("At least one IPFS gateway is required");
+  return normalized;
+}

--- a/packages/toolkit/src/repository/repository.ts
+++ b/packages/toolkit/src/repository/repository.ts
@@ -30,6 +30,7 @@ import { isEnsDomain } from "../isEnsDomain.js";
 import { dappnodeRegistry } from "./params.js";
 import { JsonRpcApiProvider } from "ethers";
 import { MirrorOptions, MirrorFileEntry, HttpMirrorProvider } from "./contentProvider/index.js";
+import { IpfsGatewayClient } from "./ipfsGatewayClient.js";
 
 const source = "ipfs" as const;
 
@@ -55,7 +56,7 @@ type ListResult =
  * @extends ApmRepository
  */
 export class DappnodeRepository extends ApmRepository {
-  protected gatewayUrl: string;
+  private readonly ipfsGatewayClient: IpfsGatewayClient;
   protected localIpfsUrl = "http://ipfs.dappnode:5001";
   private readonly mirrorProvider: HttpMirrorProvider;
   private readonly isMirrorEnabled: () => boolean;
@@ -67,9 +68,14 @@ export class DappnodeRepository extends ApmRepository {
    * @param mirrorOptions - Mirror HTTP provider configuration (baseUrl, timeouts, size limits).
    * @param isMirrorEnabled - Called before each operation to decide whether to use the mirror.
    */
-  constructor(ipfsUrl: string, provider: JsonRpcApiProvider, mirrorOptions: MirrorOptions, isMirrorEnabled: () => boolean) {
+  constructor(
+    ipfsUrl: string | string[],
+    provider: JsonRpcApiProvider,
+    mirrorOptions: MirrorOptions,
+    isMirrorEnabled: () => boolean
+  ) {
     super(provider);
-    this.gatewayUrl = ipfsUrl.replace(/\/?$/, "");
+    this.ipfsGatewayClient = new IpfsGatewayClient(ipfsUrl);
     this.mirrorProvider = new HttpMirrorProvider(mirrorOptions);
     this.isMirrorEnabled = isMirrorEnabled;
   }
@@ -78,8 +84,8 @@ export class DappnodeRepository extends ApmRepository {
    * Changes the IPFS provider and target.
    * @param ipfsUrl - The new URL of the IPFS network node.
    */
-  public changeIpfsGatewayUrl(ipfsUrl: string): void {
-    this.gatewayUrl = ipfsUrl.replace(/\/?$/, "");
+  public changeIpfsGatewayUrl(ipfsUrl: string | string[]): void {
+    this.ipfsGatewayClient.setGatewayUrls(ipfsUrl);
   }
 
   /**
@@ -201,16 +207,20 @@ export class DappnodeRepository extends ApmRepository {
         : { status: ReleaseSignatureStatusCode.notSigned };
 
     const signedSafe =
-      listResult.source === "mirror"
-        ? true
-        : signatureStatus.status === ReleaseSignatureStatusCode.signedByKnownKey;
+      listResult.source === "mirror" ? true : signatureStatus.status === ReleaseSignatureStatusCode.signedByKnownKey;
 
     // Avatar: look up by filename regex; source drives which DistributedFile shape to use
     let avatarFile: DistributedFile | undefined;
     if (listResult.source === "mirror") {
       const entry = listResult.files.find((f) => releaseFiles.avatar.regex.test(f.name));
       if (entry)
-        avatarFile = { hash: listResult.packageCidStr, size: entry.size, source: "mirror", filename: entry.name, packageHash: listResult.packageCidStr };
+        avatarFile = {
+          hash: listResult.packageCidStr,
+          size: entry.size,
+          source: "mirror",
+          filename: entry.name,
+          packageHash: listResult.packageCidStr
+        };
     } else {
       const entry = listResult.entries.find((e) => releaseFiles.avatar.regex.test(e.name));
       if (entry) avatarFile = { hash: entry.cid.toString(), size: entry.size, source };
@@ -307,7 +317,12 @@ export class DappnodeRepository extends ApmRepository {
    * @param fileCid - Individual file CID. Available for IPFS-listed packages only; absent for mirror-listed packages.
    * @param maxLength - Maximum file size in bytes.
    */
-  private async downloadReleaseAsset(filename: string, packageCidStr: string, fileCid?: string, maxLength?: number): Promise<string> {
+  private async downloadReleaseAsset(
+    filename: string,
+    packageCidStr: string,
+    fileCid?: string,
+    maxLength?: number
+  ): Promise<string> {
     // Provider 1: Mirror — try first if configured
     if (this.isMirrorEnabled()) {
       const mirrorCid = this.sanitizeIpfsPath(packageCidStr);
@@ -464,25 +479,21 @@ export class DappnodeRepository extends ApmRepository {
    */
   public async list(hash: string): Promise<IPFSEntry[]> {
     const cidStr = this.sanitizeIpfsPath(hash.toString());
-    const url = `${this.gatewayUrl}/ipfs/${cidStr}?format=dag-json`;
-    const res = await fetch(url, {
-      headers: { Accept: "application/vnd.ipld.dag-json" }
-    });
-    if (!res.ok) {
-      throw new Error(`Failed to list directory ${cidStr}: ${res.status} ${res.statusText}`);
-    }
-
-    const dagJson = (await res.json()) as {
-      Links?: Array<{
-        Name: string;
-        Hash: { "/": string };
-        Tsize: number;
-      }>;
-    };
-
-    if (!dagJson.Links) {
-      throw new Error(`Invalid IPFS directory CID ${cidStr}`);
-    }
+    const dagJson = await this.ipfsGatewayClient.fetch(
+      `/ipfs/${cidStr}?format=dag-json`,
+      { headers: { Accept: "application/vnd.ipld.dag-json" } },
+      async (res) => {
+        const result = (await res.json()) as {
+          Links?: Array<{
+            Name: string;
+            Hash: { "/": string };
+            Tsize: number;
+          }>;
+        };
+        if (!result.Links) throw new Error(`Invalid IPFS directory CID ${cidStr}`);
+        return { Links: result.Links };
+      }
+    );
 
     return dagJson.Links.map((link) => ({
       type: "file",
@@ -531,24 +542,22 @@ export class DappnodeRepository extends ApmRepository {
     root: CID;
   }> {
     // 1. Download the CAR
-    const url = `${this.gatewayUrl}/ipfs/${hash}?format=car`;
-    const res = await fetch(url, {
-      headers: { Accept: "application/vnd.ipld.car" }
-    });
-    if (!res.ok) throw new Error(`Gateway error: ${res.status} ${res.statusText}`);
-
-    // 2. Parse into a CarReader
-    const bytes = new Uint8Array(await res.arrayBuffer());
-    const carReader = await CarReader.fromBytes(bytes);
-
-    // 3. Verify the root CID
-    const roots = await carReader.getRoots();
-    const root = roots[0];
-    if (roots.length !== 1 || root.toString() !== CID.parse(hash).toString()) {
-      throw new Error(`UNTRUSTED CONTENT: expected root ${hash}, got ${roots}`);
-    }
-
-    return { carReader, root };
+    return this.ipfsGatewayClient.fetch(
+      `/ipfs/${hash}?format=car`,
+      { headers: { Accept: "application/vnd.ipld.car" } },
+      async (res) => {
+        // Parse and verify inside the retry boundary. Truncated or untrusted
+        // responses are discarded before trying the next gateway.
+        const bytes = new Uint8Array(await res.arrayBuffer());
+        const carReader = await CarReader.fromBytes(bytes);
+        const roots = await carReader.getRoots();
+        const root = roots[0];
+        if (roots.length !== 1 || root.toString() !== CID.parse(hash).toString()) {
+          throw new Error(`UNTRUSTED CONTENT: expected root ${hash}, got ${roots}`);
+        }
+        return { carReader, root };
+      }
+    );
   }
 
   /**
@@ -610,7 +619,9 @@ export class DappnodeRepository extends ApmRepository {
     const missingImageError = (): Error =>
       Error(
         `No image for architecture '${nodeArch}'. ${
-          manifest.architectures && manifest.architectures.includes(arch) ? `image for ${arch} is missing in release` : undefined
+          manifest.architectures && manifest.architectures.includes(arch)
+            ? `image for ${arch} is missing in release`
+            : undefined
         }`
       );
 

--- a/packages/toolkit/test/repository/ipfsGatewayClient.test.ts
+++ b/packages/toolkit/test/repository/ipfsGatewayClient.test.ts
@@ -1,0 +1,53 @@
+import { expect } from "chai";
+import { IpfsGatewayClient } from "../../src/repository/ipfsGatewayClient.js";
+
+describe("IpfsGatewayClient", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("tries gateways in order until one succeeds", async () => {
+    const requestedUrls: string[] = [];
+    globalThis.fetch = async (input) => {
+      requestedUrls.push(input.toString());
+      return requestedUrls.length === 1
+        ? new Response("unavailable", { status: 503 })
+        : new Response('{"ok":true}', { status: 200 });
+    };
+
+    const client = new IpfsGatewayClient(["https://first.example/", "https://second.example"]);
+    const result = await client.fetch("/ipfs/cid", {}, async (response) => response.json());
+
+    expect(result).to.deep.equal({ ok: true });
+    expect(requestedUrls).to.deep.equal(["https://first.example/ipfs/cid", "https://second.example/ipfs/cid"]);
+  });
+
+  it("tries the next gateway when consuming a successful response fails", async () => {
+    let requestCount = 0;
+    globalThis.fetch = async () => {
+      requestCount += 1;
+      return new Response(requestCount === 1 ? "invalid json" : '{"ok":true}', { status: 200 });
+    };
+
+    const client = new IpfsGatewayClient(["https://first.example", "https://second.example"]);
+    const result = await client.fetch("/ipfs/cid", {}, async (response) => response.json());
+
+    expect(result).to.deep.equal({ ok: true });
+    expect(requestCount).to.equal(2);
+  });
+
+  it("reports every gateway error when all attempts fail", async () => {
+    globalThis.fetch = async () => new Response("unavailable", { status: 502, statusText: "Bad Gateway" });
+    const client = new IpfsGatewayClient(["https://first.example", "https://second.example"]);
+
+    try {
+      await client.fetch("/ipfs/cid", {}, async (response) => response.text());
+      expect.fail("Expected the request to fail");
+    } catch (error) {
+      expect((error as Error).message).to.include("https://first.example: 502 Bad Gateway");
+      expect((error as Error).message).to.include("https://second.example: 502 Bad Gateway");
+    }
+  });
+});

--- a/packages/types/src/calls.ts
+++ b/packages/types/src/calls.ts
@@ -937,7 +937,8 @@ export interface DistributedFile {
 
 export interface IpfsRepository {
   ipfsClientTarget: IpfsClientTarget;
-  ipfsGateway: string;
+  /** Remote gateways in priority order. */
+  ipfsGateway: string[];
 }
 
 export enum IpfsClientTarget {


### PR DESCRIPTION
## Context

Dappmanager currently supports only one remote IPFS gateway. If that endpoint is unavailable or returns invalid content, package operations fail even when another gateway could serve the same CID.

This adds an ordered list of remote gateways and sequential failover while keeping existing single-gateway database values compatible.

## Approach

- Update the IPFS settings UI and API type to accept multiple ordered gateway URLs.
- Migrate legacy persisted string values to gateway arrays.
- Add an IPFS gateway client that retries the next endpoint on HTTP, connection, response-consumption, parsing, CAR validation, or CID verification failures.
- Apply the same ordered fallback behavior to repository health checks.
- Restart failed downloads from the next gateway; partial CAR resumption is intentionally excluded because it requires range support and safe block reassembly.

## Test instructions

1. Open System > IPFS and select Remote.
2. Add multiple gateways, putting an unavailable URL first and a working gateway second.
3. Save the configuration and install or inspect a package resolved through IPFS.
4. Confirm the operation succeeds through the second gateway.
5. Reorder or remove gateways and confirm the saved order is restored after refreshing.
6. Run the IPFS gateway client unit tests and affected workspace type checks.

Automated verification completed:
- IPFS gateway client tests: 3 passing.
- TypeScript checks passed for toolkit, installer, dappmanager, daemons, and admin-ui.
- ESLint passed for the changed TypeScript files.