### PR TITLE
fix: add IPFS gateway download diagnostics

### DIFF
--- a/packages/installer/src/dappnodeInstaller.ts
+++ b/packages/installer/src/dappnodeInstaller.ts
@@ -1,4 +1,5 @@
 import { params } from "@dappnode/params";
+import { logs } from "@dappnode/logger";
 import { DappnodeRepository } from "@dappnode/toolkit";
 import * as db from "@dappnode/db";
 import {
@@ -54,7 +55,8 @@ export class DappnodeInstaller extends DappnodeRepository {
         timeoutMs: params.CONTENT_MIRROR_TIMEOUT_MS,
         maxBytes: params.CONTENT_MIRROR_MAX_BYTES
       },
-      () => db.mirrorProviderEnabled.get()
+      () => db.mirrorProviderEnabled.get(),
+      (level, message) => logs[level](message)
     );
   }
 

--- a/packages/toolkit/src/repository/ipfsGatewayClient.ts
+++ b/packages/toolkit/src/repository/ipfsGatewayClient.ts
@@ -1,8 +1,10 @@
 export class IpfsGatewayClient {
   private gatewayUrls: string[];
+  private readonly log: IpfsGatewayLog;
 
-  constructor(gatewayUrls: string | string[]) {
+  constructor(gatewayUrls: string | string[], log: IpfsGatewayLog = () => undefined) {
     this.gatewayUrls = normalizeGatewayUrls(gatewayUrls);
+    this.log = log;
   }
 
   public setGatewayUrls(gatewayUrls: string | string[]): void {
@@ -23,6 +25,7 @@ export class IpfsGatewayClient {
     const errors: string[] = [];
 
     for (const gatewayUrl of this.gatewayUrls) {
+      const requestUrl = `${gatewayUrl}${ipfsPath}`;
       const controller = new AbortController();
       const callerSignal = init.signal;
       let timedOut = false;
@@ -40,7 +43,8 @@ export class IpfsGatewayClient {
       }
 
       try {
-        const response = await fetch(`${gatewayUrl}${ipfsPath}`, { ...init, signal: controller.signal });
+        this.log("info", `Trying IPFS gateway ${requestUrl}`);
+        const response = await fetch(requestUrl, { ...init, signal: controller.signal });
         if (!response.ok) throw new Error(`${response.status} ${response.statusText}`);
         return await consume(response);
       } catch (error) {
@@ -51,6 +55,7 @@ export class IpfsGatewayClient {
             ? error.message
             : String(error);
         errors.push(`${gatewayUrl}: ${message}`);
+        this.log("warn", `IPFS gateway failed ${requestUrl}: ${message}`);
       } finally {
         if (timeoutId !== undefined) clearTimeout(timeoutId);
         callerSignal?.removeEventListener("abort", abortFromCaller);
@@ -60,6 +65,8 @@ export class IpfsGatewayClient {
     throw new Error(`All IPFS gateways failed (${errors.join("; ")})`);
   }
 }
+
+export type IpfsGatewayLog = (level: "info" | "warn", message: string) => void;
 
 function normalizeGatewayUrls(gatewayUrls: string | string[]): string[] {
   const normalized = (Array.isArray(gatewayUrls) ? gatewayUrls : [gatewayUrls])

--- a/packages/toolkit/src/repository/repository.ts
+++ b/packages/toolkit/src/repository/repository.ts
@@ -31,6 +31,7 @@ import { dappnodeRegistry } from "./params.js";
 import { JsonRpcApiProvider } from "ethers";
 import { MirrorOptions, MirrorFileEntry, HttpMirrorProvider } from "./contentProvider/index.js";
 import { IpfsGatewayClient } from "./ipfsGatewayClient.js";
+import type { IpfsGatewayLog } from "./ipfsGatewayClient.js";
 
 const source = "ipfs" as const;
 const MAX_CAR_OVERHEAD_BYTES = 1024 * 1024;
@@ -73,10 +74,11 @@ export class DappnodeRepository extends ApmRepository {
     ipfsUrl: string | string[],
     provider: JsonRpcApiProvider,
     mirrorOptions: MirrorOptions,
-    isMirrorEnabled: () => boolean
+    isMirrorEnabled: () => boolean,
+    ipfsGatewayLog?: IpfsGatewayLog
   ) {
     super(provider);
-    this.ipfsGatewayClient = new IpfsGatewayClient(ipfsUrl);
+    this.ipfsGatewayClient = new IpfsGatewayClient(ipfsUrl, ipfsGatewayLog);
     this.mirrorProvider = new HttpMirrorProvider(mirrorOptions);
     this.isMirrorEnabled = isMirrorEnabled;
   }
@@ -293,8 +295,7 @@ export class DappnodeRepository extends ApmRepository {
     const cidStr = this.sanitizeIpfsPath(hash);
     const chunks: Uint8Array[] = [];
     const maxCarBytes = maxLength === undefined ? undefined : maxLength + MAX_CAR_OVERHEAD_BYTES;
-    const { carReader, root } = await this.getAndVerifyContentFromGateway(cidStr, maxCarBytes, gatewayTimeoutMs);
-    const content = await this.unpackCarReader(carReader, root);
+    const content = await this.getVerifiedContentFromGateway(cidStr, maxCarBytes, gatewayTimeoutMs);
     let totalLength = 0;
     for await (const chunk of content) {
       totalLength += chunk.length;
@@ -351,8 +352,7 @@ export class DappnodeRepository extends ApmRepository {
 
     const cidStr = this.sanitizeIpfsPath(fileCid);
     const chunks: Uint8Array[] = [];
-    const { carReader, root } = await this.getAndVerifyContentFromGateway(cidStr);
-    const content = await this.unpackCarReader(carReader, root);
+    const content = await this.getVerifiedContentFromGateway(cidStr);
     for await (const chunk of content) chunks.push(chunk);
 
     // Concatenate the chunks into a single Uint8Array
@@ -419,8 +419,7 @@ export class DappnodeRepository extends ApmRepository {
     }
 
     // Provider 2: IPFS CAR — fallback (or primary when mirror is not configured)
-    const { carReader, root } = await this.getAndVerifyContentFromGateway(cidStr);
-    const readable = await this.unpackCarReader(carReader, root);
+    const readable = await this.getVerifiedContentFromGateway(cidStr, undefined, timeout);
 
     return new Promise((resolve, reject) => {
       async function handleDownload(): Promise<void> {
@@ -548,17 +547,14 @@ export class DappnodeRepository extends ApmRepository {
    * Gets the content from an IPFS gateway using the given hash and verifies its integrity.
    *
    * @param hash - The content identifier (CID) of the content to get and verify.
-   * @returns The content as a CAR reader and the root CID.
-   * @throws Error when the root CID does not match the provided hash (content is untrusted).
+   * @returns The verified UnixFS content.
+   * @throws Error when the CAR is incomplete or its root CID does not match the requested hash.
    */
-  private async getAndVerifyContentFromGateway(
+  private async getVerifiedContentFromGateway(
     hash: string,
     maxResponseBytes?: number,
     gatewayTimeoutMs?: number
-  ): Promise<{
-    carReader: CarReader;
-    root: CID;
-  }> {
+  ): Promise<AsyncIterable<Uint8Array>> {
     // 1. Download the CAR
     return this.ipfsGatewayClient.fetch(
       `/ipfs/${hash}?format=car`,
@@ -573,7 +569,13 @@ export class DappnodeRepository extends ApmRepository {
         if (roots.length !== 1 || root.toString() !== CID.parse(hash).toString()) {
           throw new Error(`UNTRUSTED CONTENT: expected root ${hash}, got ${roots}`);
         }
-        return { carReader, root };
+        // Consume the UnixFS file inside the retry boundary. Incomplete CAR
+        // responses can contain the expected root but omit a referenced block.
+        // Treat those as a failure of the gateway that supplied the response.
+        const content = await this.unpackCarReader(carReader, root);
+        const chunks: Uint8Array[] = [];
+        for await (const chunk of content) chunks.push(chunk);
+        return chunksToAsyncIterable(chunks);
       },
       { timeoutMs: gatewayTimeoutMs }
     );
@@ -796,4 +798,8 @@ async function readResponseBytes(response: Response, maxBytes?: number): Promise
     offset += chunk.length;
   }
   return bytes;
+}
+
+async function* chunksToAsyncIterable(chunks: Uint8Array[]): AsyncIterable<Uint8Array> {
+  yield* chunks;
 }

--- a/packages/toolkit/test/repository/ipfsGatewayClient.test.ts
+++ b/packages/toolkit/test/repository/ipfsGatewayClient.test.ts
@@ -69,4 +69,29 @@ describe("IpfsGatewayClient", () => {
       expect((error as Error).message).to.include("https://second.example: 502 Bad Gateway");
     }
   });
+
+  it("logs every gateway attempt and failure with the requested IPFS path", async () => {
+    const logEntries: { level: string; message: string }[] = [];
+    let requestCount = 0;
+    globalThis.fetch = async () => {
+      requestCount += 1;
+      return requestCount === 1
+        ? new Response("unavailable", { status: 503, statusText: "Service Unavailable" })
+        : new Response("ok", { status: 200 });
+    };
+
+    const client = new IpfsGatewayClient(["https://first.example", "https://second.example"], (level, message) =>
+      logEntries.push({ level, message })
+    );
+    await client.fetch("/ipfs/cid?format=car", {}, async (response) => response.text());
+
+    expect(logEntries).to.deep.equal([
+      { level: "info", message: "Trying IPFS gateway https://first.example/ipfs/cid?format=car" },
+      {
+        level: "warn",
+        message: "IPFS gateway failed https://first.example/ipfs/cid?format=car: 503 Service Unavailable"
+      },
+      { level: "info", message: "Trying IPFS gateway https://second.example/ipfs/cid?format=car" }
+    ]);
+  });
 });


### PR DESCRIPTION
## Context

IPFS package downloads can fail while unpacking a CAR response with errors such as `Could not get block <CID>`. The existing logs do not identify which configured gateway returned the incomplete response, and the unpacking failure occurs outside the gateway retry boundary.

## Approach

- Log the full IPFS gateway request URL before each attempt.
- Log the gateway URL and failure reason before trying the next configured gateway.
- Consume and validate UnixFS content inside the retry boundary so incomplete CAR responses, including missing referenced blocks, fall back to the next gateway.
- Inject the application logger into the toolkit gateway client without coupling the toolkit package to the logger package.
- Add unit coverage for gateway attempt and failure diagnostics.

## Test instructions

1. Configure at least two remote IPFS gateways, with the first returning an error or incomplete CAR response.
2. Install or update a package through IPFS.
3. Verify logs contain an `INFO` entry such as `Trying IPFS gateway <URL>/ipfs/<CID>?format=car`.
4. Verify a failed attempt produces a `WARN` entry containing the same gateway URL and the exact failure reason.
5. Verify the next configured gateway is attempted.

Automated verification performed:

- Toolkit TypeScript type-check passes.
- Installer TypeScript type-check passes.
- Prettier check passes for all changed files.
- Direct runtime smoke test confirms attempt, failure, and fallback log sequencing.
- The focused Mocha suite could not be launched locally because the installed Mocha/Yargs stack fails during startup on Node 26; CI uses a supported Node version.