### PR TITLE
fix: allow multiple HTTPS mappings per container

### DIFF
--- a/packages/httpsPortal/src/apiMappings.ts
+++ b/packages/httpsPortal/src/apiMappings.ts
@@ -1,0 +1,22 @@
+import { HttpsPortalMapping } from "@dappnode/types";
+import { HttpPortalEntry } from "./apiClient.js";
+import { getExternalNetworkAlias } from "./domains.js";
+
+/**
+ * Return true only when the HTTPS Portal already contains this exact source and target mapping.
+ *
+ * A container can have multiple mappings, so matching by its network alias alone is not enough.
+ * Authentication is not part of the comparison because the API returns the stored password hash.
+ */
+export function hasExactApiMapping(entries: HttpPortalEntry[], mapping: HttpsPortalMapping): boolean {
+  const toHost = `${getExternalNetworkAlias(mapping)}:${mapping.port}`;
+
+  return entries.some((entry) => entry.fromSubdomain === mapping.fromSubdomain && entry.toHost === toHost);
+}
+
+/** Return true when a container has at least one mapping in the HTTPS Portal. */
+export function hasApiMappingForContainer(entries: HttpPortalEntry[], dnpName: string, serviceName: string): boolean {
+  const mappingAlias = getExternalNetworkAlias({ serviceName, dnpName });
+
+  return entries.some(({ toHost }) => toHost.split(":")[0] === mappingAlias);
+}

--- a/packages/httpsPortal/src/httpsPortal.ts
+++ b/packages/httpsPortal/src/httpsPortal.ts
@@ -13,6 +13,7 @@ import { HttpsPortalApiClient } from "./apiClient.js";
 import { ComposeEditor, ComposeFileEditor } from "@dappnode/dockercompose";
 import { prettyDnpName } from "@dappnode/utils";
 import { Log, logs } from "@dappnode/logger";
+import { hasApiMappingForContainer, hasExactApiMapping } from "./apiMappings.js";
 export { HttpsPortalApiClient };
 export { getExposableServices } from "./exposable/index.js";
 
@@ -66,7 +67,7 @@ export class HttpsPortal {
       });
     }
 
-    if (!(await this.hasApiMapping(mapping.dnpName, mapping.serviceName))) {
+    if (!(await this.hasExactApiMapping(mapping))) {
       logs.info(`Adding HTTPS portal mapping for ${mapping.dnpName}:${mapping.port}...`);
       // Call Http Portal API to add the mapping
       await this.httpsPortalApiClient.add({
@@ -174,7 +175,7 @@ export class HttpsPortal {
     for (const container of containers) {
       if (
         pkg.dnpName === params.HTTPS_PORTAL_DNPNAME ||
-        (await this.hasApiMapping(pkg.dnpName, container.serviceName))
+        (await this.hasApiMappingForContainer(pkg.dnpName, container.serviceName))
       ) {
         const alias = getExternalNetworkAlias({
           serviceName: container.serviceName,
@@ -286,22 +287,28 @@ export class HttpsPortal {
     }
   }
 
-  /**
-   * Returns weather a container has assigned or not a mapping to the https-portal API
-   */
-  private async hasApiMapping(dnpName: string, serviceName: string): Promise<boolean> {
+  /** Returns whether this exact source and target mapping exists in the HTTPS Portal API. */
+  private async hasExactApiMapping(mapping: HttpsPortalMapping): Promise<boolean> {
     const entries = await this.httpsPortalApiClient.list();
-    const mappingAlias = getExternalNetworkAlias({ serviceName, dnpName });
-    for (const { toHost } of entries) {
-      // toHost format: someDomain:80
-      const alias = toHost.split(":")[0];
-      if (alias === mappingAlias) {
-        logs.info(`Found API mapping for ${dnpName} ${serviceName}`);
-        return true;
-      }
+    const hasMapping = hasExactApiMapping(entries, mapping);
+
+    if (hasMapping) {
+      logs.info(
+        `Found API mapping for ${mapping.fromSubdomain} -> ${mapping.dnpName} ${mapping.serviceName}:${mapping.port}`
+      );
+    } else {
+      logs.info(
+        `No API mapping found for ${mapping.fromSubdomain} -> ${mapping.dnpName} ${mapping.serviceName}:${mapping.port}`
+      );
     }
-    logs.info(`No API mapping found for ${dnpName} ${serviceName}`);
-    return false;
+
+    return hasMapping;
+  }
+
+  /** Returns whether a container has at least one mapping in the HTTPS Portal API. */
+  private async hasApiMappingForContainer(dnpName: string, serviceName: string): Promise<boolean> {
+    const entries = await this.httpsPortalApiClient.list();
+    return hasApiMappingForContainer(entries, dnpName, serviceName);
   }
 
   /**

--- a/packages/httpsPortal/test/unit/apiMappings.test.ts
+++ b/packages/httpsPortal/test/unit/apiMappings.test.ts
@@ -1,0 +1,44 @@
+import { expect } from "chai";
+import { HttpsPortalMapping } from "@dappnode/types";
+import { HttpPortalEntry } from "../../src/apiClient.js";
+import { hasApiMappingForContainer, hasExactApiMapping } from "../../src/apiMappings.js";
+import { getExternalNetworkAlias } from "../../src/domains.js";
+
+describe("modules / https-portal / api mappings", () => {
+  const mapping: HttpsPortalMapping = {
+    fromSubdomain: "first",
+    dnpName: "mock-dnp.dnp.dappnode.eth",
+    serviceName: "mock-service",
+    port: 8080,
+    external: true
+  };
+  const toHost = `${getExternalNetworkAlias(mapping)}:${mapping.port}`;
+  const entries: HttpPortalEntry[] = [
+    {
+      fromSubdomain: mapping.fromSubdomain,
+      toHost,
+      external: mapping.external
+    }
+  ];
+
+  it("finds an exact existing mapping", () => {
+    expect(hasExactApiMapping(entries, mapping)).to.equal(true);
+  });
+
+  it("allows another subdomain to map to the same container and port", () => {
+    expect(hasExactApiMapping(entries, { ...mapping, fromSubdomain: "second" })).to.equal(false);
+  });
+
+  it("allows another port on the same container to be mapped", () => {
+    expect(hasExactApiMapping(entries, { ...mapping, fromSubdomain: "second", port: 9090 })).to.equal(false);
+  });
+
+  it("does not treat a conflicting subdomain pointing elsewhere as the same mapping", () => {
+    expect(hasExactApiMapping(entries, { ...mapping, port: 9090 })).to.equal(false);
+  });
+
+  it("detects whether a container has any mapping", () => {
+    expect(hasApiMappingForContainer(entries, mapping.dnpName, mapping.serviceName)).to.equal(true);
+    expect(hasApiMappingForContainer(entries, mapping.dnpName, "other-service")).to.equal(false);
+  });
+});


### PR DESCRIPTION
## Summary

- identify existing HTTPS mappings by their exact source subdomain and target instead of only the container alias
- keep the broader per-container lookup for reconnecting mapped containers to the public network
- add regression coverage for multiple subdomains and ports targeting the same container

## Context

Since #2318, adding a mapping was skipped whenever the target container already had any HTTPS mapping. The call returned successfully without reaching the HTTPS Portal API, which made the UI report success while only the first mapping existed.

## Testing

- `yarn workspace @dappnode/httpsportal test` (6 passing)
- `yarn tsc -p packages/httpsPortal/tsconfig.json`
- `yarn eslint packages/httpsPortal/src/apiMappings.ts packages/httpsPortal/src/httpsPortal.ts packages/httpsPortal/test/unit/apiMappings.test.ts`
- `git diff --check`