### PR TITLE
feat: add secure Nexus login and key management

### DIFF
--- a/packages/admin-ui/src/App.tsx
+++ b/packages/admin-ui/src/App.tsx
@@ -21,6 +21,8 @@ import { PwaPermissionsAlert, PwaPermissionsModal } from "components/PwaPermissi
 import { LocalProxyBanner } from "pages/wifi/components/localProxying/LocalProxyBanner";
 import { FloatingChatLauncher } from "pages/nexus/components/FloatingChatLauncher";
 import { NexusChatProvider } from "pages/nexus/components/ChatPanel";
+import NexusAuthCallback from "pages/nexus/components/NexusAuthCallback";
+import { NEXUS_AUTH_CALLBACK_PATH } from "pages/nexus/auth";
 // Grafana Faro for frontend monitoring and tracing
 import { FaroRoutes } from "@grafana/faro-react";
 import { useUiTelemetryConsent } from "hooks/useUiTelemetryConsent";
@@ -74,8 +76,7 @@ function MainApp({ username }: { username: string }) {
   useEffect(() => {
     window.scrollTo(0, 0);
   }, [screenLocation.pathname]);
-  const isNexusPage =
-    screenLocation.pathname === "/nexus" || screenLocation.pathname.startsWith("/nexus/");
+  const isNexusPage = screenLocation.pathname === "/nexus" || screenLocation.pathname.startsWith("/nexus/");
 
   const appContext: AppContextIface = {
     theme,
@@ -150,6 +151,12 @@ function DefaultRedirect() {
 }
 
 export default function App() {
+  const location = useLocation();
+  if (location.pathname === NEXUS_AUTH_CALLBACK_PATH) return <NexusAuthCallback />;
+  return <AuthenticatedApp />;
+}
+
+function AuthenticatedApp() {
   const [loginStatus, setLoginStatus] = useState<LoginStatus>();
   // Handles the login, register and connecting logic. Nothing else will render
   // Until the app has been logged in

--- a/packages/admin-ui/src/pages/nexus/api.ts
+++ b/packages/admin-ui/src/pages/nexus/api.ts
@@ -16,8 +16,9 @@ export interface NexusStatus {
   configured: boolean;
   gatewayUrl: string;
   defaultModel: string;
-  /** Where the active key comes from: set in-app or unset. */
-  keySource: "db" | "none";
+  /** Whether the active key was pasted manually, created through Nexus login, or is unset. */
+  keySource: "manual" | "nexus" | "none";
+  accountLabel: string | null;
 }
 
 const STATUS_URL = "/nexus/status";
@@ -151,7 +152,7 @@ export async function clearChatHistory(): Promise<void> {
 
 interface OpenAIDelta {
   choices?: { delta?: { content?: string }; finish_reason?: string | null }[];
-  error?: { message?: string; type?: string };
+  error?: { code?: string; message?: string; type?: string };
 }
 
 interface ChatErrorBody {
@@ -287,7 +288,7 @@ export async function* streamChat(options: StreamChatOptions): AsyncGenerator<St
       continue;
     }
 
-    if (chunk.error) throw new ChatError(chunk.error.message ?? "stream error", "stream_error");
+    if (chunk.error) throw new ChatError(chunk.error.message ?? "stream error", chunk.error.code ?? "stream_error");
     const delta = chunk.choices?.[0]?.delta?.content;
     if (delta) yield { type: "content", delta };
   }

--- a/packages/admin-ui/src/pages/nexus/auth.ts
+++ b/packages/admin-ui/src/pages/nexus/auth.ts
@@ -1,0 +1,418 @@
+import type { NexusStatus } from "./api";
+
+export const NEXUS_AUTH_CALLBACK_PATH = "/nexus/auth/callback";
+export const NEXUS_AUTH_CALLBACK_MESSAGE_TYPE = "dappnode:nexus-auth-callback";
+
+const AUTHGEAR_ENDPOINT = "https://nexus-auth.dappnode.com";
+const AUTHGEAR_AUTHORIZE_URL = `${AUTHGEAR_ENDPOINT}/oauth2/authorize`;
+const NEXUS_AUTH_LOGIN_URL = "/nexus/auth/login";
+// Required until nexus-auth includes Authgear DEV-3545, which fixes access-token
+// issuance for authorization-code flows without offline_access.
+const NEXUS_AUTH_SCOPE = "openid offline_access";
+const NEXUS_AUTH_CALLBACK_URL = `http://my.dappnode${NEXUS_AUTH_CALLBACK_PATH}`;
+const NEXUS_AUTH_TIMEOUT_MS = 5 * 60 * 1000;
+const NEXUS_AUTH_BACKEND_TIMEOUT_MS = 2 * 60 * 1000;
+const NEXUS_AUTH_CLIENT_ID =
+  typeof import.meta.env.VITE_NEXUS_AUTH_CLIENT_ID === "string" && import.meta.env.VITE_NEXUS_AUTH_CLIENT_ID
+    ? import.meta.env.VITE_NEXUS_AUTH_CLIENT_ID
+    : "986265c5bcad52f7";
+
+interface AuthRequest {
+  action: NexusAuthAction;
+  authorizationUrl: string;
+  codeVerifier: string;
+  nonce: string;
+  redirectUri: string;
+  state: string;
+}
+
+type NexusAuthAction = "login" | "disconnect";
+
+export interface NexusAuthCallbackMessage {
+  type: typeof NEXUS_AUTH_CALLBACK_MESSAGE_TYPE;
+  state: string;
+  code?: string;
+  error?: string;
+  errorDescription?: string;
+}
+
+export interface DappnodeNexusLoginResult {
+  status: NexusStatus;
+  accountLabel: string | null;
+}
+
+export async function loginWithDappnodeNexus(): Promise<DappnodeNexusLoginResult> {
+  return runDappnodeNexusAuth("login");
+}
+
+export async function disconnectDappnodeNexus(): Promise<DappnodeNexusLoginResult> {
+  return runDappnodeNexusAuth("disconnect");
+}
+
+async function runDappnodeNexusAuth(action: NexusAuthAction): Promise<DappnodeNexusLoginResult> {
+  const popup = window.open("about:blank", "dappnode-nexus-auth", buildPopupFeatures());
+  if (!popup) throw new Error("The Nexus login popup was blocked. Allow popups for this site and try again.");
+
+  try {
+    const request = await createAuthRequest(action);
+    const callbackPromise = waitForAuthCallback(popup, request.state, new URL(request.redirectUri).origin);
+    popup.location.href = request.authorizationUrl;
+    popup.focus();
+
+    const callback = await callbackPromise;
+    if (callback.error) throw new Error(formatAuthDeniedError(callback));
+    if (!callback.code) throw new Error("Nexus login returned without an authorization code.");
+
+    return await finishDappnodeNexusLogin(callback.code, request);
+  } catch (err) {
+    if (!popup.closed) popup.close();
+    throw err;
+  }
+}
+
+export function buildNexusAuthCallbackMessage(location: Pick<Location, "search" | "hash">): NexusAuthCallbackMessage {
+  const params = readCallbackParams(location);
+  const code = params.get("code") || undefined;
+  const error = params.get("error") || undefined;
+  const errorDescription = params.get("error_description") || undefined;
+
+  return {
+    type: NEXUS_AUTH_CALLBACK_MESSAGE_TYPE,
+    state: params.get("state") || "",
+    ...(code ? { code } : {}),
+    ...(error ? { error } : {}),
+    ...(errorDescription ? { errorDescription } : {})
+  };
+}
+
+export function readNexusAuthOpenerOrigin(state: string): string | null {
+  try {
+    const separator = state.indexOf(".");
+    const nonce = state.slice(0, separator);
+    if (!/^[A-Za-z0-9_-]{43}$/.test(nonce) || separator === state.length - 1) return null;
+    const encodedOrigin = new TextDecoder().decode(base64UrlDecode(state.slice(separator + 1)));
+    const url = new URL(encodedOrigin);
+    if (url.origin !== encodedOrigin) return null;
+    return isAllowedDappmanagerOrigin(url) ? url.origin : null;
+  } catch {
+    return null;
+  }
+}
+
+async function createAuthRequest(action: NexusAuthAction): Promise<AuthRequest> {
+  const state = `${randomBase64Url(32)}.${base64UrlEncode(new TextEncoder().encode(window.location.origin))}`;
+  const nonce = randomBase64Url(32);
+  const codeVerifier = randomBase64Url(64);
+  const codeChallenge = base64UrlEncode(await sha256Bytes(codeVerifier));
+  const redirectUri = NEXUS_AUTH_CALLBACK_URL;
+  const url = new URL(AUTHGEAR_AUTHORIZE_URL);
+
+  url.searchParams.set("client_id", NEXUS_AUTH_CLIENT_ID);
+  url.searchParams.set("code_challenge", codeChallenge);
+  url.searchParams.set("code_challenge_method", "S256");
+  url.searchParams.set("nonce", nonce);
+  url.searchParams.set("redirect_uri", redirectUri);
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("scope", NEXUS_AUTH_SCOPE);
+  url.searchParams.set("state", state);
+  if (action === "disconnect") url.searchParams.set("prompt", "login");
+
+  return {
+    action,
+    authorizationUrl: url.toString(),
+    codeVerifier,
+    nonce,
+    redirectUri,
+    state
+  };
+}
+
+function waitForAuthCallback(
+  popup: Window,
+  expectedState: string,
+  expectedCallbackOrigin: string
+): Promise<NexusAuthCallbackMessage> {
+  return new Promise((resolve, reject) => {
+    let closeTimer = 0;
+    let timeoutTimer = 0;
+    const cleanup = () => {
+      window.removeEventListener("message", onMessage);
+      window.clearInterval(closeTimer);
+      window.clearTimeout(timeoutTimer);
+    };
+
+    const fail = (message: string) => {
+      cleanup();
+      reject(new Error(message));
+    };
+
+    const onMessage = (event: MessageEvent<unknown>) => {
+      if (event.source !== popup || !isRecord(event.data)) return;
+      if (event.data.type !== NEXUS_AUTH_CALLBACK_MESSAGE_TYPE) return;
+      if (event.origin !== expectedCallbackOrigin) {
+        fail("Nexus login returned from an unexpected origin.");
+        return;
+      }
+      if (!isNexusAuthCallbackMessage(event.data)) {
+        fail("Nexus login returned an invalid message.");
+        return;
+      }
+      if (event.data.state !== expectedState) {
+        fail("Nexus login returned an invalid state. Please try again.");
+        return;
+      }
+
+      cleanup();
+      resolve(event.data);
+    };
+
+    window.addEventListener("message", onMessage);
+    closeTimer = window.setInterval(() => {
+      if (popup.closed) fail("Nexus login was closed before it finished.");
+    }, 500);
+    timeoutTimer = window.setTimeout(() => fail("Nexus login timed out. Please try again."), NEXUS_AUTH_TIMEOUT_MS);
+  });
+}
+
+async function finishDappnodeNexusLogin(code: string, request: AuthRequest): Promise<DappnodeNexusLoginResult> {
+  const { res, json } = await postNexusAuthRequest(code, request);
+
+  if (!res.ok) {
+    const message =
+      isRecord(json) && isRecord(json.error) && typeof json.error.message === "string"
+        ? json.error.message
+        : `${res.status} ${res.statusText}`;
+    throw new Error(message);
+  }
+  if (!isRecord(json) || !isRecord(json.status)) throw new Error("Nexus login returned an invalid response.");
+  return {
+    status: json.status as unknown as NexusStatus,
+    accountLabel: typeof json.accountLabel === "string" ? json.accountLabel : null
+  };
+}
+
+async function postNexusAuthRequest(code: string, request: AuthRequest): Promise<{ res: Response; json: unknown }> {
+  const controller = new AbortController();
+  const timeout = window.setTimeout(() => controller.abort(), NEXUS_AUTH_BACKEND_TIMEOUT_MS);
+  try {
+    const res = await fetch(NEXUS_AUTH_LOGIN_URL, {
+      method: "POST",
+      credentials: "include",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        clientId: NEXUS_AUTH_CLIENT_ID,
+        action: request.action,
+        code,
+        codeVerifier: request.codeVerifier,
+        nonce: request.nonce,
+        redirectUri: request.redirectUri
+      }),
+      signal: controller.signal
+    });
+    let json: unknown;
+    try {
+      json = await res.json();
+    } catch (err) {
+      if (controller.signal.aborted) throw err;
+      json = undefined;
+    }
+    return { res, json };
+  } catch (err) {
+    if (controller.signal.aborted) throw new Error("Dappmanager timed out while finishing Nexus login.");
+    throw err;
+  } finally {
+    window.clearTimeout(timeout);
+  }
+}
+
+function isAllowedDappmanagerOrigin(url: URL): boolean {
+  if (url.protocol !== "http:" && url.protocol !== "https:") return false;
+  const hostname = url.hostname.toLowerCase();
+  if (
+    [
+      "my.dappnode",
+      "my.dappnode.private",
+      "dappnode.local",
+      "dappmanager.dappnode",
+      "dappmanager.dappnode.private",
+      "localhost",
+      "127.0.0.1",
+      "[::1]"
+    ].includes(hostname)
+  ) {
+    return true;
+  }
+  if (/^pwa\.[a-z0-9-]+\.dyndns\.dappnode\.io$/.test(hostname)) return true;
+  return isPrivateIpv4(hostname) || /^\[(?:fc|fd|fe8|fe9|fea|feb)[0-9a-f:]+\]$/.test(hostname);
+}
+
+function isPrivateIpv4(hostname: string): boolean {
+  const octets = hostname.split(".").map(Number);
+  if (octets.length !== 4 || octets.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) return false;
+  return (
+    octets[0] === 10 ||
+    octets[0] === 127 ||
+    (octets[0] === 169 && octets[1] === 254) ||
+    (octets[0] === 172 && octets[1] >= 16 && octets[1] <= 31) ||
+    (octets[0] === 192 && octets[1] === 168)
+  );
+}
+
+function formatAuthDeniedError(callback: NexusAuthCallbackMessage): string {
+  if (callback.errorDescription) return callback.errorDescription;
+  if (callback.error === "access_denied") return "Nexus login was denied.";
+  return `Nexus login failed: ${callback.error}`;
+}
+
+function isNexusAuthCallbackMessage(value: unknown): value is NexusAuthCallbackMessage {
+  if (!isRecord(value)) return false;
+  return (
+    value.type === NEXUS_AUTH_CALLBACK_MESSAGE_TYPE &&
+    typeof value.state === "string" &&
+    (typeof value.code === "string" || typeof value.error === "string") &&
+    (value.errorDescription === undefined || typeof value.errorDescription === "string")
+  );
+}
+
+function readCallbackParams(location: Pick<Location, "search" | "hash">): URLSearchParams {
+  const params = new URLSearchParams(location.search);
+  const hash = location.hash.startsWith("#") ? location.hash.slice(1) : location.hash;
+  const fragmentParams = new URLSearchParams(hash);
+  fragmentParams.forEach((value, key) => {
+    if (!params.has(key)) params.set(key, value);
+  });
+  return params;
+}
+
+function buildPopupFeatures(): string {
+  const width = 520;
+  const height = 720;
+  const left = Math.max(0, window.screenX + (window.outerWidth - width) / 2);
+  const top = Math.max(0, window.screenY + (window.outerHeight - height) / 2);
+  return [
+    "popup=yes",
+    `width=${width}`,
+    `height=${height}`,
+    `left=${Math.round(left)}`,
+    `top=${Math.round(top)}`,
+    "resizable=yes",
+    "scrollbars=yes"
+  ].join(",");
+}
+
+function randomBase64Url(bytes: number): string {
+  if (!window.crypto?.getRandomValues) throw new Error("Nexus login requires browser cryptography support.");
+  const random = new Uint8Array(bytes);
+  window.crypto.getRandomValues(random);
+  return base64UrlEncode(random);
+}
+
+async function sha256Bytes(value: string): Promise<Uint8Array> {
+  if (window.crypto?.subtle) {
+    const digest = await window.crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
+    return new Uint8Array(digest);
+  }
+  return sha256(value);
+}
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let value = "";
+  bytes.forEach((byte) => {
+    value += String.fromCharCode(byte);
+  });
+  return window.btoa(value).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+function base64UrlDecode(value: string): Uint8Array {
+  const base64 = value
+    .replace(/-/g, "+")
+    .replace(/_/g, "/")
+    .padEnd(Math.ceil(value.length / 4) * 4, "=");
+  const decoded = window.atob(base64);
+  return Uint8Array.from(decoded, (character) => character.charCodeAt(0));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+const SHA256_K = new Uint32Array([
+  0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5, 0xd807aa98,
+  0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786,
+  0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da, 0x983e5152, 0xa831c66d, 0xb00327c8,
+  0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+  0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819,
+  0xd6990624, 0xf40e3585, 0x106aa070, 0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a,
+  0x5b9cca4f, 0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
+]);
+
+function sha256(input: string): Uint8Array {
+  const bytes = new TextEncoder().encode(input);
+  const bitLength = bytes.length * 8;
+  const paddedLength = Math.ceil((bytes.length + 9) / 64) * 64;
+  const data = new Uint8Array(paddedLength);
+  const view = new DataView(data.buffer);
+  const hash = new Uint32Array([
+    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19
+  ]);
+  const words = new Uint32Array(64);
+
+  data.set(bytes);
+  data[bytes.length] = 0x80;
+  view.setUint32(paddedLength - 8, Math.floor(bitLength / 0x100000000), false);
+  view.setUint32(paddedLength - 4, bitLength >>> 0, false);
+
+  for (let offset = 0; offset < paddedLength; offset += 64) {
+    for (let i = 0; i < 16; i++) words[i] = view.getUint32(offset + i * 4, false);
+    for (let i = 16; i < 64; i++) {
+      const s0 = rotateRight(words[i - 15], 7) ^ rotateRight(words[i - 15], 18) ^ (words[i - 15] >>> 3);
+      const s1 = rotateRight(words[i - 2], 17) ^ rotateRight(words[i - 2], 19) ^ (words[i - 2] >>> 10);
+      words[i] = (words[i - 16] + s0 + words[i - 7] + s1) >>> 0;
+    }
+
+    let a = hash[0];
+    let b = hash[1];
+    let c = hash[2];
+    let d = hash[3];
+    let e = hash[4];
+    let f = hash[5];
+    let g = hash[6];
+    let h = hash[7];
+
+    for (let i = 0; i < 64; i++) {
+      const s1 = rotateRight(e, 6) ^ rotateRight(e, 11) ^ rotateRight(e, 25);
+      const ch = (e & f) ^ (~e & g);
+      const temp1 = (h + s1 + ch + SHA256_K[i] + words[i]) >>> 0;
+      const s0 = rotateRight(a, 2) ^ rotateRight(a, 13) ^ rotateRight(a, 22);
+      const maj = (a & b) ^ (a & c) ^ (b & c);
+      const temp2 = (s0 + maj) >>> 0;
+
+      h = g;
+      g = f;
+      f = e;
+      e = (d + temp1) >>> 0;
+      d = c;
+      c = b;
+      b = a;
+      a = (temp1 + temp2) >>> 0;
+    }
+
+    hash[0] = (hash[0] + a) >>> 0;
+    hash[1] = (hash[1] + b) >>> 0;
+    hash[2] = (hash[2] + c) >>> 0;
+    hash[3] = (hash[3] + d) >>> 0;
+    hash[4] = (hash[4] + e) >>> 0;
+    hash[5] = (hash[5] + f) >>> 0;
+    hash[6] = (hash[6] + g) >>> 0;
+    hash[7] = (hash[7] + h) >>> 0;
+  }
+
+  const digest = new Uint8Array(32);
+  const digestView = new DataView(digest.buffer);
+  hash.forEach((word, index) => digestView.setUint32(index * 4, word, false));
+  return digest;
+}
+
+function rotateRight(value: number, bits: number): number {
+  return (value >>> bits) | (value << (32 - bits));
+}

--- a/packages/admin-ui/src/pages/nexus/components/ChatPanel.tsx
+++ b/packages/admin-ui/src/pages/nexus/components/ChatPanel.tsx
@@ -5,8 +5,20 @@ import Select from "components/Select";
 import NexusMarkdown from "./NexusMarkdown";
 import Dropdown from "react-bootstrap/Dropdown";
 import { MdChatBubbleOutline, MdHistory } from "react-icons/md";
-import { FiTrash2, FiPlus, FiKey, FiSend, FiSquare, FiEye, FiEyeOff, FiMaximize2, FiMinimize2 } from "react-icons/fi";
+import {
+  FiTrash2,
+  FiPlus,
+  FiKey,
+  FiSend,
+  FiSquare,
+  FiEye,
+  FiEyeOff,
+  FiMaximize2,
+  FiMinimize2,
+  FiLogIn
+} from "react-icons/fi";
 import { nexusExternalUrl } from "../data";
+import { disconnectDappnodeNexus, loginWithDappnodeNexus } from "../auth";
 import "./nexus.scss";
 import {
   ChatError,
@@ -398,7 +410,6 @@ export function ChatPanel({ variant = "page", onOpenFullScreen, onOpenFloating }
     clearHistory,
     applyStatus
   } = useNexusChat();
-
   useEffect(() => {
     initialize();
   }, [initialize]);
@@ -464,8 +475,14 @@ export function ChatPanel({ variant = "page", onOpenFullScreen, onOpenFloating }
             await applyStatus(next);
             setShowKeyEditor(false);
           }}
+          onLoginWithNexus={async () => {
+            const { status: nextStatus } = await loginWithDappnodeNexus();
+            await applyStatus(nextStatus);
+            setShowKeyEditor(false);
+          }}
           onClear={async () => {
-            const next = await clearNexusApiKey();
+            const next =
+              status.keySource === "nexus" ? (await disconnectDappnodeNexus()).status : await clearNexusApiKey();
             await applyStatus(next);
             setShowKeyEditor(false);
           }}
@@ -1037,12 +1054,7 @@ function Composer({
           disabled={disabled}
         />
         {isRunning ? (
-          <Button
-            variant="outline-danger"
-            className="nexus-send-button"
-            onClick={onCancel}
-            title="Stop generating"
-          >
+          <Button variant="outline-danger" className="nexus-send-button" onClick={onCancel} title="Stop generating">
             <FiSquare className="nexus-send-button-icon" />
           </Button>
         ) : (
@@ -1072,10 +1084,10 @@ function NotConfigured({ onConfigure }: { onConfigure: () => void }) {
       </div>
       <div className="nexus-not-configured-text">
         <strong>Nexus chat is not configured</strong>
-        <p>Paste a Nexus API key to get started — generate one in the Nexus user portal.</p>
+        <p>Log in with Dappnode Nexus to create a key automatically, or paste a Nexus API key manually.</p>
         <div className="nexus-not-configured-actions">
           <Button variant="dappnode" onClick={onConfigure}>
-            Add API key
+            Configure Nexus
           </Button>
           <Button variant="outline-secondary" onClick={() => window.open(nexusExternalUrl, "_blank")}>
             Open Nexus
@@ -1091,41 +1103,56 @@ function NotConfigured({ onConfigure }: { onConfigure: () => void }) {
 function ApiKeyEditor({
   status,
   onSave,
+  onLoginWithNexus,
   onClear,
   onClose
 }: {
   status: NexusStatus;
   onSave: (key: string) => Promise<void>;
+  onLoginWithNexus: () => Promise<void>;
   onClear: () => Promise<void>;
   onClose: () => void;
 }) {
   const [value, setValue] = useState("");
   const [show, setShow] = useState(false);
-  const [busy, setBusy] = useState(false);
+  const [busyAction, setBusyAction] = useState<"login" | "save" | "clear" | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const busy = busyAction !== null;
+
+  const login = async () => {
+    if (busy) return;
+    setBusyAction("login");
+    setError(null);
+    try {
+      await onLoginWithNexus();
+    } catch (err) {
+      setError((err as Error).message || "Failed to connect to Dappnode Nexus");
+      setBusyAction(null);
+    }
+  };
 
   const submit = async () => {
     const key = value.trim();
     if (!key || busy) return;
-    setBusy(true);
+    setBusyAction("save");
     setError(null);
     try {
       await onSave(key);
     } catch (err) {
       setError((err as Error).message || "Failed to save the API key");
-      setBusy(false);
+      setBusyAction(null);
     }
   };
 
   const clear = async () => {
     if (busy) return;
-    setBusy(true);
+    setBusyAction("clear");
     setError(null);
     try {
       await onClear();
     } catch (err) {
       setError((err as Error).message || "Failed to clear the API key");
-      setBusy(false);
+      setBusyAction(null);
     }
   };
 
@@ -1140,12 +1167,29 @@ function ApiKeyEditor({
         </div>
 
         <p className="nexus-key-editor-text">
-          The key is stored on this DAppNode and used to talk to Nexus.{" "}
+          The key is stored on this DAppNode and used to talk to Nexus. Log in to create one automatically, or{" "}
           <a href={nexusExternalUrl} target="_blank" rel="noopener noreferrer">
-            Generate one in the Nexus user portal
-          </a>
-          .
+            generate one in the Nexus user portal
+          </a>{" "}
+          and paste it below.
         </p>
+
+        <div className="nexus-key-editor-login">
+          <Button variant="dappnode" onClick={login} disabled={busy} fullwidth Icon={FiLogIn}>
+            {busyAction === "login" ? "Connecting..." : "Login with Dappnode Nexus"}
+          </Button>
+          {status.keySource === "nexus" && status.accountLabel ? (
+            <small className="nexus-key-editor-account">
+              Already logged in as <strong>{status.accountLabel}</strong>.
+            </small>
+          ) : (
+            <small>Creates a Dappmanager Chat key in Nexus and saves it on this DAppNode.</small>
+          )}
+        </div>
+
+        <div className="nexus-key-editor-divider">
+          <span>or paste an API key</span>
+        </div>
 
         <div className="nexus-key-editor-input-group">
           <input
@@ -1176,9 +1220,15 @@ function ApiKeyEditor({
 
         <div className="nexus-key-editor-actions">
           <div>
-            {status.keySource === "db" && (
+            {status.keySource !== "none" && (
               <Button variant="outline-danger" onClick={clear} disabled={busy}>
-                Remove key
+                {busyAction === "clear"
+                  ? status.keySource === "nexus"
+                    ? "Disconnecting..."
+                    : "Removing..."
+                  : status.keySource === "nexus"
+                    ? "Disconnect Nexus"
+                    : "Remove key"}
               </Button>
             )}
           </div>
@@ -1187,7 +1237,7 @@ function ApiKeyEditor({
               Cancel
             </Button>
             <Button variant="dappnode" onClick={submit} disabled={busy || !value.trim()}>
-              {busy ? "Saving…" : status.configured ? "Save" : "Save & connect"}
+              {busyAction === "save" ? "Saving..." : status.configured ? "Save" : "Save & connect"}
             </Button>
           </div>
         </div>

--- a/packages/admin-ui/src/pages/nexus/components/NexusAuthCallback.tsx
+++ b/packages/admin-ui/src/pages/nexus/components/NexusAuthCallback.tsx
@@ -1,0 +1,31 @@
+import React, { useEffect, useState } from "react";
+import { buildNexusAuthCallbackMessage, readNexusAuthOpenerOrigin } from "../auth";
+
+export default function NexusAuthCallback() {
+  const [message, setMessage] = useState("Finishing Nexus login...");
+
+  useEffect(() => {
+    const callback = buildNexusAuthCallbackMessage(window.location);
+    const openerOrigin = readNexusAuthOpenerOrigin(callback.state);
+
+    if (!window.opener || window.opener.closed) {
+      setMessage("This Nexus login window lost its opener. Close it and try again from Dappmanager.");
+      return;
+    }
+    if (!openerOrigin) {
+      setMessage("This Nexus login callback is invalid or expired. Close it and try again from Dappmanager.");
+      return;
+    }
+
+    window.opener.postMessage(callback, openerOrigin);
+    setMessage(callback.error ? "Nexus login did not complete." : "Nexus login complete. Returning to Dappmanager...");
+    window.setTimeout(() => window.close(), callback.error ? 1200 : 400);
+  }, []);
+
+  return (
+    <div className="nexus-auth-callback">
+      <span className="spinner-border spinner-border-sm" role="status" aria-hidden="true" />
+      <p>{message}</p>
+    </div>
+  );
+}

--- a/packages/admin-ui/src/pages/nexus/components/nexus.scss
+++ b/packages/admin-ui/src/pages/nexus/components/nexus.scss
@@ -30,6 +30,22 @@
   gap: 0.75rem;
 }
 
+.nexus-auth-callback {
+  min-height: 320px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 2rem;
+  gap: 0.75rem;
+
+  p {
+    margin: 0;
+    opacity: 0.75;
+  }
+}
+
 // Main chat card
 .nexus-chat-card {
   display: flex;
@@ -775,6 +791,47 @@
   margin-bottom: 1rem;
 }
 
+.nexus-key-editor-login {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  margin-bottom: 1rem;
+
+  small {
+    opacity: 0.65;
+    font-size: 0.78rem;
+  }
+}
+
+.nexus-key-editor-account {
+  strong {
+    font-weight: 600;
+    word-break: break-word;
+  }
+}
+
+.nexus-key-editor-divider {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin: 0 0 1rem;
+  color: inherit;
+  opacity: 0.6;
+  font-size: 0.78rem;
+
+  &::before,
+  &::after {
+    content: "";
+    flex: 1;
+    height: 1px;
+    background: var(--border-color);
+  }
+
+  span {
+    white-space: nowrap;
+  }
+}
+
 .nexus-key-editor-input-group {
   display: flex;
   align-items: center;
@@ -1124,8 +1181,15 @@
 #dark .nexus-composer-hint,
 #dark .nexus-history-sidebar-subtitle,
 #dark .nexus-history-empty,
-#dark .nexus-key-editor-text {
+#dark .nexus-key-editor-text,
+#dark .nexus-key-editor-login small,
+#dark .nexus-auth-callback p {
   color: var(--color-dark-secondarytext);
+}
+
+#dark .nexus-key-editor-divider::before,
+#dark .nexus-key-editor-divider::after {
+  background: var(--color-dark-border);
 }
 
 #dark .nexus-history-sidebar-header {

--- a/packages/dappmanager/package.json
+++ b/packages/dappmanager/package.json
@@ -72,6 +72,7 @@
     "helmet": "^4.4.1",
     "http-proxy": "^1.18.0",
     "is-ip": "^3.0.0",
+    "jose": "^6.2.3",
     "lodash-es": "^4.17.21",
     "memoizee": "^0.4.14",
     "multicodec": "^3.2.1",

--- a/packages/dappmanager/src/api/routes/nexus.ts
+++ b/packages/dappmanager/src/api/routes/nexus.ts
@@ -8,6 +8,7 @@ import { dappnodeToolList } from "../../mcp/tools.js";
 import { dispatchTool, getOpenAITools } from "../../mcp/dispatch.js";
 import { createPendingConfirmation, resolveConfirmation } from "../../mcp/confirmation.js";
 import { startDocsWarmup } from "../../mcp/docs.js";
+import { completeNexusAuth, NexusAuthError } from "./nexusAuth.js";
 
 /**
  * Thin Express adapter for the route-neutral Nexus backend module.
@@ -20,7 +21,9 @@ import { startDocsWarmup } from "../../mcp/docs.js";
 const nexus = new NexusApi({
   apiKeyStore: {
     get: () => db.nexusApiKey.get(),
-    set: (value) => db.nexusApiKey.set(value)
+    set: (value) => db.nexusApiKey.set(value),
+    getSource: () => (db.nexusManagedApiKey.get() ? "nexus" : "manual"),
+    getAccountLabel: () => db.nexusManagedApiKey.get()?.accountLabel ?? null
   },
   historyStore: {
     getAll: () => db.nexusChatHistory.getAll(),
@@ -50,15 +53,72 @@ export const nexusStatus = wrapHandler(async (_req: Request, res: ExpressRespons
 /** POST /nexus/config - validate and save the Nexus API key. */
 export const nexusSetApiKey = wrapHandler(async (req: Request, res: ExpressResponse) => {
   try {
-    res.status(200).json(await nexus.setApiKey((req.body as { apiKey?: unknown } | undefined)?.apiKey));
+    if (db.nexusManagedApiKey.get() && db.nexusApiKey.get()) {
+      res.status(409).json({
+        error: {
+          code: "nexus_key_managed",
+          message: "Disconnect the Nexus account before replacing its managed API key."
+        }
+      });
+      return;
+    }
+
+    await nexus.setApiKey((req.body as { apiKey?: unknown } | undefined)?.apiKey);
+    db.nexusManagedApiKey.set(null);
+    res.status(200).json(nexus.readStatus());
   } catch (err) {
     sendNexusError(res, err);
   }
 });
 
+/** POST /nexus/auth/login - complete a Nexus login or authenticated disconnect. */
+export const nexusLogin = wrapHandler(async (req: Request, res: ExpressResponse) => {
+  try {
+    const result = await completeNexusAuth(req.body, {
+      getApiKey: () => db.nexusApiKey.get(),
+      saveApiKey: async (rawKey) => {
+        await nexus.setApiKey(rawKey);
+      },
+      restoreApiKey: (rawKey) => db.nexusApiKey.set(rawKey),
+      clearApiKey: () => {
+        nexus.clearApiKey();
+      },
+      readStatus: () => nexus.readStatus(),
+      getManagedApiKey: () => db.nexusManagedApiKey.get(),
+      setManagedApiKey: (value) => db.nexusManagedApiKey.set(value)
+    });
+    res.status(200).json(result);
+  } catch (err) {
+    if (err instanceof NexusApiError) {
+      sendNexusError(res, err);
+      return;
+    }
+    if (err instanceof NexusAuthError) {
+      logs.warn(`nexus auth: ${err.message}`);
+      res.status(err.statusCode).json({ error: { code: err.code, message: err.message } });
+      return;
+    }
+    const message = err instanceof Error ? err.message : "Nexus login failed";
+    logs.warn(`nexus auth: ${message}`);
+    res.status(502).json({ error: { code: "nexus_login_failed", message } });
+  }
+});
+
 /** DELETE /nexus/config - clear the stored Nexus API key. */
 export const nexusClearApiKey = wrapHandler(async (_req: Request, res: ExpressResponse) => {
-  res.status(200).json(nexus.clearApiKey());
+  if (db.nexusManagedApiKey.get() && db.nexusApiKey.get()) {
+    res.status(409).json({
+      error: {
+        code: "nexus_key_managed",
+        message: "Use Disconnect Nexus to revoke this managed API key."
+      }
+    });
+    return;
+  }
+
+  nexus.clearApiKey();
+  db.nexusManagedApiKey.set(null);
+  res.status(200).json(nexus.readStatus());
 });
 
 /** GET /nexus/models - list chat-capable Nexus gateway models. */

--- a/packages/dappmanager/src/api/routes/nexusAuth.ts
+++ b/packages/dappmanager/src/api/routes/nexusAuth.ts
@@ -1,0 +1,352 @@
+import { createRemoteJWKSet, jwtVerify, type JWTPayload, type JWTVerifyGetKey } from "jose";
+
+const AUTHGEAR_ENDPOINT = "https://nexus-auth.dappnode.com";
+const AUTHGEAR_TOKEN_URL = `${AUTHGEAR_ENDPOINT}/oauth2/token`;
+const AUTHGEAR_USERINFO_URL = `${AUTHGEAR_ENDPOINT}/oauth2/userinfo`;
+const AUTHGEAR_JWKS_URL = `${AUTHGEAR_ENDPOINT}/oauth2/jwks`;
+const NEXUS_CONTROL_PLANE_URL = "https://nexus-cp.dappnode.com";
+const NEXUS_AUTH_CALLBACK_URL = "http://my.dappnode/nexus/auth/callback";
+const NEXUS_AUTH_CLIENT_ID = process.env.NEXUS_AUTH_CLIENT_ID || "986265c5bcad52f7";
+const REQUEST_TIMEOUT_MS = 15_000;
+
+const authgearJwks = createRemoteJWKSet(new URL(AUTHGEAR_JWKS_URL), {
+  timeoutDuration: REQUEST_TIMEOUT_MS
+});
+
+type NexusAuthAction = "login" | "disconnect";
+
+interface NexusAuthInput {
+  action?: unknown;
+  clientId?: unknown;
+  code?: unknown;
+  codeVerifier?: unknown;
+  nonce?: unknown;
+  redirectUri?: unknown;
+}
+
+interface ParsedNexusAuthInput {
+  action: NexusAuthAction;
+  clientId: string;
+  code: string;
+  codeVerifier: string;
+  nonce: string;
+  redirectUri: string;
+}
+
+interface AuthgearTokenResponse {
+  access_token?: unknown;
+  id_token?: unknown;
+  refresh_token?: unknown;
+  error?: unknown;
+  error_description?: unknown;
+}
+
+interface NexusApiKeyResponse {
+  id?: unknown;
+  raw_key?: unknown;
+  error?: unknown;
+  message?: unknown;
+}
+
+export interface NexusManagedApiKey {
+  id: string;
+  accountSub: string;
+  accountLabel: string | null;
+}
+
+export interface NexusAuthKeyStore<T> {
+  getApiKey(): string;
+  saveApiKey(rawKey: string): Promise<void>;
+  restoreApiKey(rawKey: string): void;
+  clearApiKey(): void;
+  readStatus(): T;
+  getManagedApiKey(): NexusManagedApiKey | null;
+  setManagedApiKey(value: NexusManagedApiKey | null): void;
+}
+
+export interface NexusAuthDependencies {
+  fetch?: typeof fetch;
+  jwks?: JWTVerifyGetKey;
+}
+
+export class NexusAuthError extends Error {
+  constructor(
+    message: string,
+    readonly statusCode = 502,
+    readonly code = "nexus_auth_failed"
+  ) {
+    super(message);
+    this.name = "NexusAuthError";
+  }
+}
+
+export async function completeNexusAuth<T>(
+  input: NexusAuthInput | undefined,
+  keyStore: NexusAuthKeyStore<T>,
+  dependencies: NexusAuthDependencies = {}
+): Promise<{ status: T; accountLabel: string | null }> {
+  const request = parseAuthInput(input);
+  const managedApiKey = keyStore.getManagedApiKey();
+
+  if (request.action === "disconnect" && !managedApiKey) {
+    throw new NexusAuthError("No Nexus-managed API key is configured.", 409, "nexus_key_not_managed");
+  }
+
+  const fetchImpl = dependencies.fetch ?? globalThis.fetch;
+  const token = await exchangeAuthorizationCode(request, fetchImpl);
+  try {
+    const claims = await verifyIdToken(String(token.id_token), request.nonce, dependencies.jwks ?? authgearJwks);
+    const accountSub = String(claims.sub);
+
+    if (managedApiKey && managedApiKey.accountSub !== accountSub) {
+      throw new NexusAuthError(
+        "This key belongs to another Nexus account. Log in with that account to disconnect it first.",
+        409,
+        "nexus_account_mismatch"
+      );
+    }
+
+    const accessToken = String(token.access_token);
+    if (request.action === "disconnect") {
+      await deleteApiKey(accessToken, managedApiKey!.id, fetchImpl);
+      keyStore.clearApiKey();
+      keyStore.setManagedApiKey(null);
+      return { status: keyStore.readStatus(), accountLabel: null };
+    }
+
+    const userInfo = await fetchUserInfo(accessToken, fetchImpl);
+    if (typeof userInfo.sub === "string" && userInfo.sub !== accountSub) {
+      throw new NexusAuthError("Nexus login returned inconsistent account details.", 401, "nexus_invalid_token");
+    }
+
+    const accountLabel = readAccountLabel(userInfo, claims);
+    const apiKey = await createApiKey(accessToken, fetchImpl);
+    const previousApiKey = keyStore.getApiKey();
+
+    try {
+      await keyStore.saveApiKey(apiKey.rawKey);
+      keyStore.setManagedApiKey({ id: apiKey.id, accountSub, accountLabel });
+
+      const status = keyStore.readStatus();
+      if (managedApiKey) await deleteApiKey(accessToken, managedApiKey.id, fetchImpl);
+      return { status, accountLabel };
+    } catch (err) {
+      const rollbackErrors: string[] = [];
+      try {
+        await deleteApiKey(accessToken, apiKey.id, fetchImpl);
+      } catch (cleanupErr) {
+        rollbackErrors.push(readUnknownError(cleanupErr, "Failed to revoke the new Nexus API key"));
+      }
+      try {
+        keyStore.restoreApiKey(previousApiKey);
+        keyStore.setManagedApiKey(managedApiKey);
+      } catch (restoreErr) {
+        rollbackErrors.push(readUnknownError(restoreErr, "Failed to restore the previous Nexus API key"));
+      }
+
+      const message = readUnknownError(err, "Failed to save the Nexus API key");
+      throw new Error(rollbackErrors.length ? `${message}. ${rollbackErrors.join(". ")}` : message);
+    }
+  } finally {
+    if (typeof token.refresh_token === "string" && token.refresh_token) {
+      await revokeRefreshToken(token.refresh_token, fetchImpl).catch(() => undefined);
+    }
+  }
+}
+
+export async function verifyIdToken(
+  idToken: string,
+  nonce: string,
+  jwks: JWTVerifyGetKey = authgearJwks
+): Promise<JWTPayload> {
+  try {
+    const { payload } = await jwtVerify(idToken, jwks, {
+      algorithms: ["RS256"],
+      audience: NEXUS_AUTH_CLIENT_ID,
+      issuer: AUTHGEAR_ENDPOINT
+    });
+    if (payload.nonce !== nonce) throw new Error("invalid nonce");
+    if (typeof payload.sub !== "string" || !payload.sub) throw new Error("missing subject");
+    if (typeof payload.exp !== "number") throw new Error("missing expiry");
+    return payload;
+  } catch {
+    throw new NexusAuthError("Nexus login returned an invalid ID token.", 401, "nexus_invalid_token");
+  }
+}
+
+function parseAuthInput(input: NexusAuthInput | undefined): ParsedNexusAuthInput {
+  const action = input?.action;
+  if (action !== "login" && action !== "disconnect") {
+    throw new NexusAuthError("Nexus login returned an invalid action.", 400, "nexus_invalid_request");
+  }
+
+  const clientId = readRequiredString(input?.clientId, "clientId");
+  const code = readRequiredString(input?.code, "code");
+  const codeVerifier = readRequiredString(input?.codeVerifier, "codeVerifier");
+  const nonce = readRequiredString(input?.nonce, "nonce");
+  const redirectUri = readRequiredString(input?.redirectUri, "redirectUri");
+
+  if (clientId !== NEXUS_AUTH_CLIENT_ID) throw invalidRequest("Nexus login returned an invalid client ID.");
+  if (redirectUri !== NEXUS_AUTH_CALLBACK_URL) throw invalidRequest("Nexus login returned an invalid redirect URI.");
+  if (codeVerifier.length < 43 || codeVerifier.length > 128) {
+    throw invalidRequest("Nexus login returned an invalid verifier.");
+  }
+  return { action, clientId, code, codeVerifier, nonce, redirectUri };
+}
+
+async function exchangeAuthorizationCode(
+  request: ParsedNexusAuthInput,
+  fetchImpl: typeof fetch
+): Promise<AuthgearTokenResponse> {
+  const body = new URLSearchParams({
+    client_id: request.clientId,
+    code: request.code,
+    code_verifier: request.codeVerifier,
+    grant_type: "authorization_code",
+    redirect_uri: request.redirectUri
+  });
+  const { res, json } = await fetchJsonWithTimeout(fetchImpl, AUTHGEAR_TOKEN_URL, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body
+  });
+  const tokenResponse = json as AuthgearTokenResponse | undefined;
+
+  if (!res.ok || tokenResponse?.error) {
+    throw new NexusAuthError(
+      `Nexus token exchange failed: ${readErrorMessage(tokenResponse) || `${res.status} ${res.statusText}`}`
+    );
+  }
+  if (typeof tokenResponse?.access_token !== "string" || typeof tokenResponse.id_token !== "string") {
+    throw new NexusAuthError("Nexus token exchange returned an invalid token response.");
+  }
+  return tokenResponse;
+}
+
+async function fetchUserInfo(accessToken: string, fetchImpl: typeof fetch): Promise<Record<string, unknown>> {
+  try {
+    const { res, json } = await fetchJsonWithTimeout(fetchImpl, AUTHGEAR_USERINFO_URL, {
+      headers: { accept: "application/json", authorization: `Bearer ${accessToken}` }
+    });
+    if (!res.ok) return {};
+    return isRecord(json) ? json : {};
+  } catch {
+    return {};
+  }
+}
+
+async function createApiKey(accessToken: string, fetchImpl: typeof fetch): Promise<{ id: string; rawKey: string }> {
+  const { res, json } = await fetchJsonWithTimeout(fetchImpl, `${NEXUS_CONTROL_PLANE_URL}/user/apikeys`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${accessToken}`, "content-type": "application/json" },
+    body: JSON.stringify({ name: "Dappmanager Chat", pii_mode: "balanced" })
+  });
+  const apiKeyResponse = json as NexusApiKeyResponse | undefined;
+
+  if (!res.ok) {
+    throw new NexusAuthError(
+      `Nexus API key creation failed: ${readErrorMessage(apiKeyResponse) || `${res.status} ${res.statusText}`}`
+    );
+  }
+  if (
+    typeof apiKeyResponse?.id !== "string" ||
+    !apiKeyResponse.id.trim() ||
+    typeof apiKeyResponse.raw_key !== "string" ||
+    !apiKeyResponse.raw_key.trim()
+  ) {
+    throw new NexusAuthError("Nexus API key creation returned an invalid key.");
+  }
+  return { id: apiKeyResponse.id, rawKey: apiKeyResponse.raw_key };
+}
+
+async function deleteApiKey(accessToken: string, id: string, fetchImpl: typeof fetch): Promise<void> {
+  const { res, json } = await fetchJsonWithTimeout(
+    fetchImpl,
+    `${NEXUS_CONTROL_PLANE_URL}/user/apikeys/${encodeURIComponent(id)}`,
+    {
+      method: "DELETE",
+      headers: { authorization: `Bearer ${accessToken}` }
+    }
+  );
+  if (!res.ok && res.status !== 404) {
+    throw new NexusAuthError(
+      `Nexus API key revocation failed: ${readErrorMessage(json) || `${res.status} ${res.statusText}`}`
+    );
+  }
+}
+
+async function revokeRefreshToken(refreshToken: string, fetchImpl: typeof fetch): Promise<void> {
+  await fetchJsonWithTimeout(fetchImpl, `${AUTHGEAR_ENDPOINT}/oauth2/revoke`, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      client_id: NEXUS_AUTH_CLIENT_ID,
+      token: refreshToken,
+      token_type_hint: "refresh_token"
+    })
+  });
+}
+
+async function fetchJsonWithTimeout(
+  fetchImpl: typeof fetch,
+  input: string,
+  init: RequestInit
+): Promise<{ res: Response; json: unknown }> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const res = await fetchImpl(input, { ...init, signal: controller.signal });
+    const json = await readJson(res);
+    if (controller.signal.aborted) throw new NexusAuthError("Nexus request timed out. Please try again.", 504);
+    return { res, json };
+  } catch (err) {
+    if (controller.signal.aborted) throw new NexusAuthError("Nexus request timed out. Please try again.", 504);
+    throw err;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function readRequiredString(value: unknown, name: string): string {
+  if (typeof value !== "string" || !value.trim()) throw invalidRequest(`Missing Nexus login ${name}.`);
+  return value;
+}
+
+function invalidRequest(message: string): NexusAuthError {
+  return new NexusAuthError(message, 400, "nexus_invalid_request");
+}
+
+async function readJson(res: Response): Promise<unknown> {
+  try {
+    return await res.json();
+  } catch {
+    return undefined;
+  }
+}
+
+function readErrorMessage(value: unknown): string {
+  if (!isRecord(value)) return "";
+  if (typeof value.error_description === "string") return value.error_description;
+  if (typeof value.message === "string") return value.message;
+  if (typeof value.error === "string") return value.error;
+  if (isRecord(value.error) && typeof value.error.message === "string") return value.error.message;
+  return "";
+}
+
+function readAccountLabel(userInfo: Record<string, unknown>, claims: JWTPayload): string | null {
+  for (const source of [userInfo, claims]) {
+    for (const key of ["name", "email", "preferred_username", "sub"]) {
+      const value = source[key];
+      if (typeof value === "string" && value.trim()) return value.trim();
+    }
+  }
+  return null;
+}
+
+function readUnknownError(value: unknown, fallback: string): string {
+  return value instanceof Error && value.message ? value.message : fallback;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/packages/dappmanager/src/api/startHttpApi.ts
+++ b/packages/dappmanager/src/api/startHttpApi.ts
@@ -27,6 +27,7 @@ import {
   nexusChatHistoryUpsert,
   nexusClearApiKey,
   nexusListModels,
+  nexusLogin,
   nexusSetApiKey,
   nexusStatus
 } from "./routes/nexus.js";
@@ -198,6 +199,7 @@ export function startHttpApi({
 
   // Nexus chat proxy (Nexus API key held server-side).
   app.get("/nexus/status", auth.onlyAdmin, nexusStatus);
+  app.post("/nexus/auth/login", auth.onlyAdmin, nexusLogin);
   app.post("/nexus/config", auth.onlyAdmin, nexusSetApiKey);
   app.delete("/nexus/config", auth.onlyAdmin, nexusClearApiKey);
   app.get("/nexus/models", auth.onlyAdmin, nexusListModels);

--- a/packages/dappmanager/test/unit/api/nexusAuth.test.ts
+++ b/packages/dappmanager/test/unit/api/nexusAuth.test.ts
@@ -1,0 +1,231 @@
+import { expect } from "chai";
+import { createLocalJWKSet, exportJWK, generateKeyPair, SignJWT, type JWTVerifyGetKey } from "jose";
+import {
+  completeNexusAuth,
+  type NexusAuthKeyStore,
+  type NexusManagedApiKey
+} from "../../../src/api/routes/nexusAuth.js";
+
+const issuer = "https://nexus-auth.dappnode.com";
+const clientId = "986265c5bcad52f7";
+const nonce = "test-nonce";
+const input = {
+  action: "login",
+  clientId,
+  code: "authorization-code",
+  codeVerifier: "v".repeat(64),
+  nonce,
+  redirectUri: "http://my.dappnode/nexus/auth/callback"
+} as const;
+
+let privateKey: CryptoKey;
+let jwks: JWTVerifyGetKey;
+
+describe("nexus auth", () => {
+  before(async () => {
+    const keyPair = await generateKeyPair("RS256");
+    privateKey = keyPair.privateKey;
+    const publicJwk = await exportJWK(keyPair.publicKey);
+    jwks = createLocalJWKSet({ keys: [{ ...publicJwk, alg: "RS256", kid: "test-key", use: "sig" }] });
+  });
+
+  it("verifies the ID token, creates a key, and records its owner", async () => {
+    const { fetchImpl, calls } = installFetchResponses([
+      jsonResponse({ access_token: "access-token", id_token: await makeIdToken(), refresh_token: "refresh-token" }),
+      jsonResponse({ sub: "user-id", email: "user@example.com" }),
+      jsonResponse({ id: "key-id", raw_key: "sk-created" }),
+      new Response(null, { status: 200 })
+    ]);
+    const state = makeKeyStore();
+
+    const result = await completeNexusAuth(input, state.store, { fetch: fetchImpl, jwks });
+
+    expect(result).to.deep.equal({
+      status: {
+        configured: true,
+        keySource: "nexus",
+        accountLabel: "user@example.com"
+      },
+      accountLabel: "user@example.com"
+    });
+    expect(state.rawKey).to.equal("sk-created");
+    expect(state.managedApiKey).to.deep.equal({
+      id: "key-id",
+      accountSub: "user-id",
+      accountLabel: "user@example.com"
+    });
+    expect(calls.map(({ method }) => method)).to.deep.equal(["POST", "GET", "POST", "POST"]);
+    expect(calls.at(-1)?.url).to.equal("https://nexus-auth.dappnode.com/oauth2/revoke");
+  });
+
+  it("rotates the previous managed key instead of accumulating keys", async () => {
+    const previous = { id: "old-key", accountSub: "user-id", accountLabel: "old@example.com" };
+    const state = makeKeyStore("sk-old", previous);
+    const { fetchImpl, calls } = installFetchResponses([
+      jsonResponse({ access_token: "access-token", id_token: await makeIdToken() }),
+      jsonResponse({ sub: "user-id", email: "new@example.com" }),
+      jsonResponse({ id: "new-key", raw_key: "sk-new" }),
+      new Response(null, { status: 204 })
+    ]);
+
+    await completeNexusAuth(input, state.store, { fetch: fetchImpl, jwks });
+
+    expect(state.rawKey).to.equal("sk-new");
+    expect(state.managedApiKey?.id).to.equal("new-key");
+    expect(calls.at(-1)).to.deep.include({
+      url: "https://nexus-cp.dappnode.com/user/apikeys/old-key",
+      method: "DELETE"
+    });
+  });
+
+  it("revokes the new key and restores the previous key when local persistence fails", async () => {
+    const previous = { id: "old-key", accountSub: "user-id", accountLabel: "user@example.com" };
+    const state = makeKeyStore("sk-old", previous, async () => {
+      throw new Error("local save failed");
+    });
+    const { fetchImpl, calls } = installFetchResponses([
+      jsonResponse({ access_token: "access-token", id_token: await makeIdToken() }),
+      jsonResponse({ sub: "user-id" }),
+      jsonResponse({ id: "new-key", raw_key: "sk-new" }),
+      new Response(null, { status: 204 })
+    ]);
+
+    let failure: unknown;
+    try {
+      await completeNexusAuth(input, state.store, { fetch: fetchImpl, jwks });
+    } catch (err) {
+      failure = err;
+    }
+
+    expect((failure as Error).message).to.equal("local save failed");
+    expect(state.rawKey).to.equal("sk-old");
+    expect(state.managedApiKey).to.deep.equal(previous);
+    expect(calls.at(-1)).to.deep.include({
+      url: "https://nexus-cp.dappnode.com/user/apikeys/new-key",
+      method: "DELETE"
+    });
+  });
+
+  it("reauthenticates before revoking a managed key on disconnect", async () => {
+    const managed = { id: "managed-key", accountSub: "user-id", accountLabel: "user@example.com" };
+    const state = makeKeyStore("sk-managed", managed);
+    const { fetchImpl, calls } = installFetchResponses([
+      jsonResponse({ access_token: "access-token", id_token: await makeIdToken() }),
+      new Response(null, { status: 204 })
+    ]);
+
+    const result = await completeNexusAuth({ ...input, action: "disconnect" }, state.store, { fetch: fetchImpl, jwks });
+
+    expect(result.status).to.deep.equal({ configured: false, keySource: "none", accountLabel: null });
+    expect(state.rawKey).to.equal("");
+    expect(state.managedApiKey).to.equal(null);
+    expect(calls.at(-1)).to.deep.include({
+      url: "https://nexus-cp.dappnode.com/user/apikeys/managed-key",
+      method: "DELETE"
+    });
+  });
+
+  it("rejects an ID token with an invalid signature before creating a key", async () => {
+    const token = await makeIdToken();
+    const [header, payload, signature] = token.split(".");
+    const tamperedToken = `${header}.${payload}.${signature.startsWith("a") ? "b" : "a"}${signature.slice(1)}`;
+    const { fetchImpl, calls } = installFetchResponses([
+      jsonResponse({ access_token: "access-token", id_token: tamperedToken })
+    ]);
+    const state = makeKeyStore();
+
+    let failure: unknown;
+    try {
+      await completeNexusAuth(input, state.store, { fetch: fetchImpl, jwks });
+    } catch (err) {
+      failure = err;
+    }
+
+    expect((failure as Error).message).to.equal("Nexus login returned an invalid ID token.");
+    expect(calls).to.have.length(1);
+    expect(state.rawKey).to.equal("");
+  });
+});
+
+function makeKeyStore(
+  initialRawKey = "",
+  initialManagedApiKey: NexusManagedApiKey | null = null,
+  saveApiKey?: (rawKey: string) => Promise<void>
+): {
+  readonly rawKey: string;
+  readonly managedApiKey: NexusManagedApiKey | null;
+  store: NexusAuthKeyStore<{ configured: boolean; keySource: string; accountLabel: string | null }>;
+} {
+  let rawKey = initialRawKey;
+  let managedApiKey = initialManagedApiKey;
+  return {
+    get rawKey() {
+      return rawKey;
+    },
+    get managedApiKey() {
+      return managedApiKey;
+    },
+    store: {
+      getApiKey: () => rawKey,
+      saveApiKey: async (nextRawKey) => {
+        if (saveApiKey) await saveApiKey(nextRawKey);
+        rawKey = nextRawKey;
+      },
+      restoreApiKey: (nextRawKey) => {
+        rawKey = nextRawKey;
+      },
+      clearApiKey: () => {
+        rawKey = "";
+      },
+      readStatus: () => ({
+        configured: Boolean(rawKey),
+        keySource: rawKey ? (managedApiKey ? "nexus" : "manual") : "none",
+        accountLabel: rawKey ? (managedApiKey?.accountLabel ?? null) : null
+      }),
+      getManagedApiKey: () => managedApiKey,
+      setManagedApiKey: (value) => {
+        managedApiKey = value;
+      }
+    }
+  };
+}
+
+function installFetchResponses(responses: Response[]): {
+  fetchImpl: typeof fetch;
+  calls: Array<{ url: string; method: string }>;
+} {
+  const calls: Array<{ url: string; method: string }> = [];
+  const fetchImpl: typeof fetch = async (fetchInput, init) => {
+    calls.push({
+      url:
+        typeof fetchInput === "string"
+          ? fetchInput
+          : fetchInput instanceof URL
+            ? fetchInput.toString()
+            : fetchInput.url,
+      method: init?.method || "GET"
+    });
+    const response = responses.shift();
+    if (!response) throw new Error("Unexpected fetch call");
+    return response;
+  };
+  return { fetchImpl, calls };
+}
+
+async function makeIdToken(): Promise<string> {
+  return new SignJWT({ nonce, email: "token@example.com" })
+    .setProtectedHeader({ alg: "RS256", kid: "test-key" })
+    .setIssuer(issuer)
+    .setAudience(clientId)
+    .setSubject("user-id")
+    .setIssuedAt()
+    .setExpirationTime("5m")
+    .sign(privateKey);
+}
+
+function jsonResponse(value: unknown): Response {
+  return new Response(JSON.stringify(value), {
+    status: 200,
+    headers: { "content-type": "application/json" }
+  });
+}

--- a/packages/db/src/nexus.ts
+++ b/packages/db/src/nexus.ts
@@ -26,5 +26,13 @@ export const nexusChatHistory = dbNexus.indexedByKey<NexusStoredConversation, st
 });
 
 const nexusApiKeyDbKey = "nexus-api-key";
+const nexusManagedApiKeyDbKey = "nexus-managed-api-key";
+
+export interface NexusManagedApiKey {
+  id: string;
+  accountSub: string;
+  accountLabel: string | null;
+}
 
 export const nexusApiKey = dbMain.staticKey<string>(nexusApiKeyDbKey, "");
+export const nexusManagedApiKey = dbMain.staticKey<NexusManagedApiKey | null>(nexusManagedApiKeyDbKey, null);

--- a/packages/nexus/src/api.ts
+++ b/packages/nexus/src/api.ts
@@ -19,6 +19,7 @@ const MAX_HISTORY_ENTRIES = 50;
 const MAX_TITLE_LENGTH = 80;
 const MAX_TOOL_ITERATIONS = 8;
 const MAX_TOOL_RESULT_BYTES = 50_000;
+const NEXUS_REQUEST_TIMEOUT_MS = 15_000;
 
 interface ErrorPayload {
   error: { code: string; message: string };
@@ -119,11 +120,13 @@ export class NexusApi {
   }
 
   readStatus(): NexusStatus {
+    const configured = this.getApiKey() !== "";
     return {
-      configured: this.getApiKey() !== "",
+      configured,
       gatewayUrl: this.getGatewayUrl(),
       defaultModel: this.getDefaultModel(),
-      keySource: this.getApiKey() ? "db" : "none"
+      keySource: configured ? (this.deps.apiKeyStore.getSource?.() ?? "manual") : "none",
+      accountLabel: configured ? (this.deps.apiKeyStore.getAccountLabel?.() ?? null) : null
     };
   }
 
@@ -220,7 +223,8 @@ export class NexusApi {
     let upstream: Awaited<ReturnType<FetchLike>>;
     try {
       upstream = await this.fetchImpl(`${this.getGatewayUrl()}/models`, {
-        headers: { accept: "application/json", authorization: `Bearer ${apiKey}` }
+        headers: { accept: "application/json", authorization: `Bearer ${apiKey}` },
+        signal: AbortSignal.timeout(NEXUS_REQUEST_TIMEOUT_MS)
       });
     } catch (err) {
       const message = err instanceof Error ? err.message : "Failed to reach Nexus gateway";
@@ -317,7 +321,8 @@ export class NexusApi {
     let upstream: Awaited<ReturnType<FetchLike>>;
     try {
       upstream = await this.fetchImpl(`${this.getGatewayUrl()}/models`, {
-        headers: { accept: "application/json", authorization: `Bearer ${apiKey}` }
+        headers: { accept: "application/json", authorization: `Bearer ${apiKey}` },
+        signal: AbortSignal.timeout(NEXUS_REQUEST_TIMEOUT_MS)
       });
     } catch (err) {
       return err instanceof Error ? err.message : "Failed to reach the Nexus gateway";
@@ -359,7 +364,7 @@ export class NexusApi {
       if (!upstream.ok || !upstream.body) {
         const text = await upstream.text().catch(() => "");
         this.deps.logger.warn(`nexus proxy: upstream ${upstream.status}: ${text.slice(0, 200)}`);
-        writeSyntheticContent(writer, `\n\n_(upstream error ${upstream.status})_\n\n`, responseModelId);
+        writeStreamError(writer, `upstream_${upstream.status || 502}`, readUpstreamErrorMessage(text, upstream.status));
         break;
       }
 
@@ -534,6 +539,44 @@ function writeSyntheticContent(writer: NexusStreamWriter, text: string, modelId:
     choices: [{ index: 0, delta: { content: text }, finish_reason: null }]
   };
   writer.write(`data: ${JSON.stringify(chunk)}\n\n`);
+}
+
+function writeStreamError(writer: NexusStreamWriter, code: string, message: string): void {
+  if (writer.writableEnded) return;
+  writer.write(`data: ${JSON.stringify({ error: { code, message } })}\n\n`);
+}
+
+function readUpstreamErrorMessage(body: string, status: number): string {
+  const fallback = readUpstreamStatusMessage(status);
+  if (!body.trim()) return fallback;
+
+  try {
+    const parsed = JSON.parse(body) as unknown;
+    if (parsed && typeof parsed === "object" && "error" in parsed) {
+      const error = (parsed as { error?: unknown }).error;
+      if (typeof error === "string" && error.trim()) return `${fallback}: ${error.trim()}`;
+      if (error && typeof error === "object" && "message" in error) {
+        const message = (error as { message?: unknown }).message;
+        if (typeof message === "string" && message.trim()) return `${fallback}: ${message.trim()}`;
+      }
+    }
+    if (parsed && typeof parsed === "object" && "message" in parsed) {
+      const message = (parsed as { message?: unknown }).message;
+      if (typeof message === "string" && message.trim()) return `${fallback}: ${message.trim()}`;
+    }
+  } catch {
+    const text = collapseWhitespace(body).slice(0, 200);
+    if (text) return `${fallback}: ${text}`;
+  }
+
+  return fallback;
+}
+
+function readUpstreamStatusMessage(status: number): string {
+  if (status === 401 || status === 403) return `Nexus gateway rejected this API key (${status})`;
+  if (status === 402) return "Nexus gateway requires payment or credits (402)";
+  if (status === 429) return "Nexus gateway rate limit exceeded (429)";
+  return `Nexus gateway error (${status || 502})`;
 }
 
 function writeDappmanagerEvent(writer: NexusStreamWriter, payload: unknown): void {

--- a/packages/nexus/src/types.ts
+++ b/packages/nexus/src/types.ts
@@ -30,13 +30,16 @@ export interface NexusHistoryStore {
 export interface NexusApiKeyStore {
   get(): string;
   set(value: string): void;
+  getSource?(): "manual" | "nexus";
+  getAccountLabel?(): string | null;
 }
 
 export interface NexusStatus {
   configured: boolean;
   gatewayUrl: string;
   defaultModel: string;
-  keySource: "db" | "none";
+  keySource: "manual" | "nexus" | "none";
+  accountLabel: string | null;
 }
 
 export interface GatewayModel {

--- a/packages/nexus/test/unit/nexus.test.ts
+++ b/packages/nexus/test/unit/nexus.test.ts
@@ -34,7 +34,8 @@ describe("nexus / api", () => {
       configured: true,
       gatewayUrl: "https://gateway.example/v1",
       defaultModel: "nexus/test",
-      keySource: "db"
+      keySource: "manual",
+      accountLabel: null
     });
     expect(JSON.stringify(status)).to.not.include("secret-key");
   });
@@ -193,7 +194,7 @@ describe("nexus / api", () => {
     expect(writer.body).to.include("Skipped **Mutating tool** - not now");
   });
 
-  it("writes an upstream error into the stream", async () => {
+  it("writes an upstream error event into the stream", async () => {
     const writer = new MemoryWriter();
     const { service } = makeService({
       apiKey: "secret",
@@ -205,7 +206,8 @@ describe("nexus / api", () => {
 
     await service.chatCompletions({ messages: [] }, writer, new AbortController().signal);
 
-    expect(writer.body).to.include("upstream error 502");
+    expect(writer.body).to.include('"code":"upstream_502"');
+    expect(writer.body).to.include("Nexus gateway error (502): bad gateway");
     expect(writer.body).to.include("[DONE]");
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1283,6 +1283,7 @@ __metadata:
     helmet: "npm:^4.4.1"
     http-proxy: "npm:^1.18.0"
     is-ip: "npm:^3.0.0"
+    jose: "npm:^6.2.3"
     kubo-rpc-client: "npm:^3.0.2"
     lodash-es: "npm:^4.17.21"
     memoizee: "npm:^0.4.14"
@@ -12442,6 +12443,13 @@ __metadata:
   version: 6.2.3
   resolution: "jose@npm:6.2.3"
   checksum: 10c0/aa91bccba22cc84d86308f833749bcb0b00441e35c24e0ac79abeac5f76dc62d47bdef9c1da6a0c609f5da6478595f52b252085888b89dbdb163861e40ea4188
+  languageName: node
+  linkType: hard
+
+"jose@npm:^6.2.3":
+  version: 6.2.8
+  resolution: "jose@npm:6.2.8"
+  checksum: 10c0/fe4c6a7197a1adab2251b000c1eaaa8b40b6cb7cfbef43dbc9e959dacd43bf2532827b2d5e0f4069731da79d26e4d9e4368ccb26559a42a884b3fe036927e6e1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adds Nexus OAuth login to Dappmanager and automatically creates and stores the API key.

- Verifies signed ID tokens and OAuth callback state.
- Uses exact-origin popup messaging and request timeouts.
- Rotates managed keys and rolls back failed setup.
- Revokes managed keys when Nexus is explicitly disconnected.
- Keeps manually entered keys local-only.