### PR TITLE
fix: route avatars through configured IPFS gateways

### DIFF
--- a/packages/admin-ui/server-mock/index.ts
+++ b/packages/admin-ui/server-mock/index.ts
@@ -69,5 +69,6 @@ startHttpApi({
   subscriptionsLogger,
   eventBus,
   isNewDappmanagerVersion: () => false,
+  getIpfsFileBytes: async () => new Uint8Array(),
   adminPasswordDb: new AdminPasswordDb(params)
 });

--- a/packages/dappmanager/src/api/avatar.ts
+++ b/packages/dappmanager/src/api/avatar.ts
@@ -1,0 +1,90 @@
+import { RequestHandler } from "express";
+import { CID } from "multiformats/cid";
+import { releaseFiles } from "@dappnode/types";
+
+const AVATAR_CACHE_MAX_BYTES = 8 * 1024 * 1024;
+const PNG_SIGNATURE = Uint8Array.from([137, 80, 78, 71, 13, 10, 26, 10]);
+
+export type GetIpfsFileBytes = (cid: string, maxBytes: number) => Promise<Uint8Array>;
+
+/**
+ * A small process-local LRU. Browser URLs are immutable by CID, while this
+ * cache prevents repeated gateway reads during the DAppManager process life.
+ */
+export class AvatarCache {
+  private readonly entries = new Map<string, Uint8Array>();
+  private readonly inFlight = new Map<string, Promise<Uint8Array>>();
+  private size = 0;
+
+  constructor(private readonly maxBytes = AVATAR_CACHE_MAX_BYTES) {}
+
+  async get(cid: string, load: () => Promise<Uint8Array>): Promise<Uint8Array> {
+    const cached = this.entries.get(cid);
+    if (cached) {
+      this.entries.delete(cid);
+      this.entries.set(cid, cached);
+      return cached;
+    }
+
+    const active = this.inFlight.get(cid);
+    if (active) return active;
+
+    const loading = load()
+      .then((bytes) => {
+        this.add(cid, bytes);
+        return bytes;
+      })
+      .finally(() => this.inFlight.delete(cid));
+    this.inFlight.set(cid, loading);
+    return loading;
+  }
+
+  private add(cid: string, bytes: Uint8Array): void {
+    if (bytes.length > this.maxBytes) return;
+
+    while (this.size + bytes.length > this.maxBytes) {
+      const oldest = this.entries.entries().next().value as [string, Uint8Array] | undefined;
+      if (!oldest) break;
+      this.entries.delete(oldest[0]);
+      this.size -= oldest[1].length;
+    }
+
+    this.entries.set(cid, bytes);
+    this.size += bytes.length;
+  }
+}
+
+export function createIpfsAvatarHandler(
+  getIpfsFileBytes: GetIpfsFileBytes,
+  cache = new AvatarCache()
+): RequestHandler<{ cid: string }> {
+  return async (req, res) => {
+    let cid: string;
+    try {
+      cid = CID.parse(req.params.cid).toString();
+    } catch {
+      res.status(400).send({ error: "Invalid IPFS CID" });
+      return;
+    }
+
+    try {
+      const bytes = await cache.get(cid, async () => {
+        const loaded = await getIpfsFileBytes(cid, releaseFiles.avatar.maxSize);
+        if (!hasPngSignature(loaded)) throw Error("Avatar is not a PNG file");
+        return loaded;
+      });
+      res.set({
+        "Cache-Control": "public, max-age=31536000, immutable",
+        "Content-Type": "image/png",
+        ETag: `"${cid}"`
+      });
+      res.send(Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength));
+    } catch {
+      res.status(502).send({ error: "Avatar unavailable from configured IPFS gateways" });
+    }
+  };
+}
+
+function hasPngSignature(bytes: Uint8Array): boolean {
+  return PNG_SIGNATURE.every((byte, index) => bytes[index] === byte);
+}

--- a/packages/dappmanager/src/api/routes/packageManifest.ts
+++ b/packages/dappmanager/src/api/routes/packageManifest.ts
@@ -16,12 +16,15 @@ export const packageManifest = wrapHandler<Params>(async (req, res) => {
   const manifest = readManifestIfExists(dnpName);
   if (!manifest) return res.status(404).send("Manifest not found");
 
-  // This is a temporary fix to get the avatarUrl from the package list
-  // Intaller now sets avatarUrl in the manifest. See `dappnodeInstaller` > `joinFilesInManifest`
-  // TODO: This setter should be removed once users have updated their packages
-  if(!manifest.avatarUrl) 
-    manifest.avatarUrl = (await listPackage({dnpName})).avatarUrl
-  
+  // Prefer the installed package URL. It points to the locally downloaded
+  // avatar and carries the current avatar reference as a cache-busting version.
+  // Keep the manifest URL as a fallback for old or temporarily stopped packages.
+  try {
+    const installedAvatarUrl = (await listPackage({ dnpName })).avatarUrl;
+    if (installedAvatarUrl) manifest.avatarUrl = installedAvatarUrl;
+  } catch {
+    // The persisted manifest is still useful when Docker package data is unavailable.
+  }
 
   // Filter manifest manually to not send new private properties
   const filteredManifest = pick(manifest, [

--- a/packages/dappmanager/src/api/startHttpApi.ts
+++ b/packages/dappmanager/src/api/startHttpApi.ts
@@ -34,6 +34,7 @@ import { handleMcpRequest } from "../mcp/server.js";
 import { MCP_UPLOAD_CHUNK_BASE64_CHARS } from "../mcp/upload.js";
 import { params as dappnodeParams } from "@dappnode/params";
 import { ensureTempTransferDir, MAX_UPLOAD_FILE_SIZE_BYTES } from "../uploads/tempTransfer.js";
+import { createIpfsAvatarHandler, GetIpfsFileBytes } from "./avatar.js";
 
 export interface HttpApiParams extends ClientSideCookiesParams, AuthPasswordSessionParams {
   AUTH_IP_ALLOW_LOCAL_IP: boolean;
@@ -78,7 +79,8 @@ export function startHttpApi({
   subscriptionsLogger,
   adminPasswordDb,
   eventBus,
-  isNewDappmanagerVersion
+  isNewDappmanagerVersion,
+  getIpfsFileBytes
 }: {
   params: HttpApiParams;
   logs: Logs;
@@ -92,6 +94,7 @@ export function startHttpApi({
   adminPasswordDb: AdminPasswordDb;
   eventBus: EventBus;
   isNewDappmanagerVersion: () => boolean;
+  getIpfsFileBytes: GetIpfsFileBytes;
 }): http.Server {
   const app = express();
   const server = new http.Server(app);
@@ -194,6 +197,7 @@ export function startHttpApi({
   app.get("/file-download/:containerName", auth.onlyAdmin, routes.fileDownload);
   app.get("/download/:fileId", auth.onlyAdmin, routes.download);
   app.get("/user-action-logs", auth.onlyAdmin, routes.downloadUserActionLogs);
+  app.get("/avatar/ipfs/:cid", auth.onlyAdmin, createIpfsAvatarHandler(getIpfsFileBytes));
   app.post("/upload", auth.onlyAdmin, ensureTempTransferDirMiddleware, uploadFileMiddleware, routes.upload);
 
   // Nexus chat proxy (Nexus API key held server-side).

--- a/packages/dappmanager/src/index.ts
+++ b/packages/dappmanager/src/index.ts
@@ -101,7 +101,8 @@ const server = startHttpApi({
   subscriptionsLogger,
   adminPasswordDb,
   eventBus,
-  isNewDappmanagerVersion
+  isNewDappmanagerVersion,
+  getIpfsFileBytes: (cid, maxBytes) => dappnodeInstaller.getIpfsFileBytes(cid, maxBytes)
 });
 
 // Start Test API

--- a/packages/dappmanager/test/unit/api/avatar.test.ts
+++ b/packages/dappmanager/test/unit/api/avatar.test.ts
@@ -1,0 +1,110 @@
+import { expect } from "chai";
+import { Request, Response } from "express";
+import { releaseFiles } from "@dappnode/types";
+import { AvatarCache, createIpfsAvatarHandler } from "../../../src/api/avatar.js";
+
+const CID_V0 = "QmYwAPJzv5CZsnAzt8auVZRnGiRAAW8h7B3S3GonqfM8E7";
+
+describe("AvatarCache", () => {
+  it("deduplicates concurrent requests for the same CID", async () => {
+    const cache = new AvatarCache();
+    let loads = 0;
+    const load = async (): Promise<Uint8Array> => {
+      loads++;
+      await Promise.resolve();
+      return Uint8Array.from([1, 2, 3]);
+    };
+
+    const [first, second] = await Promise.all([cache.get(CID_V0, load), cache.get(CID_V0, load)]);
+
+    expect(loads).to.equal(1);
+    expect(first).to.equal(second);
+  });
+
+  it("evicts the least recently used bytes", async () => {
+    const cache = new AvatarCache(4);
+    let bLoads = 0;
+    await cache.get("a", async () => Uint8Array.from([1, 1]));
+    await cache.get("b", async () => {
+      bLoads++;
+      return Uint8Array.from([2, 2]);
+    });
+    await cache.get("a", async () => Uint8Array.from([1, 1]));
+    await cache.get("c", async () => Uint8Array.from([3, 3]));
+    await cache.get("b", async () => {
+      bLoads++;
+      return Uint8Array.from([2, 2]);
+    });
+
+    expect(bLoads).to.equal(2);
+  });
+});
+
+describe("createIpfsAvatarHandler", () => {
+  it("validates the CID and serves immutable PNG bytes within the avatar limit", async () => {
+    let requestedCid = "";
+    let requestedMaxBytes = 0;
+    const handler = createIpfsAvatarHandler(async (cid, maxBytes) => {
+      requestedCid = cid;
+      requestedMaxBytes = maxBytes;
+      return Uint8Array.from([137, 80, 78, 71, 13, 10, 26, 10]);
+    });
+    const { response, state } = mockResponse();
+
+    await handler({ params: { cid: CID_V0 } } as Request<{ cid: string }>, response, () => undefined);
+
+    expect(requestedCid).to.equal(CID_V0);
+    expect(requestedMaxBytes).to.equal(releaseFiles.avatar.maxSize);
+    expect(state.headers["Content-Type"]).to.equal("image/png");
+    expect(state.headers["Cache-Control"]).to.equal("public, max-age=31536000, immutable");
+    expect(Buffer.isBuffer(state.body)).to.equal(true);
+  });
+
+  it("rejects invalid CIDs without calling a gateway", async () => {
+    let called = false;
+    const handler = createIpfsAvatarHandler(async () => {
+      called = true;
+      return new Uint8Array();
+    });
+    const { response, state } = mockResponse();
+
+    await handler({ params: { cid: "not-a-cid" } } as Request<{ cid: string }>, response, () => undefined);
+
+    expect(called).to.equal(false);
+    expect(state.statusCode).to.equal(400);
+  });
+
+  it("rejects CID content that is not a PNG", async () => {
+    const handler = createIpfsAvatarHandler(async () => Uint8Array.from([1, 2, 3]));
+    const { response, state } = mockResponse();
+
+    await handler({ params: { cid: CID_V0 } } as Request<{ cid: string }>, response, () => undefined);
+
+    expect(state.statusCode).to.equal(502);
+  });
+});
+
+function mockResponse(): {
+  response: Response;
+  state: { statusCode: number; headers: Record<string, string>; body?: unknown };
+} {
+  const state: { statusCode: number; headers: Record<string, string>; body?: unknown } = {
+    statusCode: 200,
+    headers: {}
+  };
+  const response = {
+    status(code: number) {
+      state.statusCode = code;
+      return this;
+    },
+    set(headers: Record<string, string>) {
+      state.headers = { ...state.headers, ...headers };
+      return this;
+    },
+    send(body: unknown) {
+      state.body = body;
+      return this;
+    }
+  } as Response;
+  return { response, state };
+}

--- a/packages/dockerApi/src/list/parseContainerInfo.ts
+++ b/packages/dockerApi/src/list/parseContainerInfo.ts
@@ -34,7 +34,8 @@ export function parseContainerInfo(container: ContainerInfo): PackageContainer {
   }));
   // Declared here for reusability purposes
   const isDnp = Boolean(labels.dnpName) || containerName.includes(CONTAINER_NAME_PREFIX);
-  const isCore = typeof labels.isCore === "boolean" ? labels.isCore : containerName.includes(CONTAINER_CORE_NAME_PREFIX);
+  const isCore =
+    typeof labels.isCore === "boolean" ? labels.isCore : containerName.includes(CONTAINER_CORE_NAME_PREFIX);
 
   return {
     // Identification
@@ -108,7 +109,7 @@ export function parseDnpNameFromContainerName(containerName: string): string {
 /**
  * Resolves an avatar label value to a usable URL.
  * Prefers a locally-downloaded avatar file when one exists on disk.
- * Otherwise falls back to the remote IPFS gateway or HTTP mirror URL.
+ * Otherwise falls back to the DAppManager IPFS avatar route or HTTP mirror URL.
  * @param avatar - The raw Docker label value ("/ipfs/Qm..." or HTTP URL). May be empty.
  * @param dnpName - Package name, used to locate the local avatar file.
  * @param isCore - Whether the package is a core DAppNode package.
@@ -118,12 +119,19 @@ export function resolveAvatarUrl(avatar: string | undefined, dnpName: string, is
   // Prefer locally-downloaded avatar if it exists on disk
   try {
     const localPath = getAvatarPath(dnpName, isCore);
-    if (fs.existsSync(localPath)) return `/avatars/${dnpName}.png`;
+    if (fs.existsSync(localPath)) {
+      return getLocalAvatarUrl(dnpName, avatar);
+    }
   } catch {
     // Ignore filesystem errors — fall through to remote resolution
   }
 
   if (!avatar) return "";
   if (avatar.startsWith("http")) return avatar; // Avatar URL is already an HTTP URL. Package was likely installed from mirror
-  return fileToGatewayUrl({ source: "ipfs", hash: normalizeHash(avatar), size: 0 }); // Convert IPFS multiaddress to a gateway URL.
+  return fileToGatewayUrl({ source: "ipfs", hash: normalizeHash(avatar), size: 0 });
+}
+
+export function getLocalAvatarUrl(dnpName: string, avatar?: string): string {
+  const version = avatar ? `?v=${encodeURIComponent(avatar)}` : "";
+  return `/avatars/${dnpName}.png${version}`;
 }

--- a/packages/dockerApi/test/unit/avatarUrl.test.ts
+++ b/packages/dockerApi/test/unit/avatarUrl.test.ts
@@ -1,0 +1,19 @@
+import { expect } from "chai";
+import { getLocalAvatarUrl } from "../../src/list/parseContainerInfo.js";
+
+describe("getLocalAvatarUrl", () => {
+  it("versions a stable local avatar path with its IPFS reference", () => {
+    const first = getLocalAvatarUrl("example.dnp.dappnode.eth", "/ipfs/QmFirst");
+    const updated = getLocalAvatarUrl("example.dnp.dappnode.eth", "/ipfs/QmUpdated");
+
+    expect(first).to.equal("/avatars/example.dnp.dappnode.eth.png?v=%2Fipfs%2FQmFirst");
+    expect(updated).to.equal("/avatars/example.dnp.dappnode.eth.png?v=%2Fipfs%2FQmUpdated");
+    expect(updated).to.not.equal(first);
+  });
+
+  it("versions mirror avatars with the complete source URL", () => {
+    expect(getLocalAvatarUrl("example.dnp.dappnode.eth", "https://mirror.test/CID/avatar.png")).to.equal(
+      "/avatars/example.dnp.dappnode.eth.png?v=https%3A%2F%2Fmirror.test%2FCID%2Favatar.png"
+    );
+  });
+});

--- a/packages/dockerApi/test/unit/parseContainerInfo.test.ts
+++ b/packages/dockerApi/test/unit/parseContainerInfo.test.ts
@@ -384,7 +384,7 @@ describe("modules / docker / parseContainerInfo", function () {
         running: true,
         exitCode: null,
         dependencies: {},
-        avatarUrl: "https://ipfs-gateway.dappnode.net/ipfs/QmQnHxr4YAVdtqzHnsDYvmXizxptSYyaj3YwTjoiLshVwF",
+        avatarUrl: "/avatar/ipfs/QmQnHxr4YAVdtqzHnsDYvmXizxptSYyaj3YwTjoiLshVwF",
         origin: "/ipfs/QmeBfnwgsNcEmbmxENBWtgkv5YZsAhiaDsoYd7nMTV1wKV",
         chain: "ethereum",
         canBeFullnode: false,
@@ -765,7 +765,7 @@ describe("modules / docker / parseContainerInfo", function () {
         canBeFullnode: false
       },
       {
-        avatarUrl: "https://ipfs-gateway.dappnode.net/ipfs/QmaZZVsVqaWwVLe36HhvKj3QEPt7hM1GL8kemNvsZd5F5x",
+        avatarUrl: "/avatar/ipfs/QmaZZVsVqaWwVLe36HhvKj3QEPt7hM1GL8kemNvsZd5F5x",
         canBeFullnode: false,
         containerId: "ba4765113dd6016da8b35dfe367493186f3bfd34d88eca03ccf894f7045710fa",
         containerName: "DAppNodePackage-grafana.dms.dnp.dappnode.eth",

--- a/packages/installer/src/dappnodeInstaller.ts
+++ b/packages/installer/src/dappnodeInstaller.ts
@@ -65,6 +65,15 @@ export class DappnodeInstaller extends DappnodeRepository {
   }
 
   /**
+   * Resolve a small IPFS file using the currently selected gateway target.
+   * Used by DAppManager's content-addressed avatar endpoint.
+   */
+  public async getIpfsFileBytes(hash: string, maxLength: number): Promise<Uint8Array> {
+    await this.updateProviders();
+    return super.writeFileToBytes(hash, maxLength);
+  }
+
+  /**
    * Get release assets for a request
    */
   async getRelease(name: string, version?: string): Promise<PackageRelease> {

--- a/packages/installer/src/dappnodeInstaller.ts
+++ b/packages/installer/src/dappnodeInstaller.ts
@@ -70,7 +70,7 @@ export class DappnodeInstaller extends DappnodeRepository {
    */
   public async getIpfsFileBytes(hash: string, maxLength: number): Promise<Uint8Array> {
     await this.updateProviders();
-    return super.writeFileToBytes(hash, maxLength);
+    return super.writeFileToBytes(hash, maxLength, params.IPFS_TIMEOUT);
   }
 
   /**

--- a/packages/toolkit/src/repository/ipfsGatewayClient.ts
+++ b/packages/toolkit/src/repository/ipfsGatewayClient.ts
@@ -14,16 +14,46 @@ export class IpfsGatewayClient {
    * boundary, so failures while reading or parsing a response also try the next
    * gateway.
    */
-  public async fetch<T>(ipfsPath: string, init: RequestInit, consume: (response: Response) => Promise<T>): Promise<T> {
+  public async fetch<T>(
+    ipfsPath: string,
+    init: RequestInit,
+    consume: (response: Response) => Promise<T>,
+    options: { timeoutMs?: number } = {}
+  ): Promise<T> {
     const errors: string[] = [];
 
     for (const gatewayUrl of this.gatewayUrls) {
+      const controller = new AbortController();
+      const callerSignal = init.signal;
+      let timedOut = false;
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+      const abortFromCaller = (): void => controller.abort(callerSignal?.reason);
+      if (callerSignal?.aborted) abortFromCaller();
+      else callerSignal?.addEventListener("abort", abortFromCaller, { once: true });
+
+      if (options.timeoutMs !== undefined) {
+        timeoutId = setTimeout(() => {
+          timedOut = true;
+          controller.abort();
+        }, options.timeoutMs);
+      }
+
       try {
-        const response = await fetch(`${gatewayUrl}${ipfsPath}`, init);
+        const response = await fetch(`${gatewayUrl}${ipfsPath}`, { ...init, signal: controller.signal });
         if (!response.ok) throw new Error(`${response.status} ${response.statusText}`);
         return await consume(response);
       } catch (error) {
-        errors.push(`${gatewayUrl}: ${error instanceof Error ? error.message : String(error)}`);
+        if (callerSignal?.aborted) throw error;
+        const message = timedOut
+          ? `timed out after ${options.timeoutMs} ms`
+          : error instanceof Error
+            ? error.message
+            : String(error);
+        errors.push(`${gatewayUrl}: ${message}`);
+      } finally {
+        if (timeoutId !== undefined) clearTimeout(timeoutId);
+        callerSignal?.removeEventListener("abort", abortFromCaller);
       }
     }
 

--- a/packages/toolkit/src/repository/repository.ts
+++ b/packages/toolkit/src/repository/repository.ts
@@ -289,11 +289,11 @@ export class DappnodeRepository extends ApmRepository {
    * Fetches a size-bounded IPFS file by CID into memory as bytes.
    * Does not attempt mirror routing — use downloadReleaseAsset for release files.
    */
-  public async writeFileToBytes(hash: string, maxLength?: number): Promise<Uint8Array> {
+  public async writeFileToBytes(hash: string, maxLength?: number, gatewayTimeoutMs?: number): Promise<Uint8Array> {
     const cidStr = this.sanitizeIpfsPath(hash);
     const chunks: Uint8Array[] = [];
     const maxCarBytes = maxLength === undefined ? undefined : maxLength + MAX_CAR_OVERHEAD_BYTES;
-    const { carReader, root } = await this.getAndVerifyContentFromGateway(cidStr, maxCarBytes);
+    const { carReader, root } = await this.getAndVerifyContentFromGateway(cidStr, maxCarBytes, gatewayTimeoutMs);
     const content = await this.unpackCarReader(carReader, root);
     let totalLength = 0;
     for await (const chunk of content) {
@@ -553,7 +553,8 @@ export class DappnodeRepository extends ApmRepository {
    */
   private async getAndVerifyContentFromGateway(
     hash: string,
-    maxResponseBytes?: number
+    maxResponseBytes?: number,
+    gatewayTimeoutMs?: number
   ): Promise<{
     carReader: CarReader;
     root: CID;
@@ -573,7 +574,8 @@ export class DappnodeRepository extends ApmRepository {
           throw new Error(`UNTRUSTED CONTENT: expected root ${hash}, got ${roots}`);
         }
         return { carReader, root };
-      }
+      },
+      { timeoutMs: gatewayTimeoutMs }
     );
   }
 

--- a/packages/toolkit/src/repository/repository.ts
+++ b/packages/toolkit/src/repository/repository.ts
@@ -33,6 +33,7 @@ import { MirrorOptions, MirrorFileEntry, HttpMirrorProvider } from "./contentPro
 import { IpfsGatewayClient } from "./ipfsGatewayClient.js";
 
 const source = "ipfs" as const;
+const MAX_CAR_OVERHEAD_BYTES = 1024 * 1024;
 
 /** Discriminated union returned by listWithIpfsFallback. Avoids placeholder CIDs in the mirror path. */
 type ListResult =
@@ -285,18 +286,24 @@ export class DappnodeRepository extends ApmRepository {
   }
 
   /**
-   * Fetches an IPFS file by CID into memory. Used ONLY by ipfsTest method to verify IPFS connectivity.
+   * Fetches a size-bounded IPFS file by CID into memory as bytes.
    * Does not attempt mirror routing — use downloadReleaseAsset for release files.
    */
-  public async writeFileToMemory(hash: string, maxLength?: number): Promise<string> {
+  public async writeFileToBytes(hash: string, maxLength?: number): Promise<Uint8Array> {
     const cidStr = this.sanitizeIpfsPath(hash);
     const chunks: Uint8Array[] = [];
-    const { carReader, root } = await this.getAndVerifyContentFromGateway(cidStr);
+    const maxCarBytes = maxLength === undefined ? undefined : maxLength + MAX_CAR_OVERHEAD_BYTES;
+    const { carReader, root } = await this.getAndVerifyContentFromGateway(cidStr, maxCarBytes);
     const content = await this.unpackCarReader(carReader, root);
-    for await (const chunk of content) chunks.push(chunk);
-
     let totalLength = 0;
-    chunks.forEach((chunk) => (totalLength += chunk.length));
+    for await (const chunk of content) {
+      totalLength += chunk.length;
+      if (maxLength !== undefined && totalLength > maxLength) {
+        throw Error(`Maximum size ${maxLength} bytes exceeded`);
+      }
+      chunks.push(chunk);
+    }
+
     const buffer = new Uint8Array(totalLength);
     let offset = 0;
     chunks.forEach((chunk) => {
@@ -304,8 +311,15 @@ export class DappnodeRepository extends ApmRepository {
       offset += chunk.length;
     });
 
-    if (maxLength && buffer.length >= maxLength) throw Error(`Maximum size ${maxLength} bytes exceeded`);
-    return new TextDecoder("utf-8").decode(buffer);
+    return buffer;
+  }
+
+  /**
+   * Fetches an IPFS file by CID into memory as UTF-8 text. Used ONLY by
+   * ipfsTest to verify IPFS connectivity.
+   */
+  public async writeFileToMemory(hash: string, maxLength?: number): Promise<string> {
+    return new TextDecoder("utf-8").decode(await this.writeFileToBytes(hash, maxLength));
   }
 
   /**
@@ -537,7 +551,10 @@ export class DappnodeRepository extends ApmRepository {
    * @returns The content as a CAR reader and the root CID.
    * @throws Error when the root CID does not match the provided hash (content is untrusted).
    */
-  private async getAndVerifyContentFromGateway(hash: string): Promise<{
+  private async getAndVerifyContentFromGateway(
+    hash: string,
+    maxResponseBytes?: number
+  ): Promise<{
     carReader: CarReader;
     root: CID;
   }> {
@@ -548,7 +565,7 @@ export class DappnodeRepository extends ApmRepository {
       async (res) => {
         // Parse and verify inside the retry boundary. Truncated or untrusted
         // responses are discarded before trying the next gateway.
-        const bytes = new Uint8Array(await res.arrayBuffer());
+        const bytes = await readResponseBytes(res, maxResponseBytes);
         const carReader = await CarReader.fromBytes(bytes);
         const roots = await carReader.getRoots();
         const root = roots[0];
@@ -739,4 +756,42 @@ export class DappnodeRepository extends ApmRepository {
    * @returns Arch tag in the format <os>-<arch>
    */
   private getArchTag = (arch: Architecture): string => arch.replace(/\//g, "-");
+}
+
+async function readResponseBytes(response: Response, maxBytes?: number): Promise<Uint8Array> {
+  const contentLength = response.headers.get("content-length");
+  if (maxBytes !== undefined && contentLength !== null && Number(contentLength) > maxBytes) {
+    throw Error(`Maximum gateway response size ${maxBytes} bytes exceeded`);
+  }
+
+  if (!response.body) {
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    if (maxBytes !== undefined && bytes.length > maxBytes) {
+      throw Error(`Maximum gateway response size ${maxBytes} bytes exceeded`);
+    }
+    return bytes;
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalLength = 0;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    totalLength += value.length;
+    if (maxBytes !== undefined && totalLength > maxBytes) {
+      await reader.cancel();
+      throw Error(`Maximum gateway response size ${maxBytes} bytes exceeded`);
+    }
+    chunks.push(value);
+  }
+
+  const bytes = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return bytes;
 }

--- a/packages/toolkit/test/repository/ipfsGatewayClient.test.ts
+++ b/packages/toolkit/test/repository/ipfsGatewayClient.test.ts
@@ -38,6 +38,25 @@ describe("IpfsGatewayClient", () => {
     expect(requestCount).to.equal(2);
   });
 
+  it("tries the next gateway when an attempt times out", async () => {
+    const requestedUrls: string[] = [];
+    globalThis.fetch = async (input, init) => {
+      requestedUrls.push(input.toString());
+      if (requestedUrls.length === 1) {
+        return await new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+        });
+      }
+      return new Response('{"ok":true}', { status: 200 });
+    };
+
+    const client = new IpfsGatewayClient(["https://first.example", "https://second.example"]);
+    const result = await client.fetch("/ipfs/cid", {}, async (response) => response.json(), { timeoutMs: 10 });
+
+    expect(result).to.deep.equal({ ok: true });
+    expect(requestedUrls).to.deep.equal(["https://first.example/ipfs/cid", "https://second.example/ipfs/cid"]);
+  });
+
   it("reports every gateway error when all attempts fail", async () => {
     globalThis.fetch = async () => new Response("unavailable", { status: 502, statusText: "Bad Gateway" });
     const client = new IpfsGatewayClient(["https://first.example", "https://second.example"]);

--- a/packages/utils/src/fileToGatewayUrl.ts
+++ b/packages/utils/src/fileToGatewayUrl.ts
@@ -1,12 +1,17 @@
 import { DistributedFile } from "@dappnode/types";
 import { normalizeHash } from "./normalizeHash.js";
-import url from "url";
 import { params } from "@dappnode/params";
 
+export const IPFS_AVATAR_ROUTE = "/avatar/ipfs/";
+
 /**
- * Return a queriable gateway url for a distributed file
+ * Return a URL for a distributed file.
+ *
+ * IPFS avatars are resolved by DAppManager so the backend can use the
+ * currently configured local or remote gateways instead of pinning the
+ * browser to one hard-coded public gateway.
  * @param distributedFile
- * @returns link to fetch file "http://ipfs-gateway/Qm7763518d4"
+ * @returns A relative DAppManager URL for IPFS, or an absolute mirror URL.
  */
 export function fileToGatewayUrl(distributedFile?: DistributedFile): string {
   // Fallback
@@ -14,7 +19,7 @@ export function fileToGatewayUrl(distributedFile?: DistributedFile): string {
 
   switch (distributedFile.source) {
     case "ipfs":
-      return url.resolve(url.resolve(params.IPFS_REMOTE, params.IPFS_GATEWAY), normalizeHash(distributedFile.hash));
+      return `${IPFS_AVATAR_ROUTE}${normalizeHash(distributedFile.hash)}`;
     case "mirror": {
       if (!distributedFile.filename || !distributedFile.packageHash) return "";
       const base = params.CONTENT_MIRROR_BASE_URL.replace(/\/?$/, "");

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -14,7 +14,7 @@ export { getPrivateNetworkAliases } from "./getPrivateNetworkAliases.js";
 export { getIsCore } from "./getIsCore.js";
 export { shell, shellHost, ShellError } from "./shell.js";
 export { normalizeHash } from "./normalizeHash.js";
-export { fileToGatewayUrl } from "./fileToGatewayUrl.js";
+export { fileToGatewayUrl, IPFS_AVATAR_ROUTE } from "./fileToGatewayUrl.js";
 export { packageInstalledHasPid } from "./packageInstalledHasPid.js";
 export { parseEnvironment, stringifyEnvironment, mergeEnvs } from "./environment.js";
 export { writeEnvFile, createGlobalEnvsEnvFile } from "./globalEnvs.js";

--- a/packages/utils/test/unit/fileToGatewayUrl.test.ts
+++ b/packages/utils/test/unit/fileToGatewayUrl.test.ts
@@ -1,0 +1,18 @@
+import { expect } from "chai";
+import { fileToGatewayUrl } from "../../src/fileToGatewayUrl.js";
+
+describe("fileToGatewayUrl", () => {
+  it("routes IPFS files through the DAppManager avatar endpoint", () => {
+    expect(
+      fileToGatewayUrl({
+        source: "ipfs",
+        hash: "/ipfs/QmYwAPJzv5CZsnAzt8auVZRnGiRAAW8h7B3S3GonqfM8E7",
+        size: 123
+      })
+    ).to.equal("/avatar/ipfs/QmYwAPJzv5CZsnAzt8auVZRnGiRAAW8h7B3S3GonqfM8E7");
+  });
+
+  it("returns an empty URL when no file is provided", () => {
+    expect(fileToGatewayUrl()).to.equal("");
+  });
+});


### PR DESCRIPTION
## Context

Package avatar URLs were pinned to one public IPFS gateway in the browser, bypassing the configured local or remote gateway selection. Installed avatars also used a stable local URL even when a package changed its avatar, allowing the one-day browser cache to show stale content.

## Approach

- Route IPFS avatar URLs through an authenticated DAppManager endpoint keyed by the avatar CID.
- Refresh the installer gateway list from the current local/remote setting before retrieval and retain the existing multi-gateway fallback behavior.
- Validate CIDs, bound CAR and decoded avatar sizes, require a PNG signature, and return CID-addressed immutable responses.
- Add an 8 MiB byte-bounded memory LRU with in-flight request deduplication.
- Version installed local avatar URLs with the current IPFS or mirror avatar reference so package avatar changes invalidate browser caches.
- Prefer the current installed avatar URL in the public package manifest while retaining the persisted manifest fallback.

## Test instructions

1. Configure remote IPFS mode with multiple gateways, making the first gateway unavailable and leaving a later gateway healthy.
2. Open the package directory and verify IPFS avatars load through /avatar/ipfs/{cid}.
3. Switch to local IPFS mode and verify avatars resolve through the local gateway without changing Admin UI code.
4. Install or update a package whose avatar changes and verify its local URL keeps /avatars/{package}.png but receives a new v query value and displays the new image immediately.
5. Verify mirror-backed package avatars continue to load and that an updated mirror package changes the local avatar v query.
6. Run the focused avatar tests in utils, dockerApi, and dappmanager, then build the six affected TypeScript workspaces.

Automated validation completed: focused avatar tests pass; existing container parsing expectations pass; affected workspaces compile; changed files pass ESLint, Prettier, and git diff --check.