### PR TITLE
Improve auto-update settings UX

### DIFF
--- a/packages/admin-ui/src/__mock-backend__/autoUpdate.ts
+++ b/packages/admin-ui/src/__mock-backend__/autoUpdate.ts
@@ -73,7 +73,7 @@ const autoUpdateData: AutoUpdateDataView = {
     },
     {
       id: "my-packages",
-      displayName: "Default for my packages",
+      displayName: "My packages",
       enabled: true,
       feedback: {}
     },

--- a/packages/admin-ui/src/__mock-backend__/autoUpdate.ts
+++ b/packages/admin-ui/src/__mock-backend__/autoUpdate.ts
@@ -3,12 +3,26 @@ import { pause } from "./utils/pause";
 
 export const autoUpdate: Pick<Routes, "autoUpdateDataGet" | "autoUpdateSettingsEdit"> = {
   autoUpdateDataGet: async () => autoUpdateData,
-  autoUpdateSettingsEdit: async ({ id, enabled }) => {
+  autoUpdateSettingsEdit: async ({ id, enabled, applyToAll }) => {
     await pause(500);
-    if (autoUpdateData.settings[id]) autoUpdateData.settings[id].enabled = enabled;
+    const isSinglePackage = id !== "system-packages" && id !== "my-packages";
+    const defaultEnabled = Boolean(autoUpdateData.settings["my-packages"]?.enabled);
+    if (isSinglePackage && enabled === defaultEnabled) delete autoUpdateData.settings[id];
+    else autoUpdateData.settings[id] = { enabled };
+
+    if (id === "my-packages" && applyToAll !== false) {
+      for (const settingId of Object.keys(autoUpdateData.settings)) {
+        if (settingId !== "system-packages" && settingId !== "my-packages") delete autoUpdateData.settings[settingId];
+      }
+    }
 
     for (const dnp of autoUpdateData.dnpsToShow) {
-      if (dnp.id === id) dnp.enabled = enabled;
+      const usesDefault = dnp.id !== "system-packages" && dnp.id !== "my-packages" && !autoUpdateData.settings[dnp.id];
+      if (
+        dnp.id === id ||
+        (id === "my-packages" && dnp.id !== "system-packages" && (applyToAll !== false || usesDefault))
+      )
+        dnp.enabled = enabled;
     }
   }
 };
@@ -59,7 +73,7 @@ const autoUpdateData: AutoUpdateDataView = {
     },
     {
       id: "my-packages",
-      displayName: "My packages",
+      displayName: "Default for my packages",
       enabled: true,
       feedback: {}
     },

--- a/packages/admin-ui/src/pages/system/components/AutoUpdates/AutoUpdateRowItem.tsx
+++ b/packages/admin-ui/src/pages/system/components/AutoUpdates/AutoUpdateRowItem.tsx
@@ -16,8 +16,11 @@ export function AutoUpdateRowItem({
   displayName,
   enabled,
   feedback,
+  isMixed,
+  isCustomized,
   isInstalling,
   isSinglePackage,
+  isDefaultControl,
   // Actions
   setUpdateSettings
 }: {
@@ -26,8 +29,11 @@ export function AutoUpdateRowItem({
   enabled: boolean;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   feedback: any;
+  isMixed: boolean;
+  isCustomized: boolean;
   isInstalling: boolean;
   isSinglePackage: boolean;
+  isDefaultControl: boolean;
   setUpdateSettings: (id: string, enable: boolean) => void;
 }) {
   const [collapsed, setCollapsed] = useState(true);
@@ -68,13 +74,20 @@ export function AutoUpdateRowItem({
 
   return (
     <React.Fragment key={id}>
-      <span className={`state-badge center badge-${enabled ? "success" : "secondary"}`} style={{ opacity: 0.85 }}>
-        <span className="content">{enabled ? "on" : "off"}</span>
+      <span
+        className={`state-badge center badge-${isMixed ? "warning" : enabled ? "success" : "secondary"}`}
+        style={{ opacity: 0.85 }}
+      >
+        <span className="content">{isMixed ? "mixed" : enabled ? "on" : "off"}</span>
       </span>
 
       <span className="name">
         {isSinglePackage && <li className="bullet" />}
-        {displayName}
+        <span className="auto-update-name">
+          <span>{displayName}</span>
+          {isSinglePackage && <small>{isCustomized ? "Customized" : "Using default"}</small>}
+          {isDefaultControl && <small>Used by new and non-customized packages</small>}
+        </span>
       </span>
 
       <span className="last-update">
@@ -92,7 +105,7 @@ export function AutoUpdateRowItem({
         ) : null}
       </span>
 
-      <Switch checked={enabled ? true : false} onToggle={() => setUpdateSettings(id, !enabled)} label="" />
+      <Switch checked={enabled} onToggle={(checked) => setUpdateSettings(id, checked)} label="" />
 
       {!collapsed && <div className="extra-info">{errorMessage}</div>}
 

--- a/packages/admin-ui/src/pages/system/components/AutoUpdates/AutoUpdateRowItem.tsx
+++ b/packages/admin-ui/src/pages/system/components/AutoUpdates/AutoUpdateRowItem.tsx
@@ -16,11 +16,9 @@ export function AutoUpdateRowItem({
   displayName,
   enabled,
   feedback,
-  isMixed,
   isCustomized,
   isInstalling,
   isSinglePackage,
-  isDefaultControl,
   // Actions
   setUpdateSettings
 }: {
@@ -29,11 +27,9 @@ export function AutoUpdateRowItem({
   enabled: boolean;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   feedback: any;
-  isMixed: boolean;
   isCustomized: boolean;
   isInstalling: boolean;
   isSinglePackage: boolean;
-  isDefaultControl: boolean;
   setUpdateSettings: (id: string, enable: boolean) => void;
 }) {
   const [collapsed, setCollapsed] = useState(true);
@@ -74,19 +70,14 @@ export function AutoUpdateRowItem({
 
   return (
     <React.Fragment key={id}>
-      <span
-        className={`state-badge center badge-${isMixed ? "warning" : enabled ? "success" : "secondary"}`}
-        style={{ opacity: 0.85 }}
-      >
-        <span className="content">{isMixed ? "mixed" : enabled ? "on" : "off"}</span>
+      <span className={`state-badge center badge-${enabled ? "success" : "secondary"}`} style={{ opacity: 0.85 }}>
+        <span className="content">{enabled ? "on" : "off"}</span>
       </span>
 
-      <span className="name">
-        {isSinglePackage && <li className="bullet" />}
+      <span className={`name ${isSinglePackage ? "nested" : ""}`}>
         <span className="auto-update-name">
           <span>{displayName}</span>
           {isSinglePackage && <small>{isCustomized ? "Customized" : "Using default"}</small>}
-          {isDefaultControl && <small>Used by new and non-customized packages</small>}
         </span>
       </span>
 

--- a/packages/admin-ui/src/pages/system/components/AutoUpdates/autoUpdates.scss
+++ b/packages/admin-ui/src/pages/system/components/AutoUpdates/autoUpdates.scss
@@ -10,6 +10,27 @@
   margin-bottom: var(--default-spacing);
 }
 
+.auto-updates-bulk-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--default-spacing);
+  margin-bottom: var(--default-spacing);
+  padding: 0.75rem;
+  border: var(--border-style);
+  border-radius: 0.25rem;
+
+  > span {
+    color: var(--light-text-color);
+  }
+
+  .buttons {
+    display: flex;
+    gap: 0.5rem;
+    flex-shrink: 0;
+  }
+}
+
 .list-grid.auto-updates {
   /*
   Col 1: Shrink the text to an extend, otherwise fill all available space
@@ -30,13 +51,22 @@
   }
 
   .state-badge {
-    width: 2.5rem;
+    width: 3.5rem;
     overflow: hidden;
     overflow-wrap: normal;
   }
 
   .name {
     display: flex;
+  }
+  .auto-update-name {
+    display: flex;
+    flex-direction: column;
+
+    small {
+      color: var(--light-text-color);
+      font-size: 75%;
+    }
   }
   .bullet {
     padding-left: 15px;
@@ -75,6 +105,17 @@
 
     .extra-info {
       display: none;
+    }
+  }
+}
+
+@media screen and (max-width: 40rem) {
+  .auto-updates-bulk-actions {
+    align-items: stretch;
+    flex-direction: column;
+
+    .buttons > button {
+      flex: 1;
     }
   }
 }

--- a/packages/admin-ui/src/pages/system/components/AutoUpdates/autoUpdates.scss
+++ b/packages/admin-ui/src/pages/system/components/AutoUpdates/autoUpdates.scss
@@ -10,25 +10,86 @@
   margin-bottom: var(--default-spacing);
 }
 
-.auto-updates-bulk-actions {
+.auto-updates-section {
+  padding: var(--default-spacing);
+  border: var(--border-style);
+  border-radius: 0.35rem;
+
+  & + & {
+    margin-top: var(--default-spacing);
+  }
+}
+
+.auto-updates-section-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--default-spacing);
+  margin-bottom: var(--default-spacing);
+
+  h4,
+  p {
+    margin: 0;
+  }
+
+  p {
+    margin-top: 0.25rem;
+    color: var(--light-text-color);
+  }
+
+  > button {
+    flex-shrink: 0;
+  }
+}
+
+.auto-update-name {
+  display: flex;
+  flex-direction: column;
+
+  small {
+    color: var(--light-text-color);
+    font-size: 75%;
+  }
+}
+
+.auto-updates-default-setting {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: var(--default-spacing);
-  margin-bottom: var(--default-spacing);
+  padding: 0.75rem 0;
+  border-top: var(--border-style);
+
+  .switch {
+    flex-shrink: 0;
+  }
+}
+
+.auto-updates-section-expand {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   padding: 0.75rem;
   border: var(--border-style);
   border-radius: 0.25rem;
+  color: inherit;
+  background: transparent;
+  text-align: left;
 
-  > span {
-    color: var(--light-text-color);
-  }
-
-  .buttons {
-    display: flex;
-    gap: 0.5rem;
+  svg {
     flex-shrink: 0;
+    margin-left: var(--default-spacing);
+    transition: transform 0.2s ease;
+
+    &.rotated {
+      transform: rotate(180deg);
+    }
   }
+}
+
+.auto-updates-package-list {
+  margin-top: var(--default-spacing);
 }
 
 .list-grid.auto-updates {
@@ -58,20 +119,13 @@
 
   .name {
     display: flex;
-  }
-  .auto-update-name {
-    display: flex;
-    flex-direction: column;
 
-    small {
-      color: var(--light-text-color);
-      font-size: 75%;
+    &.nested {
+      margin-left: 1rem;
+      padding-left: 1rem;
+      border-left: 2px solid var(--border-color);
     }
   }
-  .bullet {
-    padding-left: 15px;
-  }
-
   .last-update {
     justify-self: right;
     color: #8c8c8c;
@@ -110,13 +164,9 @@
 }
 
 @media screen and (max-width: 40rem) {
-  .auto-updates-bulk-actions {
+  .auto-updates-section-heading {
     align-items: stretch;
     flex-direction: column;
-
-    .buttons > button {
-      flex: 1;
-    }
   }
 }
 

--- a/packages/admin-ui/src/pages/system/components/AutoUpdates/enableAutoUpdatesForPackageWithConfirm.ts
+++ b/packages/admin-ui/src/pages/system/components/AutoUpdates/enableAutoUpdatesForPackageWithConfirm.ts
@@ -40,7 +40,7 @@ export async function enableAutoUpdatesForPackageWithConfirm(dnpName: string): P
 
     const id = enableForAll ? MY_PACKAGES : dnpName;
     const logId = enableForAll ? "all packages" : prettyName;
-    await withToastNoThrow(() => api.autoUpdateSettingsEdit({ id, enabled: true }), {
+    await withToastNoThrow(() => api.autoUpdateSettingsEdit({ id, enabled: true, applyToAll: enableForAll }), {
       message: `Enabling auto-updates for ${logId}`,
       onSuccess: `Enabled auto-updates for ${logId}`
     });

--- a/packages/admin-ui/src/pages/system/components/AutoUpdates/index.tsx
+++ b/packages/admin-ui/src/pages/system/components/AutoUpdates/index.tsx
@@ -3,6 +3,8 @@ import { useSelector } from "react-redux";
 import { api, useApi } from "api";
 // Components
 import Card from "components/Card";
+import Button from "components/Button";
+import { confirm } from "components/ConfirmDialog";
 import { withToast } from "components/toast/Toast";
 // Utils
 import { prettyDnpName } from "utils/format";
@@ -25,12 +27,16 @@ export default function AutoUpdates() {
   const autoUpdateDataReq = useApi.autoUpdateDataGet();
   const progressLogsByDnp = useSelector(getProgressLogsByDnp);
 
-  async function setUpdateSettings(id: string, enabled: boolean): Promise<void> {
+  async function setUpdateSettings(id: string, enabled: boolean, applyToAll?: boolean): Promise<void> {
     try {
       const actioning = enabled ? "Enabling" : "Disabling";
       const actioned = enabled ? "Enabled" : "Disabled";
-      const prettyName = prettyDnpName(id);
-      await withToast(() => api.autoUpdateSettingsEdit({ id, enabled }), {
+      const prettyName = applyToAll
+        ? "all my packages"
+        : id === MY_PACKAGES
+          ? "the package default"
+          : prettyDnpName(id);
+      await withToast(() => api.autoUpdateSettingsEdit({ id, enabled, applyToAll }), {
         message: `${actioning} auto updates for ${prettyName}...`,
         onSuccess: `${actioned} auto updates for ${prettyName}`
       });
@@ -39,14 +45,41 @@ export default function AutoUpdates() {
     }
   }
 
+  function confirmSetAllPackages(enabled: boolean): void {
+    const action = enabled ? "Enable" : "Disable";
+    confirm({
+      title: `${action} auto-updates for all my packages?`,
+      text: "This will remove every per-package customization and cannot be undone automatically.",
+      label: `${action} all my packages`,
+      variant: enabled ? "dappnode" : "outline-danger",
+      onClick: () => setUpdateSettings(MY_PACKAGES, enabled, true)
+    });
+  }
+
   return renderResponse(autoUpdateDataReq, ["Loading auto-update data"], (autoUpdateData) => {
-    const { dnpsToShow = [] } = autoUpdateData || {};
+    const { dnpsToShow = [], settings = {} } = autoUpdateData || {};
+    const myPackages = dnpsToShow.find(({ id }) => id === MY_PACKAGES);
+    const packageSettingsAreMixed = dnpsToShow
+      .filter(({ id }) => getIsSinglePackage(id))
+      .some(({ enabled }) => enabled !== myPackages?.enabled);
 
     return (
       <Card>
         <div className="auto-updates-explanation">
           Enable auto-updates for DAppNode to install automatically the latest versions. For major breaking updates,
           your approval will always be required.
+        </div>
+
+        <div className="auto-updates-bulk-actions">
+          <span>Default changes preserve customized packages.</span>
+          <div className="buttons">
+            <Button variant="outline-dappnode" onClick={() => confirmSetAllPackages(true)}>
+              Enable all my packages
+            </Button>
+            <Button variant="outline-danger" onClick={() => confirmSetAllPackages(false)}>
+              Disable all my packages
+            </Button>
+          </div>
         </div>
 
         <div className="list-grid auto-updates">
@@ -66,10 +99,14 @@ export default function AutoUpdates() {
                 displayName,
                 enabled,
                 feedback,
+                isMixed: id === MY_PACKAGES && packageSettingsAreMixed,
+                isCustomized: getIsSinglePackage(id) && Boolean(settings[id]),
                 isInstalling: Boolean((progressLogsByDnp || {})[id === SYSTEM_PACKAGES ? coreDnpName : id]),
                 isSinglePackage: getIsSinglePackage(id),
+                isDefaultControl: id === MY_PACKAGES,
                 // Actions
-                setUpdateSettings
+                setUpdateSettings: (settingId: string, settingEnabled: boolean) =>
+                  setUpdateSettings(settingId, settingEnabled, settingId === MY_PACKAGES ? false : undefined)
               }}
             />
           ))}

--- a/packages/admin-ui/src/pages/system/components/AutoUpdates/index.tsx
+++ b/packages/admin-ui/src/pages/system/components/AutoUpdates/index.tsx
@@ -1,14 +1,16 @@
-import React from "react";
+import React, { useState } from "react";
 import { useSelector } from "react-redux";
+import { BsChevronDown } from "react-icons/bs";
 import { api, useApi } from "api";
 // Components
 import Card from "components/Card";
 import Button from "components/Button";
+import Switch from "components/Switch";
 import { confirm } from "components/ConfirmDialog";
 import { withToast } from "components/toast/Toast";
 // Utils
 import { prettyDnpName } from "utils/format";
-import { coreDnpName, autoUpdateIds } from "params";
+import { autoUpdateIds } from "params";
 // External
 import { getProgressLogsByDnp } from "services/isInstallingLogs/selectors";
 // Styles
@@ -26,6 +28,7 @@ const getIsSinglePackage = (id: string) => id !== MY_PACKAGES && id !== SYSTEM_P
 export default function AutoUpdates() {
   const autoUpdateDataReq = useApi.autoUpdateDataGet();
   const progressLogsByDnp = useSelector(getProgressLogsByDnp);
+  const [showPackageSettings, setShowPackageSettings] = useState(false);
 
   async function setUpdateSettings(id: string, enabled: boolean, applyToAll?: boolean): Promise<void> {
     try {
@@ -45,12 +48,12 @@ export default function AutoUpdates() {
     }
   }
 
-  function confirmSetAllPackages(enabled: boolean): void {
-    const action = enabled ? "Enable" : "Disable";
+  function confirmApplyDefault(enabled: boolean): void {
+    const defaultLabel = enabled ? "enabled" : "disabled";
     confirm({
-      title: `${action} auto-updates for all my packages?`,
-      text: "This will remove every per-package customization and cannot be undone automatically.",
-      label: `${action} all my packages`,
+      title: `Apply the ${defaultLabel} default to all my packages?`,
+      text: "This will remove every per-package customization and make all packages use the current default.",
+      label: "Apply default to all",
       variant: enabled ? "dappnode" : "outline-danger",
       onClick: () => setUpdateSettings(MY_PACKAGES, enabled, true)
     });
@@ -58,10 +61,12 @@ export default function AutoUpdates() {
 
   return renderResponse(autoUpdateDataReq, ["Loading auto-update data"], (autoUpdateData) => {
     const { dnpsToShow = [], settings = {} } = autoUpdateData || {};
+    const systemPackages = dnpsToShow.find(({ id }) => id === SYSTEM_PACKAGES);
     const myPackages = dnpsToShow.find(({ id }) => id === MY_PACKAGES);
-    const packageSettingsAreMixed = dnpsToShow
-      .filter(({ id }) => getIsSinglePackage(id))
-      .some(({ enabled }) => enabled !== myPackages?.enabled);
+    const singlePackages = dnpsToShow.filter(({ id }) => getIsSinglePackage(id));
+    const customizedPackageCount = singlePackages.filter(({ id }) => Boolean(settings[id])).length;
+
+    if (!systemPackages || !myPackages) return <Card>Auto-update settings are unavailable.</Card>;
 
     return (
       <Card>
@@ -70,47 +75,93 @@ export default function AutoUpdates() {
           your approval will always be required.
         </div>
 
-        <div className="auto-updates-bulk-actions">
-          <span>Default changes preserve customized packages.</span>
-          <div className="buttons">
-            <Button variant="outline-dappnode" onClick={() => confirmSetAllPackages(true)}>
-              Enable all my packages
-            </Button>
-            <Button variant="outline-danger" onClick={() => confirmSetAllPackages(false)}>
-              Disable all my packages
+        <section className="auto-updates-section">
+          <div className="auto-updates-section-heading">
+            <div>
+              <h4>Default settings</h4>
+              <p>These settings control automatic updates unless a package has its own customized setting.</p>
+            </div>
+          </div>
+
+          <div className="auto-updates-default-setting">
+            <span className="auto-update-name">
+              <strong>System packages</strong>
+              <small>All DAppNode system packages share this setting and are updated together.</small>
+            </span>
+            <Switch
+              checked={systemPackages.enabled}
+              onToggle={(enabled) => setUpdateSettings(SYSTEM_PACKAGES, enabled)}
+              label=""
+            />
+          </div>
+
+          <div className="auto-updates-default-setting">
+            <span className="auto-update-name">
+              <strong>My packages</strong>
+              <small>Used by new packages and packages without a customized setting.</small>
+            </span>
+            <Switch
+              checked={myPackages.enabled}
+              onToggle={(enabled) => setUpdateSettings(MY_PACKAGES, enabled, false)}
+              label=""
+            />
+          </div>
+        </section>
+
+        <section className="auto-updates-section">
+          <div className="auto-updates-section-heading">
+            <div>
+              <h4>Per-package settings</h4>
+              <p>Customize individual packages or reset every package to the current “My packages” default.</p>
+            </div>
+            <Button
+              variant={myPackages.enabled ? "outline-dappnode" : "outline-danger"}
+              disabled={singlePackages.length === 0}
+              onClick={() => confirmApplyDefault(myPackages.enabled)}
+            >
+              Apply {myPackages.enabled ? "enabled" : "disabled"} default to all
             </Button>
           </div>
-        </div>
 
-        <div className="list-grid auto-updates">
-          {/* Table header */}
-          <span className="state-badge" />
-          <span className="name" />
-          <span className="last-update header">Last auto-update</span>
-          <span className="header">Enabled</span>
+          <button
+            type="button"
+            className="auto-updates-section-expand"
+            onClick={() => setShowPackageSettings((isOpen) => !isOpen)}
+            aria-expanded={showPackageSettings}
+          >
+            <span>
+              {showPackageSettings ? "Hide" : "Show"} {singlePackages.length} package settings
+              {customizedPackageCount > 0 ? ` (${customizedPackageCount} customized)` : ""}
+            </span>
+            <BsChevronDown className={showPackageSettings ? "rotated" : ""} />
+          </button>
 
-          <hr />
-          {/* Items of the table */}
-          {dnpsToShow.map(({ id, displayName, enabled, feedback }) => (
-            <AutoUpdateRowItem
-              key={id}
-              {...{
-                id,
-                displayName,
-                enabled,
-                feedback,
-                isMixed: id === MY_PACKAGES && packageSettingsAreMixed,
-                isCustomized: getIsSinglePackage(id) && Boolean(settings[id]),
-                isInstalling: Boolean((progressLogsByDnp || {})[id === SYSTEM_PACKAGES ? coreDnpName : id]),
-                isSinglePackage: getIsSinglePackage(id),
-                isDefaultControl: id === MY_PACKAGES,
-                // Actions
-                setUpdateSettings: (settingId: string, settingEnabled: boolean) =>
-                  setUpdateSettings(settingId, settingEnabled, settingId === MY_PACKAGES ? false : undefined)
-              }}
-            />
-          ))}
-        </div>
+          {showPackageSettings && (
+            <div className="list-grid auto-updates auto-updates-package-list">
+              <span className="state-badge" />
+              <span className="name" />
+              <span className="last-update header">Last auto-update</span>
+              <span className="header">Enabled</span>
+              <hr />
+
+              {singlePackages.map(({ id, displayName, enabled, feedback }) => (
+                <AutoUpdateRowItem
+                  key={id}
+                  {...{
+                    id,
+                    displayName,
+                    enabled,
+                    feedback,
+                    isCustomized: Boolean(settings[id]),
+                    isInstalling: Boolean((progressLogsByDnp || {})[id]),
+                    isSinglePackage: true,
+                    setUpdateSettings
+                  }}
+                />
+              ))}
+            </div>
+          )}
+        </section>
       </Card>
     );
   });

--- a/packages/daemons/src/autoUpdates/editDnpSetting.ts
+++ b/packages/daemons/src/autoUpdates/editDnpSetting.ts
@@ -1,27 +1,41 @@
 import * as db from "@dappnode/db";
-import { pick } from "lodash-es";
+import { omit, pick } from "lodash-es";
 import { MY_PACKAGES, SYSTEM_PACKAGES } from "./params.js";
+import { params } from "@dappnode/params";
+import { eventBus } from "@dappnode/eventbus";
 import { clearPendingUpdates } from "./clearPendingUpdates.js";
 import { setSettings } from "./setSettings.js";
 
 /**
  * Edit the settings of regular DNPs
- * - pass the `name` argument to edit a specific DNP
- * - set `name` to null to edit the general My packages setting
+ * - pass `dnpName` to edit a specific DNP
+ * - omit `dnpName` to edit all package defaults
  *
  * @param enabled
- * @param dnpName, if null modifies MY_PACKAGES settings
+ * @param dnpName modifies MY_PACKAGES by default
+ * @param applyToAll when editing MY_PACKAGES, clear package overrides
  */
-export function editDnpSetting(enabled: boolean, dnpName = MY_PACKAGES): void {
+export function editDnpSetting(enabled: boolean, dnpName = MY_PACKAGES, applyToAll = dnpName === MY_PACKAGES): void {
   const autoUpdateSettings = db.autoUpdateSettings.get();
 
-  // When disabling MY_PACKAGES, turn off all DNPs settings by
-  // Ignoring all entries but the system packages
-  if (dnpName === MY_PACKAGES && !enabled) db.autoUpdateSettings.set(pick(autoUpdateSettings, SYSTEM_PACKAGES));
+  if (dnpName === MY_PACKAGES && applyToAll) db.autoUpdateSettings.set(pick(autoUpdateSettings, SYSTEM_PACKAGES));
 
   // When disabling any DNP, clear their pending updates
-  // Ignoring all entries but the system packages
-  if (!enabled) clearPendingUpdates(dnpName);
+  if (!enabled) {
+    if (dnpName === MY_PACKAGES && !applyToAll) {
+      // Preserve pending updates for packages explicitly enabled despite the
+      // default being disabled. Reset only packages that inherit the default.
+      for (const pendingDnpName of Object.keys(db.autoUpdatePending.get())) {
+        if (pendingDnpName !== params.coreDnpName && !autoUpdateSettings[pendingDnpName]?.enabled)
+          clearPendingUpdates(pendingDnpName);
+      }
+    } else clearPendingUpdates(dnpName);
+  }
 
-  setSettings(dnpName, enabled);
+  const defaultEnabled = Boolean(autoUpdateSettings[MY_PACKAGES]?.enabled);
+  if (dnpName !== MY_PACKAGES && enabled === defaultEnabled) {
+    // A package set to the default no longer needs a persistent override.
+    db.autoUpdateSettings.set(omit(db.autoUpdateSettings.get(), dnpName));
+    eventBus.requestAutoUpdateData.emit();
+  } else setSettings(dnpName, enabled);
 }

--- a/packages/dappmanager/src/calls/autoUpdateDataGet.ts
+++ b/packages/dappmanager/src/calls/autoUpdateDataGet.ts
@@ -39,7 +39,7 @@ export async function autoUpdateDataGet(): Promise<AutoUpdateDataView> {
     },
     {
       id: MY_PACKAGES,
-      displayName: "Default for my packages",
+      displayName: "My packages",
       enabled: isDnpUpdateEnabled(),
       feedback: {}
     }

--- a/packages/dappmanager/src/calls/autoUpdateDataGet.ts
+++ b/packages/dappmanager/src/calls/autoUpdateDataGet.ts
@@ -39,44 +39,42 @@ export async function autoUpdateDataGet(): Promise<AutoUpdateDataView> {
     },
     {
       id: MY_PACKAGES,
-      displayName: "My packages",
+      displayName: "Default for my packages",
       enabled: isDnpUpdateEnabled(),
       feedback: {}
     }
   ];
 
-  if (isDnpUpdateEnabled()) {
-    const singleDnpsToShow: InstalledPackageData[] = [];
-    for (const dnp of dnpList) {
-      const storedDnp = singleDnpsToShow.find((_dnp) => _dnp.dnpName === dnp.dnpName);
-      const storedVersion = storedDnp ? storedDnp.version : "";
-      if (
-        dnp.dnpName &&
-        // Ignore core DNPs
-        dnp.isDnp &&
-        !dnp.isCore &&
-        // Ignore wierd versions
-        valid(dnp.version) &&
-        // Ensure there are no duplicates
-        (!storedVersion || gt(storedVersion, dnp.version))
-      )
-        singleDnpsToShow.push(dnp);
-    }
+  const singleDnpsToShow: InstalledPackageData[] = [];
+  for (const dnp of dnpList) {
+    const storedDnp = singleDnpsToShow.find((_dnp) => _dnp.dnpName === dnp.dnpName);
+    const storedVersion = storedDnp ? storedDnp.version : "";
+    if (
+      dnp.dnpName &&
+      // Ignore core DNPs
+      dnp.isDnp &&
+      !dnp.isCore &&
+      // Ignore wierd versions
+      valid(dnp.version) &&
+      // Ensure there are no duplicates
+      (!storedVersion || gt(storedVersion, dnp.version))
+    )
+      singleDnpsToShow.push(dnp);
+  }
 
-    for (const dnp of singleDnpsToShow) {
-      const enabled = isDnpUpdateEnabled(dnp.dnpName);
-      dnpsToShow.push({
-        id: dnp.dnpName,
-        displayName: prettyDnpName(dnp.dnpName),
-        enabled,
-        feedback: enabled
-          ? getDnpFeedbackMessage({
-              dnpName: dnp.dnpName,
-              currentVersion: dnp.version
-            })
-          : {}
-      });
-    }
+  for (const dnp of singleDnpsToShow) {
+    const enabled = isDnpUpdateEnabled(dnp.dnpName);
+    dnpsToShow.push({
+      id: dnp.dnpName,
+      displayName: prettyDnpName(dnp.dnpName),
+      enabled,
+      feedback: enabled
+        ? getDnpFeedbackMessage({
+            dnpName: dnp.dnpName,
+            currentVersion: dnp.version
+          })
+        : {}
+    });
   }
 
   return {

--- a/packages/dappmanager/src/calls/autoUpdateSettingsEdit.ts
+++ b/packages/dappmanager/src/calls/autoUpdateSettingsEdit.ts
@@ -6,10 +6,18 @@ import { editCoreSetting, MY_PACKAGES, SYSTEM_PACKAGES, editDnpSetting } from "@
  * @param id = "my-packages", "system-packages" or "bitcoin.dnp.dappnode.eth"
  * @param enabled Auto update is enabled for ID
  */
-export async function autoUpdateSettingsEdit({ id, enabled }: { id: string; enabled: boolean }): Promise<void> {
+export async function autoUpdateSettingsEdit({
+  id,
+  enabled,
+  applyToAll
+}: {
+  id: string;
+  enabled: boolean;
+  applyToAll?: boolean;
+}): Promise<void> {
   if (!id) throw Error(`Argument id is required or generalSettings must be true`);
 
-  if (id === MY_PACKAGES) editDnpSetting(enabled);
+  if (id === MY_PACKAGES) editDnpSetting(enabled, MY_PACKAGES, applyToAll);
   else if (id === SYSTEM_PACKAGES) editCoreSetting(enabled);
   else editDnpSetting(enabled, id);
 }

--- a/packages/dappmanager/test/unit/utils/autoUpdateHelper.test.ts
+++ b/packages/dappmanager/test/unit/utils/autoUpdateHelper.test.ts
@@ -13,7 +13,8 @@ import {
   updateDelay,
   isCoreUpdateEnabled,
   isDnpUpdateEnabled,
-  isUpdateDelayCompleted
+  isUpdateDelayCompleted,
+  MY_PACKAGES
 } from "@dappnode/daemons";
 
 const coreDnpName = params.coreDnpName;
@@ -58,10 +59,39 @@ describe("Util: autoUpdateHelper", () => {
       editDnpSetting(true, dnpName);
       expect(check()).to.equal(true, `After enabling ${dnpName}`);
 
+      // Enabling my-packages must clear a disabled package override
+      editDnpSetting(false, dnpName);
+      editDnpSetting(true);
+      expect(check()).to.equal(true, `After enabling all packages`);
+      expect(db.autoUpdateSettings.get()).to.deep.equal({
+        [MY_PACKAGES]: { enabled: true }
+      });
+
       // Disable my-packages
       editDnpSetting(false);
       expect(check()).to.equal(false, "After disabling");
       expect(check()).to.equal(false, `After disabling ${dnpName} final`);
+    });
+
+    it("Should preserve package overrides when changing the default", () => {
+      editDnpSetting(false);
+      editDnpSetting(true, dnpName);
+
+      editDnpSetting(true, MY_PACKAGES, false);
+      expect(isDnpUpdateEnabled(dnpName)).to.equal(true);
+      expect(db.autoUpdateSettings.get()).to.deep.equal({
+        [MY_PACKAGES]: { enabled: true },
+        [dnpName]: { enabled: true }
+      });
+
+      editDnpSetting(false, MY_PACKAGES, false);
+      expect(isDnpUpdateEnabled(dnpName)).to.equal(true);
+
+      // Setting a customized package to the default removes its override.
+      editDnpSetting(false, dnpName);
+      expect(db.autoUpdateSettings.get()).to.deep.equal({
+        [MY_PACKAGES]: { enabled: false }
+      });
     });
 
     it("Should set active for system packages", () => {

--- a/packages/types/src/routes.ts
+++ b/packages/types/src/routes.ts
@@ -73,8 +73,9 @@ export interface Routes {
    * Edits the auto-update settings
    * @param id = "my-packages", "system-packages" or "bitcoin.dnp.dappnode.eth"
    * @param enabled Auto update is enabled for ID
+   * @param applyToAll Clear package overrides when editing "my-packages"
    */
-  autoUpdateSettingsEdit: (kwargs: { id: string; enabled: boolean }) => Promise<void>;
+  autoUpdateSettingsEdit: (kwargs: { id: string; enabled: boolean; applyToAll?: boolean }) => Promise<void>;
 
   /**
    * Generates a backup of a package and sends it to the client for download.


### PR DESCRIPTION
## Summary

Redesign the auto-update settings page so the relationship between defaults and per-package customizations is explicit.

### Changes

- Add a collapsible per-package settings section, showing the count of customized packages
- Replace the bulk 'enable/disable all' buttons with a single 'Apply default to all packages' action that resets customizations
- Add a separate **System packages** switch, since system packages share one setting and are updated together
- Use the existing `Switch` component for toggles instead of legacy inline row controls
- Update mock backend (`__mock-backend__/autoUpdate.ts`) and `autoUpdateDataGet` to keep types and examples in sync with the UI
