### PR TITLE
fix: remove sunset bloXroute Max Profit relay

### DIFF
--- a/packages/admin-ui/src/pages/stakers/components/columns/MevBoost.tsx
+++ b/packages/admin-ui/src/pages/stakers/components/columns/MevBoost.tsx
@@ -168,7 +168,6 @@ function Relay({
 
 // Utils
 
-// bloxroute (maxprofit) is OFAC compliant as of Dec 2023: https://x.com/bloXrouteLabs/status/1736819783520092357
 // Info on all relays specs: https://github.com/eth-educators/ethstaker-guides/blob/main/MEV-relay-list.md
 const getDefaultRelays = (network: Network): RelayIface[] => {
   switch (network) {
@@ -201,13 +200,6 @@ const getDefaultRelays = (network: Network): RelayIface[] => {
           docs: "https://boost.flashbots.net/",
           url:
             "https://0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae@boost-relay.flashbots.net"
-        },
-        {
-          operator: "bloXroute (Max profit)",
-          ofacCompliant: true,
-          docs: "https://bloxroute.com/",
-          url:
-            "https://0x8b5d2e73e2a3a55c6c87b8b6eb92e0149a125c852751db1422fa951e42a09b82c142c3ea98d0d9930b056a3bc9896b8f@bloxroute.max-profit.blxrbdn.com"
         },
         {
           operator: "bloXroute (Regulated)",

--- a/packages/migrations/src/index.ts
+++ b/packages/migrations/src/index.ts
@@ -4,6 +4,7 @@ import { pruneUserActionLogs } from "./pruneUserActionLogs.js";
 import { recreateContainersIfLegacyDns } from "./recreateContainersIfLegacyDns.js";
 import { ensureCoreComposesHardcodedIpsRange } from "./ensureCoreComposesHardcodedIpsRange.js";
 import { determineIsDappnodeAws } from "./determineIsDappnodeAws.js";
+import { removeBloxrouteMaxProfitRelay } from "./removeBloxrouteMaxProfitRelay.js";
 
 class MigrationError extends Error {
   errors: Error[];
@@ -56,6 +57,11 @@ export async function executeMigrations(): Promise<void> {
       fn: determineIsDappnodeAws,
       migration: "determine if the dappnode is running in Dappnode AWS",
       coreVersion: "0.2.94"
+    },
+    {
+      fn: removeBloxrouteMaxProfitRelay,
+      migration: "remove the retired bloXroute Max Profit relay from MEV-Boost",
+      coreVersion: "0.2.127"
     }
   ];
 

--- a/packages/migrations/src/removeBloxrouteMaxProfitRelay.ts
+++ b/packages/migrations/src/removeBloxrouteMaxProfitRelay.ts
@@ -1,0 +1,49 @@
+import { ComposeFileEditor } from "@dappnode/dockercompose";
+import { dockerComposeUpPackage, getContainersStatus, listPackageNoThrow } from "@dappnode/dockerapi";
+import { logs } from "@dappnode/logger";
+import { MevBoostMainnet } from "@dappnode/types";
+
+const MEV_BOOST_SERVICE_NAME = "mev-boost";
+export const BLOXROUTE_MAX_PROFIT_RELAY =
+  "https://0x8b5d2e73e2a3a55c6c87b8b6eb92e0149a125c852751db1422fa951e42a09b82c142c3ea98d0d9930b056a3bc9896b8f@bloxroute.max-profit.blxrbdn.com";
+
+/**
+ * Remove the retired bloXroute Max Profit relay from the installed mainnet
+ * MEV-Boost package while preserving all other configured relays.
+ */
+export async function removeBloxrouteMaxProfitRelay(): Promise<void> {
+  const dnpName = MevBoostMainnet.Mevboost;
+  const installedPackage = await listPackageNoThrow({ dnpName });
+  if (!installedPackage) return;
+
+  const compose = new ComposeFileEditor(dnpName, false);
+  const service = compose.services()[MEV_BOOST_SERVICE_NAME];
+  if (!service) {
+    logs.warn(`Cannot migrate bloXroute Max Profit relay: service ${MEV_BOOST_SERVICE_NAME} not found in ${dnpName}`);
+    return;
+  }
+
+  const currentRelays = service.getEnvs().RELAYS;
+  if (currentRelays === undefined) return;
+
+  const migratedRelays = removeRelayFromList(currentRelays, BLOXROUTE_MAX_PROFIT_RELAY);
+  if (migratedRelays === currentRelays) return;
+
+  service.mergeEnvs({ RELAYS: migratedRelays });
+  compose.write();
+  logs.info(`Removed bloXroute Max Profit relay from ${dnpName}`);
+
+  const containersStatus = await getContainersStatus({ dnpName, dnp: installedPackage });
+  await dockerComposeUpPackage({
+    composeArgs: { dnpName },
+    upAll: false,
+    containersStatus,
+    dockerComposeUpOptions: { forceRecreate: true }
+  });
+}
+
+export function removeRelayFromList(relays: string, relayToRemove: string): string {
+  const relayList = relays.split(",").map((relay) => relay.trim());
+  if (!relayList.includes(relayToRemove)) return relays;
+  return relayList.filter((relay) => relay && relay !== relayToRemove).join(",");
+}

--- a/packages/migrations/test/int/removeBloxrouteMaxProfitRelay.test.int.ts
+++ b/packages/migrations/test/int/removeBloxrouteMaxProfitRelay.test.int.ts
@@ -1,0 +1,29 @@
+import { expect } from "chai";
+import { BLOXROUTE_MAX_PROFIT_RELAY, removeRelayFromList } from "../../src/removeBloxrouteMaxProfitRelay.js";
+
+describe("removeBloxrouteMaxProfitRelay", () => {
+  const flashbotsRelay = "https://flashbots.example";
+  const regulatedRelay = "https://bloxroute-regulated.example";
+
+  it("removes the Max Profit relay and preserves all other relays", () => {
+    const relays = [flashbotsRelay, BLOXROUTE_MAX_PROFIT_RELAY, regulatedRelay].join(",");
+
+    expect(removeRelayFromList(relays, BLOXROUTE_MAX_PROFIT_RELAY)).to.equal(
+      [flashbotsRelay, regulatedRelay].join(",")
+    );
+  });
+
+  it("removes every occurrence and is idempotent", () => {
+    const relays = [BLOXROUTE_MAX_PROFIT_RELAY, flashbotsRelay, BLOXROUTE_MAX_PROFIT_RELAY].join(",");
+    const migratedRelays = removeRelayFromList(relays, BLOXROUTE_MAX_PROFIT_RELAY);
+
+    expect(migratedRelays).to.equal(flashbotsRelay);
+    expect(removeRelayFromList(migratedRelays, BLOXROUTE_MAX_PROFIT_RELAY)).to.equal(flashbotsRelay);
+  });
+
+  it("does not rewrite relay lists that do not contain Max Profit", () => {
+    const relays = ` ${flashbotsRelay}, ${regulatedRelay} `;
+
+    expect(removeRelayFromList(relays, BLOXROUTE_MAX_PROFIT_RELAY)).to.equal(relays);
+  });
+});


### PR DESCRIPTION
## Context

The bloXroute Max Profit relay is being sunset on August 26, 2026. It must be removed from the UI and existing MEV-Boost configurations.

## Approach

- Remove Max Profit from the mainnet relay list.
- Migrate existing installations by removing only its exact URL.
- Preserve other relays and the container’s running state.
- Add migration and idempotency coverage.

## Test instructions

1. Configure Max Profit alongside another relay.
2. Run the migration.
3. Confirm Max Profit is removed while other relays and the container state are preserved.
4. Confirm Max Profit is no longer available in the Stakers UI.

Checks: migration type-check, lint, formatting, and smoke test pass.